### PR TITLE
feat(ai): instrument the agent turn waterfall

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -487,13 +487,8 @@ export type QueryCompletedEvent = BaseTrack & {
         executionSource: QueryExecutionSource | null;
         warehouseType: WarehouseTypes | null;
         warehouseExecutionTimeMs: number | null;
-        /**
-         * Breakdown of `warehouseExecutionTimeMs` into the phases the adapter
-         * reports. Previously computed and only written to a log line, which
-         * left "the warehouse was slow" as one opaque number — connect/session
-         * cost points at pooling, `query`/`fetch` at the query itself.
-         * Absent phases mean the adapter does not report them.
-         */
+        // Phase breakdown of warehouseExecutionTimeMs. Absent phases mean the
+        // adapter does not report them.
         warehousePhaseTimings: WarehousePhaseTimings | null;
         totalRowCount: number | null;
         columnsCount: number | null;
@@ -2923,9 +2918,7 @@ export type AiAgentPromptCreatedEvent = BaseTrack & {
         projectId: string;
         aiAgentId: string;
         threadId: string | undefined;
-        // Joins the turn's start to every downstream event in it (steps, tool
-        // calls, the streamed response). Without it the head of a turn —
-        // submit to first model output — cannot be measured.
+        // Joins turn start to its steps, tool calls and response.
         promptId: string;
         context: 'slack' | 'web_app';
         hasPinnedContext: boolean;
@@ -2954,8 +2947,6 @@ export type AiAgentResponseStreamed = BaseTrack & {
         projectId: string;
         aiAgentId: string;
         agentName: string;
-        // Turn identity, so the tail of the turn joins to its steps, its tool
-        // calls and the prompt that started it.
         promptId: string;
         threadId: string;
         usageTokensCount: number;
@@ -2970,14 +2961,8 @@ export type AiAgentResponseStreamed = BaseTrack & {
 };
 
 /**
- * One row per iteration of the agent loop — the grain the turn waterfall is
- * reconstructed from. `ai.usage` reports a whole streamed run as a single
- * total, which cannot express the alternation of inference and tool
- * execution, so latency is sliced here instead.
- *
- * `toolWallMs` is a step's tool phase measured as wall time, not the sum of
- * its tool durations: a step that fans out concurrent calls would otherwise
- * be counted several times over.
+ * One row per iteration of the agent loop. `toolWallMs` is wall time, not the
+ * sum of the step's tool durations, so a concurrent fan-out counts once.
  */
 export type AiAgentStepCompletedEvent = BaseTrack & {
     event: 'ai_agent.step_completed';
@@ -2991,13 +2976,10 @@ export type AiAgentStepCompletedEvent = BaseTrack & {
         stepIndex: number;
         model: string;
         modelProvider: string | null;
-        // Offset from turn start, so steps order and locate without relying on
-        // event timestamps (which carry ingestion jitter).
+        // Order steps by this, not event timestamps, which carry ingestion jitter.
         stepOffsetMs: number;
         stepTotalMs: number;
-        // Null when the step ran tools but the transport never exposed the
-        // decide/execute boundary (the non-streaming provider path).
-        // `stepTotalMs` is always present.
+        // Null when the transport hid the decide/execute boundary.
         inferenceMs: number | null;
         toolWallMs: number | null;
         ttftMs: number | null;
@@ -3126,21 +3108,15 @@ export type AiAgentToolCallEvent = BaseTrack & {
         threadId: string;
         promptId: string;
         toolCallId: string;
-        // Which loop iteration emitted the call. Calls sharing a stepIndex ran
-        // concurrently, so their durations must not be summed.
+        // Calls sharing a stepIndex ran concurrently; do not sum their durations.
         stepIndex: number;
     };
 };
 
 /**
- * Fires when a tool returns, carrying what the call-time event cannot know.
- * Kept as its own event rather than a second `ai_agent_tool_call` so the
- * existing one stays one-row-per-call for the models that count it; join the
- * pair on `toolCallId`.
- *
- * A call that never returns (aborted turn, crash) has no row here, so a
- * missing completion is itself the signal — treat these as a left join, not
- * an inner one.
+ * Its own event rather than a second `ai_agent_tool_call`, which stays
+ * one-row-per-call for the models that count it; join on `toolCallId`. A call
+ * that never returns has no row here, so left join, not inner.
  */
 export type AiAgentToolCallCompletedEvent = BaseTrack & {
     event: 'ai_agent.tool_call_completed';
@@ -3251,15 +3227,10 @@ export type ContentReviewSimilarContentFoundEvent = BaseTrack & {
 };
 
 /**
- * The browser fetching an artifact's chart data. This runs *after* the agent
- * turn has streamed and closed, as a separate request that re-executes the
- * query from the persisted config — so it is on the user's path to seeing a
- * chart but sits outside the turn's own duration.
- *
- * `queryId` joins to `query.completed` for cache-hit and warehouse timings
- * rather than restating them here.
- *
- * Previously emitted untyped, which is why it never reached the warehouse.
+ * The browser fetching an artifact's chart data. Runs after the turn closed,
+ * re-executing the query from the persisted config, so it is on the user's
+ * path to the chart but outside the turn's duration. `queryId` joins to
+ * `query.completed` for cache-hit and warehouse timings.
  */
 export type AiAgentArtifactVizQueryEvent = BaseTrack & {
     event: 'ai_agent.artifact_viz_query';
@@ -3273,8 +3244,7 @@ export type AiAgentArtifactVizQueryEvent = BaseTrack & {
         artifactVersionId: string;
         vizType: string;
         source: string;
-        // Ties the render round-trip back to the turn that produced the
-        // artifact. Null for artifacts persisted without a prompt.
+        // Null for artifacts persisted without a prompt.
         promptId: string | null;
         durationMs: number;
         queryId: string | null;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -35,6 +35,7 @@ import {
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
+    type WarehousePhaseTimings,
     type AiAgentMemoryConsolidationTrigger,
     type AiAgentMemoryScope,
     type AiAgentMemoryStatus,
@@ -486,6 +487,14 @@ export type QueryCompletedEvent = BaseTrack & {
         executionSource: QueryExecutionSource | null;
         warehouseType: WarehouseTypes | null;
         warehouseExecutionTimeMs: number | null;
+        /**
+         * Breakdown of `warehouseExecutionTimeMs` into the phases the adapter
+         * reports. Previously computed and only written to a log line, which
+         * left "the warehouse was slow" as one opaque number — connect/session
+         * cost points at pooling, `query`/`fetch` at the query itself.
+         * Absent phases mean the adapter does not report them.
+         */
+        warehousePhaseTimings: WarehousePhaseTimings | null;
         totalRowCount: number | null;
         columnsCount: number | null;
     };
@@ -2914,6 +2923,10 @@ export type AiAgentPromptCreatedEvent = BaseTrack & {
         projectId: string;
         aiAgentId: string;
         threadId: string | undefined;
+        // Joins the turn's start to every downstream event in it (steps, tool
+        // calls, the streamed response). Without it the head of a turn —
+        // submit to first model output — cannot be measured.
+        promptId: string;
         context: 'slack' | 'web_app';
         hasPinnedContext: boolean;
         pinnedContextCount: number;
@@ -2941,6 +2954,10 @@ export type AiAgentResponseStreamed = BaseTrack & {
         projectId: string;
         aiAgentId: string;
         agentName: string;
+        // Turn identity, so the tail of the turn joins to its steps, its tool
+        // calls and the prompt that started it.
+        promptId: string;
+        threadId: string;
         usageTokensCount: number;
         stepsCount: number;
         model: string;
@@ -2949,6 +2966,49 @@ export type AiAgentResponseStreamed = BaseTrack & {
         stepCapReached: boolean;
         timeToFirstTokenMs: number | null;
         durationMs: number;
+    };
+};
+
+/**
+ * One row per iteration of the agent loop — the grain the turn waterfall is
+ * reconstructed from. `ai.usage` reports a whole streamed run as a single
+ * total, which cannot express the alternation of inference and tool
+ * execution, so latency is sliced here instead.
+ *
+ * `toolWallMs` is a step's tool phase measured as wall time, not the sum of
+ * its tool durations: a step that fans out concurrent calls would otherwise
+ * be counted several times over.
+ */
+export type AiAgentStepCompletedEvent = BaseTrack & {
+    event: 'ai_agent.step_completed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        promptId: string;
+        threadId: string;
+        stepIndex: number;
+        model: string;
+        modelProvider: string | null;
+        // Offset from turn start, so steps order and locate without relying on
+        // event timestamps (which carry ingestion jitter).
+        stepOffsetMs: number;
+        stepTotalMs: number;
+        // Null when the step ran tools but the transport never exposed the
+        // decide/execute boundary (the non-streaming provider path).
+        // `stepTotalMs` is always present.
+        inferenceMs: number | null;
+        toolWallMs: number | null;
+        ttftMs: number | null;
+        toolCallCount: number;
+        reasoningChars: number;
+        inputTokens: number | null;
+        outputTokens: number | null;
+        cacheReadTokens: number | null;
+        cacheWriteTokens: number | null;
+        reasoningTokens: number | null;
+        totalTokens: number | null;
     };
 };
 
@@ -3065,6 +3125,37 @@ export type AiAgentToolCallEvent = BaseTrack & {
         toolName: string;
         threadId: string;
         promptId: string;
+        toolCallId: string;
+        // Which loop iteration emitted the call. Calls sharing a stepIndex ran
+        // concurrently, so their durations must not be summed.
+        stepIndex: number;
+    };
+};
+
+/**
+ * Fires when a tool returns, carrying what the call-time event cannot know.
+ * Kept as its own event rather than a second `ai_agent_tool_call` so the
+ * existing one stays one-row-per-call for the models that count it; join the
+ * pair on `toolCallId`.
+ *
+ * A call that never returns (aborted turn, crash) has no row here, so a
+ * missing completion is itself the signal — treat these as a left join, not
+ * an inner one.
+ */
+export type AiAgentToolCallCompletedEvent = BaseTrack & {
+    event: 'ai_agent.tool_call_completed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        aiAgentId: string;
+        toolName: string;
+        threadId: string;
+        promptId: string;
+        toolCallId: string;
+        stepIndex: number;
+        durationMs: number;
+        status: 'success' | 'error';
     };
 };
 
@@ -3156,6 +3247,37 @@ export type ContentReviewSimilarContentFoundEvent = BaseTrack & {
         contentId: string | null;
         matchCount: number;
         verifiedMatchCount: number;
+    };
+};
+
+/**
+ * The browser fetching an artifact's chart data. This runs *after* the agent
+ * turn has streamed and closed, as a separate request that re-executes the
+ * query from the persisted config — so it is on the user's path to seeing a
+ * chart but sits outside the turn's own duration.
+ *
+ * `queryId` joins to `query.completed` for cache-hit and warehouse timings
+ * rather than restating them here.
+ *
+ * Previously emitted untyped, which is why it never reached the warehouse.
+ */
+export type AiAgentArtifactVizQueryEvent = BaseTrack & {
+    event: 'ai_agent.artifact_viz_query';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        agentId: string;
+        agentName: string;
+        artifactId: string;
+        artifactVersionId: string;
+        vizType: string;
+        source: string;
+        // Ties the render round-trip back to the turn that produced the
+        // artifact. Null for artifacts persisted without a prompt.
+        promptId: string | null;
+        durationMs: number;
+        queryId: string | null;
     };
 };
 
@@ -4012,7 +4134,10 @@ type TypedEvent =
     | AiAgentEvalAppendedEvent
     | McpToolCallEvent
     | AiAgentToolCallEvent
+    | AiAgentToolCallCompletedEvent
     | AiAgentToolCallFailedEvent
+    | AiAgentStepCompletedEvent
+    | AiAgentArtifactVizQueryEvent
     | AiAgentArtifactVersionVerifiedEvent
     | AiAgentArtifactsRetrievedEvent
     | AiAgentFindContentCoverageEvent

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -35,7 +35,6 @@ import {
     TableSelectionType,
     ValidateProjectPayload,
     WarehouseTypes,
-    type WarehousePhaseTimings,
     type AiAgentMemoryConsolidationTrigger,
     type AiAgentMemoryScope,
     type AiAgentMemoryStatus,
@@ -65,6 +64,7 @@ import {
     type PersistentDownloadFileAccessMode,
     type PlaygroundProjectTrigger,
     type PullRequestProvider,
+    type WarehousePhaseTimings,
 } from '@lightdash/common';
 import Analytics, {
     Track as AnalyticsTrack,

--- a/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
+++ b/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
@@ -73,8 +73,6 @@ describe('EventStreamSink', () => {
             execution_source: 'warehouse',
             warehouse_type: WarehouseTypes.POSTGRES,
             warehouse_execution_time_ms: 123,
-            // Phases flatten into their own columns; an unreported phase
-            // stays null rather than defaulting to 0.
             warehouse_connect_ms: 20,
             warehouse_query_ms: 90,
             warehouse_fetch_ms: 13,

--- a/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
+++ b/packages/backend/src/analytics/eventStream/EventStreamSink.test.ts
@@ -39,6 +39,7 @@ const queryCompletedEvent: QueryCompletedEvent = {
         executionSource: 'warehouse',
         warehouseType: WarehouseTypes.POSTGRES,
         warehouseExecutionTimeMs: 123,
+        warehousePhaseTimings: { connect: 20, query: 90, fetch: 13 },
         totalRowCount: 42,
         columnsCount: 5,
     },
@@ -72,6 +73,13 @@ describe('EventStreamSink', () => {
             execution_source: 'warehouse',
             warehouse_type: WarehouseTypes.POSTGRES,
             warehouse_execution_time_ms: 123,
+            // Phases flatten into their own columns; an unreported phase
+            // stays null rather than defaulting to 0.
+            warehouse_connect_ms: 20,
+            warehouse_query_ms: 90,
+            warehouse_fetch_ms: 13,
+            warehouse_session_ms: null,
+            warehouse_ssh_tunnel_ms: null,
             total_row_count: 42,
             columns_count: 5,
         });
@@ -89,6 +97,7 @@ describe('EventStreamSink', () => {
                 warehouseType: null,
                 executionSource: null,
                 warehouseExecutionTimeMs: null,
+                warehousePhaseTimings: null,
                 totalRowCount: null,
                 columnsCount: null,
             },

--- a/packages/backend/src/analytics/eventStream/UsageEventsCompactor.test.ts
+++ b/packages/backend/src/analytics/eventStream/UsageEventsCompactor.test.ts
@@ -206,7 +206,9 @@ describe('buildCompactionSql', () => {
             'COPY (SELECT "event_name", "org_id", "user_id", "event_ts", "schema_version", ' +
                 '"project_id", "query_id", "status", "context", "explore_name", "chart_id", ' +
                 '"dashboard_id", "cache_hit", "execution_source", "warehouse_type", ' +
-                '"warehouse_execution_time_ms", "total_row_count", "columns_count" ' +
+                '"warehouse_execution_time_ms", "warehouse_ssh_tunnel_ms", ' +
+                '"warehouse_connect_ms", "warehouse_session_ms", "warehouse_query_ms", ' +
+                '"warehouse_fetch_ms", "total_row_count", "columns_count" ' +
                 "FROM read_json(['s3://events-bucket/events/raw/org_id=org-1/stream=query_events/dt=2026-07-01/a.jsonl.gz', " +
                 "'s3://events-bucket/events/raw/org_id=org-1/stream=query_events/dt=2026-07-01/b.jsonl.gz'], " +
                 "format='newline_delimited', " +
@@ -216,6 +218,9 @@ describe('buildCompactionSql', () => {
                 '"explore_name": \'VARCHAR\', "chart_id": \'VARCHAR\', "dashboard_id": \'VARCHAR\', ' +
                 '"cache_hit": \'BOOLEAN\', "execution_source": \'VARCHAR\', "warehouse_type": \'VARCHAR\', ' +
                 '"warehouse_execution_time_ms": \'BIGINT\', ' +
+                '"warehouse_ssh_tunnel_ms": \'BIGINT\', "warehouse_connect_ms": \'BIGINT\', ' +
+                '"warehouse_session_ms": \'BIGINT\', "warehouse_query_ms": \'BIGINT\', ' +
+                '"warehouse_fetch_ms": \'BIGINT\', ' +
                 '"total_row_count": \'BIGINT\', "columns_count": \'INTEGER\'})) ' +
                 `TO 's3://events-bucket/${compactedKey}' (FORMAT PARQUET, COMPRESSION zstd)`,
         );

--- a/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
+++ b/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
@@ -1,0 +1,157 @@
+import type {
+    AiAgentStepCompletedEvent,
+    AiAgentToolCallCompletedEvent,
+} from '../LightdashAnalytics';
+import { EventStreamSink } from './EventStreamSink';
+import { agentStepsCompactedColumns } from './agentStepsStream';
+import { EVENT_STREAM_SCHEMA_VERSION } from './projection';
+import { eventStreamRegistry } from './registry';
+import { EventStreamRow } from './types';
+
+vi.mock('../../logging/logger', () => ({
+    __esModule: true,
+    default: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+const createWriterMock = () => ({
+    push: vi.fn<(stream: string, row: EventStreamRow) => void>(),
+    flush: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+});
+
+const stepEvent: AiAgentStepCompletedEvent = {
+    event: 'ai_agent.step_completed',
+    userId: 'user-1',
+    properties: {
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        aiAgentId: 'agent-1',
+        promptId: 'prompt-1',
+        threadId: 'thread-1',
+        stepIndex: 2,
+        model: 'claude-sonnet-5',
+        modelProvider: 'anthropic',
+        stepOffsetMs: 8_000,
+        stepTotalMs: 5_500,
+        inferenceMs: 4_200,
+        toolWallMs: 1_300,
+        ttftMs: 900,
+        toolCallCount: 3,
+        reasoningChars: 412,
+        inputTokens: 12_000,
+        outputTokens: 320,
+        cacheReadTokens: 11_000,
+        cacheWriteTokens: 500,
+        reasoningTokens: 180,
+        totalTokens: 12_320,
+    },
+};
+
+const toolCallEvent: AiAgentToolCallCompletedEvent = {
+    event: 'ai_agent.tool_call_completed',
+    userId: 'user-1',
+    properties: {
+        organizationId: 'org-1',
+        projectId: 'project-1',
+        aiAgentId: 'agent-1',
+        toolName: 'runMetricQuery',
+        threadId: 'thread-1',
+        promptId: 'prompt-1',
+        toolCallId: 'call-9',
+        stepIndex: 2,
+        durationMs: 1_300,
+        status: 'success',
+    },
+};
+
+describe('agentStepsStream', () => {
+    it('projects a completed step into the agent_steps stream', () => {
+        const writer = createWriterMock();
+        new EventStreamSink(eventStreamRegistry, writer).handle(stepEvent);
+
+        expect(writer.push).toHaveBeenCalledTimes(1);
+        const [stream, row] = writer.push.mock.calls[0]!;
+        expect(stream).toBe('agent_steps');
+        expect(row).toMatchObject({
+            event_name: 'ai_agent.step_completed',
+            org_id: 'org-1',
+            user_id: 'user-1',
+            schema_version: EVENT_STREAM_SCHEMA_VERSION,
+            record_type: 'step',
+            prompt_id: 'prompt-1',
+            step_index: 2,
+            inference_ms: 4_200,
+            tool_wall_ms: 1_300,
+            ttft_ms: 900,
+            total_tokens: 12_320,
+        });
+    });
+
+    it('projects a completed tool call into the same stream', () => {
+        const writer = createWriterMock();
+        new EventStreamSink(eventStreamRegistry, writer).handle(toolCallEvent);
+
+        const [stream, row] = writer.push.mock.calls[0]!;
+        expect(stream).toBe('agent_steps');
+        expect(row).toMatchObject({
+            record_type: 'tool_call',
+            prompt_id: 'prompt-1',
+            step_index: 2,
+            tool_call_id: 'call-9',
+            tool_name: 'runMetricQuery',
+            tool_duration_ms: 1_300,
+            tool_status: 'success',
+        });
+    });
+
+    it('shares one schema across both grains, nulling the absent side', () => {
+        const writer = createWriterMock();
+        const sink = new EventStreamSink(eventStreamRegistry, writer);
+        sink.handle(stepEvent);
+        sink.handle(toolCallEvent);
+
+        const columns = agentStepsCompactedColumns.map((c) => c.name);
+        writer.push.mock.calls.forEach(([, row]) => {
+            // Every declared column is present, so the parquet cast never sees
+            // a missing key for one grain.
+            columns.forEach((column) => expect(row).toHaveProperty(column));
+        });
+
+        const [, stepRow] = writer.push.mock.calls[0]!;
+        const [, toolRow] = writer.push.mock.calls[1]!;
+        expect(stepRow.tool_call_id).toBeNull();
+        expect(toolRow.inference_ms).toBeNull();
+    });
+
+    it('drops events that cannot be attributed to an organization', () => {
+        const writer = createWriterMock();
+        new EventStreamSink(eventStreamRegistry, writer).handle({
+            ...stepEvent,
+            properties: { ...stepEvent.properties, organizationId: '' },
+        });
+
+        expect(writer.push).not.toHaveBeenCalled();
+    });
+
+    it('keeps a null inference split rather than coercing it to zero', () => {
+        const writer = createWriterMock();
+        new EventStreamSink(eventStreamRegistry, writer).handle({
+            ...stepEvent,
+            properties: {
+                ...stepEvent.properties,
+                inferenceMs: null,
+                toolWallMs: null,
+            },
+        });
+
+        const [, row] = writer.push.mock.calls[0]!;
+        expect(row.inference_ms).toBeNull();
+        expect(row.tool_wall_ms).toBeNull();
+        expect(row.step_total_ms).toBe(5_500);
+    });
+});

--- a/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
+++ b/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
@@ -117,8 +117,6 @@ describe('agentStepsStream', () => {
 
         const columns = agentStepsCompactedColumns.map((c) => c.name);
         writer.push.mock.calls.forEach(([, row]) => {
-            // Every declared column is present, so the parquet cast never sees
-            // a missing key for one grain.
             columns.forEach((column) => expect(row).toHaveProperty(column));
         });
 

--- a/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
+++ b/packages/backend/src/analytics/eventStream/agentStepsStream.test.ts
@@ -2,8 +2,8 @@ import type {
     AiAgentStepCompletedEvent,
     AiAgentToolCallCompletedEvent,
 } from '../LightdashAnalytics';
-import { EventStreamSink } from './EventStreamSink';
 import { agentStepsCompactedColumns } from './agentStepsStream';
+import { EventStreamSink } from './EventStreamSink';
 import { EVENT_STREAM_SCHEMA_VERSION } from './projection';
 import { eventStreamRegistry } from './registry';
 import { EventStreamRow } from './types';

--- a/packages/backend/src/analytics/eventStream/agentStepsStream.ts
+++ b/packages/backend/src/analytics/eventStream/agentStepsStream.ts
@@ -6,16 +6,9 @@ import { buildEnvelope, ProjectionResult } from './projection';
 import type { CompactedStreamColumn } from './types';
 
 /**
- * Typed column list for the compacted (parquet) zone of the `agent_steps`
- * stream, v1.
- *
- * One stream carries both grains — a loop step and a finished tool call —
- * discriminated by `record_type`, because they are only useful read together:
- * a step's tool phase is the wall time of the calls sharing its `step_index`,
- * so splitting them across streams would force a cross-stream join for the
- * most common question.
- *
- * Columns that belong to only one grain are null on the other.
+ * Compacted (parquet) columns for the `agent_steps` stream, v1. Both grains —
+ * loop step and finished tool call — share it, discriminated by `record_type`,
+ * since they are read together. Columns of one grain are null on the other.
  */
 export const agentStepsCompactedColumns: CompactedStreamColumn[] = [
     { name: 'event_name', type: 'VARCHAR' },
@@ -52,7 +45,7 @@ export const agentStepsCompactedColumns: CompactedStreamColumn[] = [
     { name: 'tool_status', type: 'VARCHAR' },
 ];
 
-/** One row per finished iteration of the agent loop. */
+/** One row per finished loop iteration. */
 const projectAgentStepEvent = (
     payload: AiAgentStepCompletedEvent,
 ): ProjectionResult => {
@@ -91,7 +84,7 @@ const projectAgentStepEvent = (
     };
 };
 
-/** One row per tool call that returned, joinable to its step by step_index. */
+/** One row per returned tool call, joined to its step by step_index. */
 const projectAgentToolCallCompletedEvent = (
     payload: AiAgentToolCallCompletedEvent,
 ): ProjectionResult => {

--- a/packages/backend/src/analytics/eventStream/agentStepsStream.ts
+++ b/packages/backend/src/analytics/eventStream/agentStepsStream.ts
@@ -1,0 +1,136 @@
+import type {
+    AiAgentStepCompletedEvent,
+    AiAgentToolCallCompletedEvent,
+} from '../LightdashAnalytics';
+import { buildEnvelope, ProjectionResult } from './projection';
+import type { CompactedStreamColumn } from './types';
+
+/**
+ * Typed column list for the compacted (parquet) zone of the `agent_steps`
+ * stream, v1.
+ *
+ * One stream carries both grains — a loop step and a finished tool call —
+ * discriminated by `record_type`, because they are only useful read together:
+ * a step's tool phase is the wall time of the calls sharing its `step_index`,
+ * so splitting them across streams would force a cross-stream join for the
+ * most common question.
+ *
+ * Columns that belong to only one grain are null on the other.
+ */
+export const agentStepsCompactedColumns: CompactedStreamColumn[] = [
+    { name: 'event_name', type: 'VARCHAR' },
+    { name: 'org_id', type: 'VARCHAR' },
+    { name: 'user_id', type: 'VARCHAR' },
+    { name: 'event_ts', type: 'TIMESTAMP' },
+    { name: 'schema_version', type: 'INTEGER' },
+    { name: 'record_type', type: 'VARCHAR' },
+    { name: 'project_id', type: 'VARCHAR' },
+    { name: 'agent_id', type: 'VARCHAR' },
+    { name: 'thread_id', type: 'VARCHAR' },
+    { name: 'prompt_id', type: 'VARCHAR' },
+    { name: 'step_index', type: 'INTEGER' },
+    // step grain
+    { name: 'model', type: 'VARCHAR' },
+    { name: 'model_provider', type: 'VARCHAR' },
+    { name: 'step_offset_ms', type: 'BIGINT' },
+    { name: 'step_total_ms', type: 'BIGINT' },
+    { name: 'inference_ms', type: 'BIGINT' },
+    { name: 'tool_wall_ms', type: 'BIGINT' },
+    { name: 'ttft_ms', type: 'BIGINT' },
+    { name: 'tool_call_count', type: 'INTEGER' },
+    { name: 'reasoning_chars', type: 'BIGINT' },
+    { name: 'input_tokens', type: 'BIGINT' },
+    { name: 'output_tokens', type: 'BIGINT' },
+    { name: 'cache_read_tokens', type: 'BIGINT' },
+    { name: 'cache_write_tokens', type: 'BIGINT' },
+    { name: 'reasoning_tokens', type: 'BIGINT' },
+    { name: 'total_tokens', type: 'BIGINT' },
+    // tool-call grain
+    { name: 'tool_call_id', type: 'VARCHAR' },
+    { name: 'tool_name', type: 'VARCHAR' },
+    { name: 'tool_duration_ms', type: 'BIGINT' },
+    { name: 'tool_status', type: 'VARCHAR' },
+];
+
+/** One row per finished iteration of the agent loop. */
+const projectAgentStepEvent = (
+    payload: AiAgentStepCompletedEvent,
+): ProjectionResult => {
+    const { properties } = payload;
+    if (!properties.organizationId) return null;
+    return {
+        stream: 'agent_steps',
+        row: {
+            ...buildEnvelope(payload, properties.organizationId),
+            record_type: 'step',
+            project_id: properties.projectId,
+            agent_id: properties.aiAgentId,
+            thread_id: properties.threadId,
+            prompt_id: properties.promptId,
+            step_index: properties.stepIndex,
+            model: properties.model,
+            model_provider: properties.modelProvider,
+            step_offset_ms: properties.stepOffsetMs,
+            step_total_ms: properties.stepTotalMs,
+            inference_ms: properties.inferenceMs,
+            tool_wall_ms: properties.toolWallMs,
+            ttft_ms: properties.ttftMs,
+            tool_call_count: properties.toolCallCount,
+            reasoning_chars: properties.reasoningChars,
+            input_tokens: properties.inputTokens,
+            output_tokens: properties.outputTokens,
+            cache_read_tokens: properties.cacheReadTokens,
+            cache_write_tokens: properties.cacheWriteTokens,
+            reasoning_tokens: properties.reasoningTokens,
+            total_tokens: properties.totalTokens,
+            tool_call_id: null,
+            tool_name: null,
+            tool_duration_ms: null,
+            tool_status: null,
+        },
+    };
+};
+
+/** One row per tool call that returned, joinable to its step by step_index. */
+const projectAgentToolCallCompletedEvent = (
+    payload: AiAgentToolCallCompletedEvent,
+): ProjectionResult => {
+    const { properties } = payload;
+    if (!properties.organizationId) return null;
+    return {
+        stream: 'agent_steps',
+        row: {
+            ...buildEnvelope(payload, properties.organizationId),
+            record_type: 'tool_call',
+            project_id: properties.projectId,
+            agent_id: properties.aiAgentId,
+            thread_id: properties.threadId,
+            prompt_id: properties.promptId,
+            step_index: properties.stepIndex,
+            model: null,
+            model_provider: null,
+            step_offset_ms: null,
+            step_total_ms: null,
+            inference_ms: null,
+            tool_wall_ms: null,
+            ttft_ms: null,
+            tool_call_count: null,
+            reasoning_chars: null,
+            input_tokens: null,
+            output_tokens: null,
+            cache_read_tokens: null,
+            cache_write_tokens: null,
+            reasoning_tokens: null,
+            total_tokens: null,
+            tool_call_id: properties.toolCallId,
+            tool_name: properties.toolName,
+            tool_duration_ms: properties.durationMs,
+            tool_status: properties.status,
+        },
+    };
+};
+
+export const agentStepsProjections = {
+    'ai_agent.step_completed': projectAgentStepEvent,
+    'ai_agent.tool_call_completed': projectAgentToolCallCompletedEvent,
+};

--- a/packages/backend/src/analytics/eventStream/projection.ts
+++ b/packages/backend/src/analytics/eventStream/projection.ts
@@ -3,7 +3,7 @@ import { EventStreamRow } from './types';
 
 export const EVENT_STREAM_SCHEMA_VERSION = 1;
 
-export type StreamName = 'query_events' | 'ai_usage';
+export type StreamName = 'query_events' | 'ai_usage' | 'agent_steps';
 
 /**
  * Common envelope stamped on every row pushed into the usage event stream.

--- a/packages/backend/src/analytics/eventStream/queryEventsStream.ts
+++ b/packages/backend/src/analytics/eventStream/queryEventsStream.ts
@@ -24,6 +24,14 @@ export const queryEventsCompactedColumns: CompactedStreamColumn[] = [
     { name: 'execution_source', type: 'VARCHAR' },
     { name: 'warehouse_type', type: 'VARCHAR' },
     { name: 'warehouse_execution_time_ms', type: 'BIGINT' },
+    // Phase split of the line above, flattened so the compacted zone stays
+    // typed columns rather than a nested blob. Null where the adapter (or the
+    // code path) reports no phases.
+    { name: 'warehouse_ssh_tunnel_ms', type: 'BIGINT' },
+    { name: 'warehouse_connect_ms', type: 'BIGINT' },
+    { name: 'warehouse_session_ms', type: 'BIGINT' },
+    { name: 'warehouse_query_ms', type: 'BIGINT' },
+    { name: 'warehouse_fetch_ms', type: 'BIGINT' },
     { name: 'total_row_count', type: 'BIGINT' },
     { name: 'columns_count', type: 'INTEGER' },
 ];
@@ -54,6 +62,14 @@ const projectQueryCompletedEvent = (
             execution_source: properties.executionSource,
             warehouse_type: properties.warehouseType,
             warehouse_execution_time_ms: properties.warehouseExecutionTimeMs,
+            warehouse_ssh_tunnel_ms:
+                properties.warehousePhaseTimings?.ssh_tunnel ?? null,
+            warehouse_connect_ms:
+                properties.warehousePhaseTimings?.connect ?? null,
+            warehouse_session_ms:
+                properties.warehousePhaseTimings?.session ?? null,
+            warehouse_query_ms: properties.warehousePhaseTimings?.query ?? null,
+            warehouse_fetch_ms: properties.warehousePhaseTimings?.fetch ?? null,
             total_row_count: properties.totalRowCount,
             columns_count: properties.columnsCount,
         },

--- a/packages/backend/src/analytics/eventStream/queryEventsStream.ts
+++ b/packages/backend/src/analytics/eventStream/queryEventsStream.ts
@@ -24,9 +24,7 @@ export const queryEventsCompactedColumns: CompactedStreamColumn[] = [
     { name: 'execution_source', type: 'VARCHAR' },
     { name: 'warehouse_type', type: 'VARCHAR' },
     { name: 'warehouse_execution_time_ms', type: 'BIGINT' },
-    // Phase split of the line above, flattened so the compacted zone stays
-    // typed columns rather than a nested blob. Null where the adapter (or the
-    // code path) reports no phases.
+    // Phase breakdown of warehouse_execution_time_ms; null when not reported.
     { name: 'warehouse_ssh_tunnel_ms', type: 'BIGINT' },
     { name: 'warehouse_connect_ms', type: 'BIGINT' },
     { name: 'warehouse_session_ms', type: 'BIGINT' },

--- a/packages/backend/src/analytics/eventStream/registry.ts
+++ b/packages/backend/src/analytics/eventStream/registry.ts
@@ -1,5 +1,13 @@
 import type { AiUsageEvent } from '../aiUsage';
-import type { QueryCompletedEvent } from '../LightdashAnalytics';
+import type {
+    AiAgentStepCompletedEvent,
+    AiAgentToolCallCompletedEvent,
+    QueryCompletedEvent,
+} from '../LightdashAnalytics';
+import {
+    agentStepsCompactedColumns,
+    agentStepsProjections,
+} from './agentStepsStream';
 import { aiUsageCompactedColumns, aiUsageProjections } from './aiUsageStream';
 import type { ProjectionResult, StreamName } from './projection';
 import {
@@ -13,7 +21,11 @@ import type { CompactedStreamColumn } from './types';
  * Adding a new stream/event = add the event type here and a projection entry
  * below; nothing else needs to change.
  */
-export type ProjectedEvent = QueryCompletedEvent | AiUsageEvent;
+export type ProjectedEvent =
+    | QueryCompletedEvent
+    | AiUsageEvent
+    | AiAgentStepCompletedEvent
+    | AiAgentToolCallCompletedEvent;
 
 export type EventStreamRegistry = {
     [E in ProjectedEvent as E['event']]: (payload: E) => ProjectionResult;
@@ -26,6 +38,7 @@ export type EventStreamRegistry = {
 export const eventStreamRegistry: EventStreamRegistry = {
     ...queryEventsProjections,
     ...aiUsageProjections,
+    ...agentStepsProjections,
 };
 
 /**
@@ -39,6 +52,7 @@ export const compactedStreamSchemas: Record<
 > = {
     query_events: queryEventsCompactedColumns,
     ai_usage: aiUsageCompactedColumns,
+    agent_steps: agentStepsCompactedColumns,
 };
 
 export const getCompactedStreamColumns = (

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -7519,8 +7519,7 @@ export class AiAgentService extends BaseService {
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
         },
     ): Promise<ApiAiAgentArtifactVizQuery> {
-        // The browser blocks on this whole call before it can paint a chart,
-        // so time it from the top rather than around the warehouse leg only.
+        // Timed from the top: the browser blocks on the whole call.
         const vizQueryStartedAt = Date.now();
         const { organizationUuid } = user;
         if (!organizationUuid) {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -11856,13 +11856,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
 
                 return updateWithCitationTelemetryPromise.then(() => undefined);
             },
-            trackEvent: (
-                event:
-                    | AiAgentResponseStreamed
-                    | AiAgentToolCallEvent
-                    | AiAgentToolCallFailedEvent
-                    | AiAgentFindContentCoverageEvent,
-            ) => this.analytics.track(event),
+            trackEvent: (event) => this.analytics.track(event),
 
             createOrUpdateArtifact: async (data) => {
                 const artifact =

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3748,6 +3748,7 @@ export class AiAgentService extends BaseService {
                     projectId: agent.projectUuid,
                     aiAgentId: agentUuid,
                     threadId: threadUuid,
+                    promptId: promptUuid,
                     context: 'web_app',
                     ...AiAgentService.getPinnedContextAnalyticsProperties(
                         context,
@@ -3896,6 +3897,7 @@ export class AiAgentService extends BaseService {
                 projectId: agent.projectUuid,
                 aiAgentId: agentUuid,
                 threadId: threadUuid,
+                promptId: messageUuid,
                 context: 'web_app',
                 ...AiAgentService.getPinnedContextAnalyticsProperties(context),
             },
@@ -7517,6 +7519,9 @@ export class AiAgentService extends BaseService {
             runtimeOptions?: EmbedAiAgentRuntimeOptions;
         },
     ): Promise<ApiAiAgentArtifactVizQuery> {
+        // The browser blocks on this whole call before it can paint a chart,
+        // so time it from the top rather than around the warehouse leg only.
+        const vizQueryStartedAt = Date.now();
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -7588,6 +7593,9 @@ export class AiAgentService extends BaseService {
                     artifactVersionId: versionUuid,
                     vizType: AiResultType.QUERY_RESULT,
                     source: 'semantic',
+                    promptId: artifact.promptUuid,
+                    durationMs: Date.now() - vizQueryStartedAt,
+                    queryId: query.queryUuid,
                 },
             });
             return {
@@ -7639,6 +7647,9 @@ export class AiAgentService extends BaseService {
                     artifactVersionId: versionUuid,
                     vizType: AiResultType.TABLE_RESULT,
                     source: 'sql',
+                    promptId: artifact.promptUuid,
+                    durationMs: Date.now() - vizQueryStartedAt,
+                    queryId: query.queryUuid,
                 },
             });
 
@@ -7702,6 +7713,9 @@ export class AiAgentService extends BaseService {
                 artifactVersionId: versionUuid,
                 vizType: parsedVizConfig.type,
                 source: artifactChartConfig.source,
+                promptId: artifact.promptUuid,
+                durationMs: Date.now() - vizQueryStartedAt,
+                queryId: query.queryUuid,
             },
         });
 
@@ -12198,6 +12212,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
                     projectId: data.projectUuid,
                     aiAgentId: data.agentUuid || '',
                     threadId: threadUuid,
+                    promptId: uuid,
                     context: 'slack',
                     ...AiAgentService.getPinnedContextAnalyticsProperties(
                         undefined,

--- a/packages/backend/src/ee/services/AiAgentService/sqlArtifactVizQuery.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/sqlArtifactVizQuery.test.ts
@@ -122,6 +122,11 @@ describe('AiAgentService SQL artifact visualization query', () => {
                 properties: expect.objectContaining({
                     vizType: AiResultType.TABLE_RESULT,
                     source: 'sql',
+                    // Ties the render round-trip to the turn that produced
+                    // the artifact, and to query_events for warehouse timings.
+                    promptId: 'prompt-uuid',
+                    queryId: 'fresh-query-uuid',
+                    durationMs: expect.any(Number),
                 }),
             }),
         );

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -149,12 +149,8 @@ export const recordAgentStepUsage = async ({
 };
 
 /**
- * Emits one `ai_agent.step_completed` row for a finished loop step, pairing
- * the step's wall-clock slices with the tokens that step consumed.
- *
- * Kept beside `recordAgentStepUsage` (which reports billing tokens) rather
- * than folded into it: token accounting must stay exactly once per model
- * call, while this is the latency grain and carries the step's shape.
+ * Separate from `recordAgentStepUsage`: that reports billing tokens exactly
+ * once per model call, this is the latency grain.
  */
 const trackAgentStep = (
     args: AiAgentArgs,
@@ -1641,8 +1637,7 @@ export const generateAgentResponse = async ({
         `Agent settings: ${JSON.stringify(args.agentSettings)}`,
     );
     const startTime = Date.now();
-    // Same waterfall grain as the streaming path, minus the decide/execute
-    // split: this transport only reports a step once it has wholly finished.
+    // No decide/execute split here: steps are reported once wholly finished.
     const timing = new TurnTimingTracker(startTime);
     const modelName = getAiAgentModelName(args.model);
     let generatedTokenUsage = initialPromptTokenUsage(
@@ -1736,8 +1731,7 @@ export const generateAgentResponse = async ({
                     telemetry,
                     execution: args.execution,
                 });
-                // Read before completing: completeStep opens the next step,
-                // and the tool calls below belong to the one just closed.
+                // completeStep opens the next step; these calls belong to this one.
                 const stepIndex = timing.getCurrentStepIndex();
                 trackAgentStep(
                     args,
@@ -2027,8 +2021,7 @@ export const streamAgentResponse = async ({
     let firstChunkTime: number | null = null;
     let firstTextTime: number | null = null;
     let mcpClientsClosed = false;
-    // Per-step boundaries for the turn waterfall. The turn-level timers above
-    // stay as they are: they feed Prometheus and the persisted responseTiming.
+    // The turn-level timers above still feed Prometheus and responseTiming.
     const timing = new TurnTimingTracker(startTime);
     const modelName = getAiAgentModelName(args.model);
     const persistPrompt = makeStreamSafePersist(

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -118,6 +118,7 @@ import {
 import { getMcpActiveTools } from './mcpToolGating';
 import { buildQueryRetryStepOverride } from './queryRetryCap';
 import { getAgentTelemetryConfig, getAiAgentModelName } from './telemetry';
+import { TurnTimingTracker, type StepTiming } from './turnTiming';
 
 const createAiAgentLogger =
     (debugLoggingEnabled: boolean) => (context: string, message: string) => {
@@ -145,6 +146,56 @@ export const recordAgentStepUsage = async ({
         });
     }
     return tokens;
+};
+
+/**
+ * Emits one `ai_agent.step_completed` row for a finished loop step, pairing
+ * the step's wall-clock slices with the tokens that step consumed.
+ *
+ * Kept beside `recordAgentStepUsage` (which reports billing tokens) rather
+ * than folded into it: token accounting must stay exactly once per model
+ * call, while this is the latency grain and carries the step's shape.
+ */
+const trackAgentStep = (
+    args: AiAgentArgs,
+    dependencies: AiAgentDependencies,
+    timing: StepTiming,
+    usage: LanguageModelUsage | undefined,
+) => {
+    const tokens = usage
+        ? languageModelUsageToTokens(usage)
+        : {
+              inputTokens: null,
+              outputTokens: null,
+              cacheReadTokens: null,
+              cacheWriteTokens: null,
+              reasoningTokens: null,
+              totalTokens: null,
+          };
+
+    dependencies.trackEvent({
+        event: 'ai_agent.step_completed',
+        userId: args.userId,
+        properties: {
+            organizationId: args.organizationId,
+            projectId: args.agentSettings.projectUuid,
+            aiAgentId: args.agentSettings.uuid,
+            promptId: args.promptUuid,
+            threadId: args.threadUuid,
+            stepIndex: timing.stepIndex,
+            model: getAiAgentModelName(args.model),
+            modelProvider:
+                typeof args.model === 'string' ? null : args.model.provider,
+            stepOffsetMs: timing.stepOffsetMs,
+            stepTotalMs: timing.stepTotalMs,
+            inferenceMs: timing.inferenceMs,
+            toolWallMs: timing.toolWallMs,
+            ttftMs: timing.ttftMs,
+            toolCallCount: timing.toolCallCount,
+            reasoningChars: timing.reasoningChars,
+            ...tokens,
+        },
+    });
 };
 
 export const DEFAULT_AGENT_MAX_STEPS = 40;
@@ -1590,6 +1641,9 @@ export const generateAgentResponse = async ({
         `Agent settings: ${JSON.stringify(args.agentSettings)}`,
     );
     const startTime = Date.now();
+    // Same waterfall grain as the streaming path, minus the decide/execute
+    // split: this transport only reports a step once it has wholly finished.
+    const timing = new TurnTimingTracker(startTime);
     const modelName = getAiAgentModelName(args.model);
     let generatedTokenUsage = initialPromptTokenUsage(
         args.execution.mode === 'deep_research'
@@ -1682,6 +1736,18 @@ export const generateAgentResponse = async ({
                     telemetry,
                     execution: args.execution,
                 });
+                // Read before completing: completeStep opens the next step,
+                // and the tool calls below belong to the one just closed.
+                const stepIndex = timing.getCurrentStepIndex();
+                trackAgentStep(
+                    args,
+                    dependencies,
+                    timing.completeStep(
+                        step.reasoningText?.length ?? 0,
+                        step.toolCalls?.length ?? 0,
+                    ),
+                    step.usage,
+                );
                 for (const toolCall of step.toolCalls) {
                     if (toolCall) {
                         logger(
@@ -1720,6 +1786,8 @@ export const generateAgentResponse = async ({
                                         toolName: toolCall.toolName,
                                         threadId: args.threadUuid,
                                         promptId: args.promptUuid,
+                                        toolCallId: toolCall.toolCallId,
+                                        stepIndex,
                                     },
                                 });
 
@@ -1959,6 +2027,9 @@ export const streamAgentResponse = async ({
     let firstChunkTime: number | null = null;
     let firstTextTime: number | null = null;
     let mcpClientsClosed = false;
+    // Per-step boundaries for the turn waterfall. The turn-level timers above
+    // stay as they are: they feed Prometheus and the persisted responseTiming.
+    const timing = new TurnTimingTracker(startTime);
     const modelName = getAiAgentModelName(args.model);
     const persistPrompt = makeStreamSafePersist(
         dependencies.updatePrompt,
@@ -2043,6 +2114,7 @@ export const streamAgentResponse = async ({
             messages,
             experimental_context: new AgentContext(availableExplores),
             onChunk: (event) => {
+                timing.recordChunk();
                 // Track time to first chunk (any type) - only once
                 if (firstChunkTime === null) {
                     firstChunkTime = Date.now();
@@ -2056,6 +2128,10 @@ export const streamAgentResponse = async ({
 
                 switch (event.chunk.type) {
                     case 'tool-call':
+                        timing.recordToolCallStart(
+                            event.chunk.toolCallId,
+                            event.chunk.toolName,
+                        );
                         logger(
                             'Chunk Tool Call',
                             `Storing tool call for Prompt UUID ${
@@ -2077,6 +2153,8 @@ export const streamAgentResponse = async ({
                                 toolName: event.chunk.toolName,
                                 threadId: args.threadUuid,
                                 promptId: args.promptUuid,
+                                toolCallId: event.chunk.toolCallId,
+                                stepIndex: timing.getCurrentStepIndex(),
                             },
                         });
 
@@ -2197,6 +2275,31 @@ export const streamAgentResponse = async ({
                             event.chunk.toolName,
                             event.chunk.output,
                         );
+                        const toolTiming = timing.recordToolCallEnd(
+                            event.chunk.toolCallId,
+                        );
+                        if (toolTiming) {
+                            dependencies.trackEvent({
+                                event: 'ai_agent.tool_call_completed',
+                                userId: args.userId,
+                                properties: {
+                                    organizationId: args.organizationId,
+                                    projectId: args.agentSettings.projectUuid,
+                                    aiAgentId: args.agentSettings.uuid,
+                                    toolName: event.chunk.toolName,
+                                    threadId: args.threadUuid,
+                                    promptId: args.promptUuid,
+                                    toolCallId: event.chunk.toolCallId,
+                                    stepIndex: toolTiming.stepIndex,
+                                    durationMs: toolTiming.durationMs,
+                                    status: isErrorToolResult(
+                                        event.chunk.output as AnyType,
+                                    )
+                                        ? 'error'
+                                        : 'success',
+                                },
+                            });
+                        }
                         void dependencies
                             .storeToolResults([
                                 {
@@ -2246,6 +2349,12 @@ export const streamAgentResponse = async ({
                 }
             },
             onStepFinish: (step) => {
+                trackAgentStep(
+                    args,
+                    dependencies,
+                    timing.completeStep(step.reasoningText?.length ?? 0),
+                    step.usage,
+                );
                 if (step.reasoningText && step.reasoningText.length > 0) {
                     logger(
                         'On Step Finish',
@@ -2367,6 +2476,8 @@ export const streamAgentResponse = async ({
                         projectId: args.agentSettings.projectUuid,
                         aiAgentId: args.agentSettings.uuid,
                         agentName: args.agentSettings.name,
+                        promptId: args.promptUuid,
+                        threadId: args.threadUuid,
                         usageTokensCount: totalUsage.totalTokens ?? 0,
                         stepsCount: steps.length,
                         model: modelName,

--- a/packages/backend/src/ee/services/ai/agents/turnTiming.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/turnTiming.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { TurnTimingTracker } from './turnTiming';
+
+/** Deterministic clock: each advance() moves wall time forward by `ms`. */
+const clock = (start: number) => {
+    let t = start;
+    return {
+        now: () => t,
+        advance: (ms: number) => {
+            t += ms;
+        },
+    };
+};
+
+describe('TurnTimingTracker', () => {
+    it('reports a tool-free step as inference end to end', () => {
+        const c = clock(1_000);
+        const tracker = new TurnTimingTracker(1_000, c.now);
+
+        c.advance(200);
+        tracker.recordChunk();
+        c.advance(800);
+
+        const step = tracker.completeStep(0);
+
+        expect(step).toMatchObject({
+            stepIndex: 0,
+            stepOffsetMs: 0,
+            stepTotalMs: 1_000,
+            inferenceMs: 1_000,
+            toolWallMs: 0,
+            ttftMs: 200,
+            toolCallCount: 0,
+        });
+    });
+
+    it('splits a step at its first tool call', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        c.advance(3_000); // model thinking
+        tracker.recordToolCallStart('call-1', 'grepFields');
+        c.advance(500); // tool running
+        tracker.recordToolCallEnd('call-1');
+        const step = tracker.completeStep(0);
+
+        expect(step.inferenceMs).toBe(3_000);
+        expect(step.toolWallMs).toBe(500);
+        expect(step.stepTotalMs).toBe(3_500);
+    });
+
+    it('counts concurrent tool calls as one wall-time span, not a sum', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        c.advance(2_000);
+        // Three calls emitted together, all still running.
+        tracker.recordToolCallStart('a', 'runMetricQuery');
+        tracker.recordToolCallStart('b', 'runMetricQuery');
+        tracker.recordToolCallStart('c', 'runMetricQuery');
+
+        c.advance(1_000);
+        const a = tracker.recordToolCallEnd('a');
+        c.advance(1_000);
+        const b = tracker.recordToolCallEnd('b');
+        c.advance(1_000);
+        const cc = tracker.recordToolCallEnd('c');
+
+        const step = tracker.completeStep(0);
+
+        expect([a?.durationMs, b?.durationMs, cc?.durationMs]).toEqual([
+            1_000, 2_000, 3_000,
+        ]);
+        // Summing the three would claim 6s; the batch only took 3s.
+        expect(step.toolWallMs).toBe(3_000);
+        expect(step.toolCallCount).toBe(3);
+        expect(step.stepTotalMs).toBe(5_000);
+    });
+
+    it('attributes each tool call to the step that emitted it', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        tracker.recordToolCallStart('s0', 'grepFields');
+        c.advance(100);
+        expect(tracker.recordToolCallEnd('s0')?.stepIndex).toBe(0);
+        tracker.completeStep(0);
+
+        expect(tracker.getCurrentStepIndex()).toBe(1);
+        tracker.recordToolCallStart('s1', 'getMetadata');
+        c.advance(100);
+        expect(tracker.recordToolCallEnd('s1')?.stepIndex).toBe(1);
+    });
+
+    it('carries a tool call spanning a step boundary with its own step', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        tracker.recordToolCallStart('slow', 'runSql');
+        c.advance(500);
+        tracker.completeStep(0);
+        c.advance(500);
+
+        // Resolved after its step closed — still attributed to step 0.
+        const timing = tracker.recordToolCallEnd('slow');
+        expect(timing).toMatchObject({ stepIndex: 0, durationMs: 1_000 });
+    });
+
+    it('returns null for a result whose call was never observed', () => {
+        const tracker = new TurnTimingTracker(0, clock(0).now);
+        expect(tracker.recordToolCallEnd('never-started')).toBeNull();
+    });
+
+    it('offsets successive steps from the turn start', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        c.advance(1_000);
+        tracker.completeStep(0);
+        c.advance(2_000);
+        const second = tracker.completeStep(0);
+
+        expect(second).toMatchObject({
+            stepIndex: 1,
+            stepOffsetMs: 1_000,
+            stepTotalMs: 2_000,
+        });
+    });
+
+    it('resets time-to-first-chunk per step', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        c.advance(100);
+        tracker.recordChunk();
+        c.advance(100);
+        tracker.recordChunk(); // later chunks do not move TTFT
+        expect(tracker.completeStep(0).ttftMs).toBe(100);
+
+        c.advance(700);
+        tracker.recordChunk();
+        expect(tracker.completeStep(0).ttftMs).toBe(700);
+    });
+
+    it('leaves the split null when tools ran without observed boundaries', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        // Non-streaming transport: the step is reported only once finished,
+        // with a tool-call count but no per-call timing.
+        c.advance(4_000);
+        const step = tracker.completeStep(0, 2);
+
+        expect(step.stepTotalMs).toBe(4_000);
+        expect(step.inferenceMs).toBeNull();
+        expect(step.toolWallMs).toBeNull();
+        expect(step.toolCallCount).toBe(2);
+    });
+
+    it('still reports a full split when a step genuinely ran no tools', () => {
+        const c = clock(0);
+        const tracker = new TurnTimingTracker(0, c.now);
+
+        c.advance(2_500);
+        const step = tracker.completeStep(0, 0);
+
+        expect(step.inferenceMs).toBe(2_500);
+        expect(step.toolWallMs).toBe(0);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/turnTiming.ts
+++ b/packages/backend/src/ee/services/ai/agents/turnTiming.ts
@@ -154,7 +154,8 @@ export class TurnTimingTracker {
         // Ran tools, but nothing told us when they started: report the step
         // total and leave the split empty rather than crediting tool time to
         // the model.
-        const splitUnobservable = calls > 0 && this.stepFirstToolCallAt === null;
+        const splitUnobservable =
+            calls > 0 && this.stepFirstToolCallAt === null;
 
         const timing: StepTiming = {
             stepIndex: this.stepIndex,

--- a/packages/backend/src/ee/services/ai/agents/turnTiming.ts
+++ b/packages/backend/src/ee/services/ai/agents/turnTiming.ts
@@ -1,24 +1,9 @@
 /**
- * Wall-clock timing for one agent turn, sliced per loop step.
+ * Per-step wall-clock timing for one agent turn.
  *
- * The agent loop alternates inference and tool execution:
- *
- *   step 0: [inference ....][tool a ][tool b ]   (a and b run concurrently)
- *   step 1: [inference ..][tool c ..............]
- *   step 2: [inference .......]                  (final text, no tools)
- *
- * Totals alone cannot express that shape, and summing tool durations
- * overcounts a step whose tools ran in parallel. So each step records its own
- * boundaries and every tool call records its own start/end, keyed by step:
- * a step's tool wall time is the span from the first tool call it emitted to
- * the step finishing, which is `max` over concurrent calls by construction.
- *
- * Boundaries within a step, in the order the AI SDK reports them:
- *   stepStartedAt -> firstChunkAt (TTFT) -> ... -> firstToolCallAt -> stepFinish
- *
- * `firstToolCallAt` is the inference/tool-execution split: the model has
- * finished deciding by the time it emits a tool call, and everything after is
- * the tool batch. A step that emits no tool call is inference end to end.
+ * A step's tool phase is measured as a span (first tool call -> step finish),
+ * not the sum of its tool durations: the SDK runs a step's calls
+ * concurrently, so summing would overcount a fan-out.
  */
 
 export type ToolCallTiming = {
@@ -31,38 +16,19 @@ export type ToolCallTiming = {
 
 export type StepTiming = {
     stepIndex: number;
-    /** Turn start to step start. Locates the step on the turn's timeline. */
+    /** Turn start to step start. */
     stepOffsetMs: number;
-    /** Step start to the step finishing. */
     stepTotalMs: number;
-    /**
-     * Step start to the first tool call it emitted, or the whole step when it
-     * emitted none. The model's own latency for this step.
-     *
-     * Null when the step ran tools but the transport never surfaced the
-     * boundary between deciding and executing — the non-streaming path only
-     * reports a step once it is wholly finished. `stepTotalMs` still holds
-     * there, so a null split narrows what the row can answer rather than
-     * invalidating it.
-     */
+    /** Model latency. Null when the transport hid the decide/execute boundary. */
     inferenceMs: number | null;
-    /**
-     * First tool call to step finish — the wall time of this step's tool
-     * batch, so concurrent calls count once rather than summing.
-     * Zero for a step that called no tools, null when unobservable.
-     */
+    /** Wall time of the step's tool batch. Zero without tools, null when unobservable. */
     toolWallMs: number | null;
-    /** Step start to its first streamed chunk of any kind. */
     ttftMs: number | null;
     toolCallCount: number;
     reasoningChars: number;
 };
 
-/**
- * Tracks step and tool-call boundaries across one streamed or generated turn.
- * Fed by the AI SDK callbacks; holds no I/O of its own so the agent decides
- * what to do with each completed step.
- */
+/** Fed by the AI SDK callbacks; holds no I/O of its own. */
 export class TurnTimingTracker {
     private readonly turnStartedAt: number;
 
@@ -89,17 +55,14 @@ export class TurnTimingTracker {
         this.now = now;
     }
 
-    /** Any streamed chunk. Only the first one in a step is retained (TTFT). */
+    /** Only the first chunk of a step is retained (TTFT). */
     recordChunk(): void {
         if (this.stepFirstChunkAt === null) {
             this.stepFirstChunkAt = this.now();
         }
     }
 
-    /**
-     * The model emitted a tool call. Opens the call's timer and, for the first
-     * call of the step, closes the step's inference phase.
-     */
+    /** The first call of a step also closes that step's inference phase. */
     recordToolCallStart(toolCallId: string, toolName: string): void {
         const startedAt = this.now();
         if (this.stepFirstToolCallAt === null) {
@@ -113,12 +76,7 @@ export class TurnTimingTracker {
         });
     }
 
-    /**
-     * The tool returned. Returns its timing, or null for a call this tracker
-     * never saw start — a result can arrive without its call chunk (a resumed
-     * stream, a preliminary chunk filtered upstream), and a fabricated
-     * duration would be worse than an absent one.
-     */
+    /** Null for a call never seen starting — better absent than fabricated. */
     recordToolCallEnd(toolCallId: string): ToolCallTiming | null {
         const open = this.openToolCalls.get(toolCallId);
         if (!open) {
@@ -134,26 +92,20 @@ export class TurnTimingTracker {
         };
     }
 
-    /** Step index the next tool call will be attributed to. */
     getCurrentStepIndex(): number {
         return this.stepIndex;
     }
 
     /**
-     * Closes the current step and opens the next. The returned timing is the
-     * step that just finished.
-     *
-     * `toolCallCount` overrides the tracked count for callers that learn a
-     * step's tool calls only once it has finished (the non-streaming path).
-     * Supplying it without any observed tool-call boundary is what marks the
-     * inference/tool split unavailable.
+     * Closes the current step and opens the next. `toolCallCount` overrides
+     * the tracked count for callers that learn a step's calls only once it has
+     * finished, which is what marks the split unavailable.
      */
     completeStep(reasoningChars: number, toolCallCount?: number): StepTiming {
         const finishedAt = this.now();
         const calls = toolCallCount ?? this.stepToolCallCount;
-        // Ran tools, but nothing told us when they started: report the step
-        // total and leave the split empty rather than crediting tool time to
-        // the model.
+        // Ran tools but nothing said when: leave the split empty rather than
+        // crediting tool time to the model.
         const splitUnobservable =
             calls > 0 && this.stepFirstToolCallAt === null;
 

--- a/packages/backend/src/ee/services/ai/agents/turnTiming.ts
+++ b/packages/backend/src/ee/services/ai/agents/turnTiming.ts
@@ -1,0 +1,188 @@
+/**
+ * Wall-clock timing for one agent turn, sliced per loop step.
+ *
+ * The agent loop alternates inference and tool execution:
+ *
+ *   step 0: [inference ....][tool a ][tool b ]   (a and b run concurrently)
+ *   step 1: [inference ..][tool c ..............]
+ *   step 2: [inference .......]                  (final text, no tools)
+ *
+ * Totals alone cannot express that shape, and summing tool durations
+ * overcounts a step whose tools ran in parallel. So each step records its own
+ * boundaries and every tool call records its own start/end, keyed by step:
+ * a step's tool wall time is the span from the first tool call it emitted to
+ * the step finishing, which is `max` over concurrent calls by construction.
+ *
+ * Boundaries within a step, in the order the AI SDK reports them:
+ *   stepStartedAt -> firstChunkAt (TTFT) -> ... -> firstToolCallAt -> stepFinish
+ *
+ * `firstToolCallAt` is the inference/tool-execution split: the model has
+ * finished deciding by the time it emits a tool call, and everything after is
+ * the tool batch. A step that emits no tool call is inference end to end.
+ */
+
+export type ToolCallTiming = {
+    toolCallId: string;
+    toolName: string;
+    stepIndex: number;
+    startedAt: number;
+    durationMs: number;
+};
+
+export type StepTiming = {
+    stepIndex: number;
+    /** Turn start to step start. Locates the step on the turn's timeline. */
+    stepOffsetMs: number;
+    /** Step start to the step finishing. */
+    stepTotalMs: number;
+    /**
+     * Step start to the first tool call it emitted, or the whole step when it
+     * emitted none. The model's own latency for this step.
+     *
+     * Null when the step ran tools but the transport never surfaced the
+     * boundary between deciding and executing — the non-streaming path only
+     * reports a step once it is wholly finished. `stepTotalMs` still holds
+     * there, so a null split narrows what the row can answer rather than
+     * invalidating it.
+     */
+    inferenceMs: number | null;
+    /**
+     * First tool call to step finish — the wall time of this step's tool
+     * batch, so concurrent calls count once rather than summing.
+     * Zero for a step that called no tools, null when unobservable.
+     */
+    toolWallMs: number | null;
+    /** Step start to its first streamed chunk of any kind. */
+    ttftMs: number | null;
+    toolCallCount: number;
+    reasoningChars: number;
+};
+
+/**
+ * Tracks step and tool-call boundaries across one streamed or generated turn.
+ * Fed by the AI SDK callbacks; holds no I/O of its own so the agent decides
+ * what to do with each completed step.
+ */
+export class TurnTimingTracker {
+    private readonly turnStartedAt: number;
+
+    private readonly now: () => number;
+
+    private stepIndex = 0;
+
+    private stepStartedAt: number;
+
+    private stepFirstChunkAt: number | null = null;
+
+    private stepFirstToolCallAt: number | null = null;
+
+    private stepToolCallCount = 0;
+
+    private readonly openToolCalls = new Map<
+        string,
+        { toolName: string; stepIndex: number; startedAt: number }
+    >();
+
+    constructor(turnStartedAt: number, now: () => number = Date.now) {
+        this.turnStartedAt = turnStartedAt;
+        this.stepStartedAt = turnStartedAt;
+        this.now = now;
+    }
+
+    /** Any streamed chunk. Only the first one in a step is retained (TTFT). */
+    recordChunk(): void {
+        if (this.stepFirstChunkAt === null) {
+            this.stepFirstChunkAt = this.now();
+        }
+    }
+
+    /**
+     * The model emitted a tool call. Opens the call's timer and, for the first
+     * call of the step, closes the step's inference phase.
+     */
+    recordToolCallStart(toolCallId: string, toolName: string): void {
+        const startedAt = this.now();
+        if (this.stepFirstToolCallAt === null) {
+            this.stepFirstToolCallAt = startedAt;
+        }
+        this.stepToolCallCount += 1;
+        this.openToolCalls.set(toolCallId, {
+            toolName,
+            stepIndex: this.stepIndex,
+            startedAt,
+        });
+    }
+
+    /**
+     * The tool returned. Returns its timing, or null for a call this tracker
+     * never saw start — a result can arrive without its call chunk (a resumed
+     * stream, a preliminary chunk filtered upstream), and a fabricated
+     * duration would be worse than an absent one.
+     */
+    recordToolCallEnd(toolCallId: string): ToolCallTiming | null {
+        const open = this.openToolCalls.get(toolCallId);
+        if (!open) {
+            return null;
+        }
+        this.openToolCalls.delete(toolCallId);
+        return {
+            toolCallId,
+            toolName: open.toolName,
+            stepIndex: open.stepIndex,
+            startedAt: open.startedAt,
+            durationMs: this.now() - open.startedAt,
+        };
+    }
+
+    /** Step index the next tool call will be attributed to. */
+    getCurrentStepIndex(): number {
+        return this.stepIndex;
+    }
+
+    /**
+     * Closes the current step and opens the next. The returned timing is the
+     * step that just finished.
+     *
+     * `toolCallCount` overrides the tracked count for callers that learn a
+     * step's tool calls only once it has finished (the non-streaming path).
+     * Supplying it without any observed tool-call boundary is what marks the
+     * inference/tool split unavailable.
+     */
+    completeStep(reasoningChars: number, toolCallCount?: number): StepTiming {
+        const finishedAt = this.now();
+        const calls = toolCallCount ?? this.stepToolCallCount;
+        // Ran tools, but nothing told us when they started: report the step
+        // total and leave the split empty rather than crediting tool time to
+        // the model.
+        const splitUnobservable = calls > 0 && this.stepFirstToolCallAt === null;
+
+        const timing: StepTiming = {
+            stepIndex: this.stepIndex,
+            stepOffsetMs: this.stepStartedAt - this.turnStartedAt,
+            stepTotalMs: finishedAt - this.stepStartedAt,
+            inferenceMs: splitUnobservable
+                ? null
+                : (this.stepFirstToolCallAt ?? finishedAt) - this.stepStartedAt,
+            toolWallMs: (() => {
+                if (splitUnobservable) return null;
+                return this.stepFirstToolCallAt === null
+                    ? 0
+                    : finishedAt - this.stepFirstToolCallAt;
+            })(),
+            ttftMs:
+                this.stepFirstChunkAt === null
+                    ? null
+                    : this.stepFirstChunkAt - this.stepStartedAt,
+            toolCallCount: calls,
+            reasoningChars,
+        };
+
+        this.stepIndex += 1;
+        this.stepStartedAt = finishedAt;
+        this.stepFirstChunkAt = null;
+        this.stepFirstToolCallAt = null;
+        this.stepToolCallCount = 0;
+
+        return timing;
+    }
+}

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -52,6 +52,8 @@ import {
 import {
     AiAgentFindContentCoverageEvent,
     AiAgentResponseStreamed,
+    AiAgentStepCompletedEvent,
+    AiAgentToolCallCompletedEvent,
     AiAgentToolCallEvent,
     AiAgentToolCallFailedEvent,
 } from '../../../../analytics/LightdashAnalytics';
@@ -521,7 +523,9 @@ export type ConsumePromptSteersFn = (args: {
 export type TrackEventFn = (
     event:
         | AiAgentResponseStreamed
+        | AiAgentStepCompletedEvent
         | AiAgentToolCallEvent
+        | AiAgentToolCallCompletedEvent
         | AiAgentToolCallFailedEvent
         | AiAgentFindContentCoverageEvent,
 ) => void;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3222,6 +3222,8 @@ export class AsyncQueryService extends ProjectService {
                 executionSource,
                 warehouseType,
                 warehouseExecutionTimeMs: null,
+                // Error path: the query never reported phases.
+                warehousePhaseTimings: null,
                 totalRowCount: null,
                 columnsCount: null,
                 ...(isRegisteredUser ? undefined : { externalId: userUuid }),
@@ -3646,6 +3648,7 @@ export class AsyncQueryService extends ProjectService {
                     executionSource,
                     warehouseType: warehouseClient.credentials.type,
                     warehouseExecutionTimeMs: Math.round(durationMs),
+                    warehousePhaseTimings,
                     totalRowCount: pivotDetails?.totalRows ?? totalRows,
                     columnsCount:
                         pivotDetails?.totalColumnCount ??
@@ -4696,6 +4699,9 @@ export class AsyncQueryService extends ProjectService {
                                 warehouseExecutionTimeMs: outcome.cacheHit
                                     ? 0
                                     : null,
+                                // Terminal-state path: phases are reported by
+                                // the executor, which this branch did not run.
+                                warehousePhaseTimings: null,
                                 totalRowCount: outcome.totalRowCount ?? null,
                                 columnsCount: outcome.columnsCount ?? null,
                             },
@@ -8639,6 +8645,8 @@ export class AsyncQueryService extends ProjectService {
                 executionSource: 'pre_aggregate_duckdb',
                 warehouseType,
                 warehouseExecutionTimeMs: 0,
+                // Served from cache — no warehouse phases to report.
+                warehousePhaseTimings: null,
                 totalRowCount: cached.totalRowCount,
                 columnsCount: cached.columns
                     ? Object.keys(cached.columns).length

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4699,8 +4699,7 @@ export class AsyncQueryService extends ProjectService {
                                 warehouseExecutionTimeMs: outcome.cacheHit
                                     ? 0
                                     : null,
-                                // Terminal-state path: phases are reported by
-                                // the executor, which this branch did not run.
+                                // Phases come from the executor, not this path.
                                 warehousePhaseTimings: null,
                                 totalRowCount: outcome.totalRowCount ?? null,
                                 columnsCount: outcome.columnsCount ?? null,


### PR DESCRIPTION
Relates: PROD-8493

### Description:

Agent latency can only be measured as turn totals today, which cannot express the loop's actual shape — inference, then a batch of tool calls, then inference again, then a warehouse query, and so on.

Three gaps make the waterfall unreconstructable:

- `ai.usage` reports **one row for a whole streamed run** (`onFinish`, `totalUsage`), so the streaming path — the one real users hit — has no per-step grain at all. The non-streaming path emits per step, so the grain is also inconsistent between them.
- `ai_agent_tool_call` carries a timestamp but **no duration and no step index**, so tool time can only be inferred from gaps between calls, and parallel calls are indistinguishable from fast sequential ones.
- The **head and tail of a turn are not joinable to it**: `ai_agent_prompt.created` has no `promptId`, and `ai_agent.response_streamed` carries neither `promptId` nor `threadId`.

This slices the turn per step instead.

**New events**

- **`ai_agent.step_completed`** — one row per loop iteration: `stepIndex`, `stepOffsetMs`, `stepTotalMs`, `inferenceMs`, `toolWallMs`, `ttftMs`, `reasoningChars`, model/provider, and the full token breakdown.
- **`ai_agent.tool_call_completed`** — execution time and status per call, joinable to its step.

**Existing events extended**

- `ai_agent_tool_call` gains `toolCallId` and `stepIndex`.
- `ai_agent_prompt.created` gains `promptId` (all three call sites: web app ×2, Slack).
- `ai_agent.response_streamed` gains `promptId` and `threadId`.
- `query.completed` gains `warehousePhaseTimings` (`ssh_tunnel`/`connect`/`session`/`query`/`fetch`). These were already computed and then written only to a log line — connect/session cost points at pooling, `query`/`fetch` at the query itself.
- `ai_agent.artifact_viz_query` becomes a **typed** event (it was emitted through the `UntypedEvent` escape hatch, which is why it never reached the warehouse) and gains `promptId`, `durationMs` and `queryId`. This is the browser's blocking round-trip before a chart can paint, and it re-executes the query from the persisted config rather than reusing the agent's — so it is on the user's critical path but sits entirely outside the turn's own duration.

**Warehouse delivery**

New `agent_steps` stream carries both grains, discriminated by `record_type`, because they are only useful read together — a step's tool phase is the wall time of the calls sharing its `step_index`. Phase timings are flattened into typed columns on `query_events`.

### Design notes

**Parallel tool calls.** A step's tool phase is measured as wall time from its first tool call to the step finishing — *not* the sum of its tool durations. The SDK runs a step's calls concurrently, so summing a three-way fan-out would count it roughly three times over. `turnTiming.ts` owns this; a test pins the case explicitly.

**Tool completion is a separate event**, not a second `ai_agent_tool_call`. Emitting the existing event twice would have silently doubled `count_tool_calls` in the downstream `ai_agent_usage` model. Join the pair on `toolCallId`; a call that never returns has no completion row, so treat it as a left join.

**The non-streaming provider path** reports a step only once it has wholly finished, so it has no observable boundary between deciding and executing. It reports `stepTotalMs` and leaves `inferenceMs`/`toolWallMs` null rather than crediting tool time to the model.

### Not included

Agent-initiated queries still do not join to a turn. That needs `ai_prompt_uuid` threaded through `RunQueryTags` and `executeMetricQueryAndGetResults`, which changes a signature every caller uses — better as its own PR (see also #26121). The render round-trip *does* join, via `queryId` on `ai_agent.artifact_viz_query`.

The dbt models for the three new/changed events do not exist yet, so the events will land raw in BigQuery but are not explorable until those are added in the analytics repo.

### Verification

- `pnpm -F backend typecheck` — clean
- `pnpm -F backend lint` — clean
- `pnpm -F backend test src/analytics src/ee/services/ai src/ee/services/AiAgentService` — **2511 passed / 151 files**
- New: 10 tests for `TurnTimingTracker` (parallel fan-out, calls spanning a step boundary, per-step TTFT reset, unobservable split), 5 for the `agent_steps` projections.

### Risk assessment:

- [ ] This is a high-risk change

Additive analytics instrumentation. No schema migrations, no behaviour change to the agent loop, no change to what is persisted for users. The one downstream consideration is noted above: the new completion event is deliberately separate so existing tool-call counts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrjgVZidS2EnD49Xox8yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTrjgVZidS2EnD49Xox8yj)_