### PR TITLE
feat(frontend): diagnose requests that never reach the server and hand the user the evidence

### DIFF
--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -224,6 +224,133 @@ describe('networkHistory redaction', () => {
     });
 });
 
+describe('network error messages', () => {
+    let previousFetch: typeof fetch;
+
+    beforeEach(() => {
+        previousFetch = globalThis.fetch;
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        globalThis.fetch = previousFetch;
+        vi.restoreAllMocks();
+    });
+
+    const request = () =>
+        lightdashApi({
+            method: 'PATCH',
+            url: '/projects/abc',
+            body: JSON.stringify({}),
+        });
+
+    it('says the request never reached the server when fetch rejects', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch'));
+
+        await expect(request()).rejects.toMatchObject({
+            status: 'error',
+            error: {
+                name: 'NetworkError',
+                statusCode: 500,
+                message: expect.stringContaining(
+                    'The request PATCH /projects/abc never reached the Lightdash server',
+                ),
+                data: { cause: 'Failed to fetch' },
+            },
+        });
+    });
+
+    it('reports the HTTP status when the response is not the API envelope', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(
+            new Response('<html>blocked</html>', {
+                status: 502,
+                headers: { 'Content-Type': 'text/html' },
+            }),
+        );
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message: expect.stringContaining(
+                    'unexpected response (HTTP 502) to PATCH /projects/abc',
+                ),
+            },
+        });
+    });
+
+    it('reports a cancelled request', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new DOMException('Aborted', 'AbortError'));
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message: expect.stringContaining('was cancelled'),
+            },
+        });
+    });
+
+    it('reports being offline ahead of any other cause', async () => {
+        vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch'));
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message:
+                    'You appear to be offline. Check your internet connection and try again.',
+            },
+        });
+    });
+
+    it('passes real API errors through untouched', async () => {
+        const scope = nock(BASE_API_URL)
+            .patch('/api/v1/projects/abc')
+            .reply(400, {
+                status: 'error',
+                error: {
+                    name: 'ParameterError',
+                    statusCode: 400,
+                    message:
+                        'SSH tunnel is enabled but no public key has been generated.',
+                    data: {},
+                },
+            });
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'ParameterError',
+                statusCode: 400,
+                message:
+                    'SSH tunnel is enabled but no public key has been generated.',
+            },
+        });
+        scope.done();
+    });
+
+    it('uses the same messages for stream requests', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(
+            new Response('<html>blocked</html>', {
+                status: 403,
+                headers: { 'Content-Type': 'text/html' },
+            }),
+        );
+
+        await expect(
+            lightdashApiStream({
+                method: 'POST',
+                url: '/stream',
+                body: JSON.stringify({}),
+            }),
+        ).rejects.toThrow('unexpected response (HTTP 403) to POST /stream');
+    });
+});
+
 describe('fetch binding', () => {
     const okResponse = (results: unknown) =>
         new Response(JSON.stringify({ status: 'ok', results }), {

--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -237,6 +237,9 @@ describe('network error messages', () => {
         vi.restoreAllMocks();
     });
 
+    const healthOk = () =>
+        new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+
     const request = () =>
         lightdashApi({
             method: 'PATCH',
@@ -244,10 +247,11 @@ describe('network error messages', () => {
             body: JSON.stringify({}),
         });
 
-    it('says the request never reached the server when fetch rejects', async () => {
+    it('says the request was blocked when fetch rejects but the server answers a probe', async () => {
         globalThis.fetch = vi
             .fn()
-            .mockRejectedValue(new TypeError('Failed to fetch'));
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(healthOk());
 
         await expect(request()).rejects.toMatchObject({
             status: 'error',
@@ -255,9 +259,29 @@ describe('network error messages', () => {
                 name: 'NetworkError',
                 statusCode: 500,
                 message: expect.stringContaining(
-                    'The request PATCH /projects/abc never reached the Lightdash server',
+                    'Lightdash is reachable, but PATCH http://test.lightdash/api/v1/projects/abc was blocked before it arrived',
                 ),
-                data: { cause: 'Failed to fetch' },
+                data: {
+                    kind: 'blocked',
+                    cause: 'Failed to fetch',
+                    probe: { ok: true, status: 200 },
+                },
+            },
+        });
+    });
+
+    it('says the server is unreachable when the probe fails too', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch'));
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message: expect.stringContaining(
+                    'Lightdash cannot be reached from your network right now',
+                ),
+                data: { kind: 'unreachable' },
             },
         });
     });
@@ -274,8 +298,9 @@ describe('network error messages', () => {
             error: {
                 name: 'NetworkError',
                 message: expect.stringContaining(
-                    'unexpected response (HTTP 502) to PATCH /projects/abc',
+                    'with HTTP 502 instead of Lightdash',
                 ),
+                data: { kind: 'intercepted', responseStatus: 502 },
             },
         });
     });
@@ -289,6 +314,7 @@ describe('network error messages', () => {
             error: {
                 name: 'NetworkError',
                 message: expect.stringContaining('was cancelled'),
+                data: { kind: 'cancelled' },
             },
         });
     });
@@ -304,8 +330,22 @@ describe('network error messages', () => {
                 name: 'NetworkError',
                 message:
                     'You appear to be offline. Check your internet connection and try again.',
+                data: { kind: 'offline' },
             },
         });
+    });
+
+    it('records the diagnosed error in networkHistory', async () => {
+        networkHistory.length = 0;
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(healthOk());
+
+        await expect(request()).rejects.toBeDefined();
+
+        expect(networkHistory).toHaveLength(1);
+        expect(networkHistory[0].error).toContain('"kind":"blocked"');
     });
 
     it('passes real API errors through untouched', async () => {
@@ -347,7 +387,7 @@ describe('network error messages', () => {
                 url: '/stream',
                 body: JSON.stringify({}),
             }),
-        ).rejects.toThrow('unexpected response (HTTP 403) to POST /stream');
+        ).rejects.toThrow('with HTTP 403 instead of Lightdash');
     });
 });
 

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -4,13 +4,12 @@ import {
     LightdashSdkVersionHeader,
     LightdashVersionHeader,
     RequestMethod,
-    getErrorMessage,
     isApiError,
     type AnyType,
     type ApiError,
     type ApiResponse,
 } from '@lightdash/common';
-import { spanToTraceHeader, startSpan } from '@sentry/react';
+import { addBreadcrumb, spanToTraceHeader, startSpan } from '@sentry/react';
 // No fetch import on purpose: `isomorphic-fetch` captures `window.fetch` at
 // module evaluation, so a host page (SDK embeds) that patches and later
 // restores fetch strands us with a stale reference. The global `fetch`
@@ -18,6 +17,11 @@ import { spanToTraceHeader, startSpan } from '@sentry/react';
 import { EMBED_KEY, type InMemoryEmbed } from './ee/providers/Embed/types';
 import { recordServerBuildHash } from './features/buildHashHandshake/buildHashHandshake';
 import { getFromInMemoryStorage } from './utils/inMemoryStorage';
+import {
+    diagnoseTransportFailure,
+    networkFailureMessage,
+    UnexpectedResponseError,
+} from './utils/networkDiagnostics';
 
 // TODO: import from common or fix the instantiation of the request module
 const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
@@ -105,56 +109,22 @@ function finalizeUrl(url: string, embed: InMemoryEmbed | undefined): string {
     return url;
 }
 
-// A response arrived but its body is not the Lightdash API JSON envelope, e.g.
-// a proxy block page, a gateway error page, or a load balancer timeout.
-class UnexpectedResponseError extends Error {
-    readonly status: number;
-
-    constructor(status: number) {
-        super(`Unexpected response with HTTP status ${status}`);
-        this.name = 'UnexpectedResponseError';
-        this.status = status;
-    }
-}
-
 const parseJsonBody = (r: Response): Promise<AnyType> =>
     r.json().catch(() => {
         throw new UnexpectedResponseError(r.status);
     });
 
-type RequestDescriptor = { method: string; url: string };
-
-const GENERIC_NETWORK_ERROR_MESSAGE =
-    'We are currently unable to reach the Lightdash server. Please try again in a few moments.';
-
-const networkErrorMessage = (
-    err: unknown,
-    { method, url }: RequestDescriptor,
-): string => {
-    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
-        return 'You appear to be offline. Check your internet connection and try again.';
-    }
-    if (err instanceof UnexpectedResponseError) {
-        return `The Lightdash server returned an unexpected response (HTTP ${err.status}) to ${method} ${url}. A proxy, firewall or load balancer may have intercepted the request. Please try again in a few moments.`;
-    }
-    // DOMException does not extend Error in every realm, so match by name.
-    if (
-        typeof err === 'object' &&
-        err !== null &&
-        'name' in err &&
-        err.name === 'AbortError'
-    ) {
-        return `The request ${method} ${url} was cancelled before the Lightdash server responded.`;
-    }
-    // fetch() rejects with a TypeError when no response came back at all:
-    // DNS, CORS, connection reset, or a proxy dropping the request.
-    if (err instanceof TypeError) {
-        return `The request ${method} ${url} never reached the Lightdash server. Your browser, network, VPN or a corporate proxy may have blocked it. Check the Network tab in your browser developer tools, or try again from another network.`;
-    }
-    return GENERIC_NETWORK_ERROR_MESSAGE;
+type FailedRequest = {
+    method: string;
+    url: string;
+    apiPrefix: string;
+    traceId: string | null;
 };
 
-const handleError = (err: unknown, request: RequestDescriptor): ApiError => {
+const handleError = async (
+    err: unknown,
+    request: FailedRequest,
+): Promise<ApiError> => {
     if (isApiError(err) && err.error?.statusCode && err.error?.name) {
         if (
             err.error.name === 'DeactivatedAccountError' &&
@@ -168,13 +138,23 @@ const handleError = (err: unknown, request: RequestDescriptor): ApiError => {
     // Surface the real transport error (abort, CORS, DNS, connection reset)
     // instead of silently masking it as the generic message below.
     console.error('Failed to reach the Lightdash server:', err);
+    const diagnostics = await diagnoseTransportFailure({
+        ...request,
+        error: err,
+    });
+    addBreadcrumb({
+        category: 'network',
+        level: 'warning',
+        message: `Transport failure: ${diagnostics.kind}`,
+        data: diagnostics,
+    });
     return {
         status: 'error',
         error: {
             name: 'NetworkError',
             statusCode: 500,
-            message: networkErrorMessage(err, request),
-            data: { cause: getErrorMessage(err) },
+            message: networkFailureMessage(diagnostics),
+            data: diagnostics,
         },
     };
 };
@@ -285,28 +265,37 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
                     throw d;
             }
         })
-        .catch((err) => {
+        .catch(async (err) => {
+            const apiError = await handleError(err, {
+                method,
+                url,
+                apiPrefix,
+                traceId: sentryTrace?.split('-')[0] ?? null,
+            });
             networkHistory.push(
                 sensitive
                     ? {
                           method,
-                          status: err.status,
+                          status: apiError.error.statusCode,
                           url,
                           body: SENSITIVE_DATA_REDACTED,
                           error: SENSITIVE_DATA_REDACTED,
                       }
                     : {
                           method,
-                          status: err.status,
+                          status: apiError.error.statusCode,
                           url,
                           body,
-                          error: JSON.stringify(err).substring(0, 500),
+                          error: JSON.stringify(apiError.error).substring(
+                              0,
+                              1000,
+                          ),
                       },
             );
             // only store last MAX_NETWORK_HISTORY requests
             if (networkHistory.length > MAX_NETWORK_HISTORY)
                 networkHistory.shift();
-            throw handleError(err, { method, url });
+            throw apiError;
         });
 };
 
@@ -351,7 +340,13 @@ export const lightdashApiStream = ({
     }).then(async (r) => {
         if (!r.ok) {
             const error: unknown = await parseJsonBody(r).catch((e) => e);
-            throw new Error(handleError(error, { method, url }).error.message);
+            const apiError = await handleError(error, {
+                method,
+                url,
+                apiPrefix,
+                traceId: sentryTrace?.split('-')[0] ?? null,
+            });
+            throw new Error(apiError.error.message);
         }
         return r;
     });

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -4,6 +4,8 @@ import {
     LightdashSdkVersionHeader,
     LightdashVersionHeader,
     RequestMethod,
+    getErrorMessage,
+    isApiError,
     type AnyType,
     type ApiError,
     type ApiResponse,
@@ -103,10 +105,59 @@ function finalizeUrl(url: string, embed: InMemoryEmbed | undefined): string {
     return url;
 }
 
-const handleError = (err: any): ApiError => {
-    if (err.error?.statusCode && err.error?.name) {
+// A response arrived but its body is not the Lightdash API JSON envelope, e.g.
+// a proxy block page, a gateway error page, or a load balancer timeout.
+class UnexpectedResponseError extends Error {
+    readonly status: number;
+
+    constructor(status: number) {
+        super(`Unexpected response with HTTP status ${status}`);
+        this.name = 'UnexpectedResponseError';
+        this.status = status;
+    }
+}
+
+const parseJsonBody = (r: Response): Promise<AnyType> =>
+    r.json().catch(() => {
+        throw new UnexpectedResponseError(r.status);
+    });
+
+type RequestDescriptor = { method: string; url: string };
+
+const GENERIC_NETWORK_ERROR_MESSAGE =
+    'We are currently unable to reach the Lightdash server. Please try again in a few moments.';
+
+const networkErrorMessage = (
+    err: unknown,
+    { method, url }: RequestDescriptor,
+): string => {
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+        return 'You appear to be offline. Check your internet connection and try again.';
+    }
+    if (err instanceof UnexpectedResponseError) {
+        return `The Lightdash server returned an unexpected response (HTTP ${err.status}) to ${method} ${url}. A proxy, firewall or load balancer may have intercepted the request. Please try again in a few moments.`;
+    }
+    // DOMException does not extend Error in every realm, so match by name.
+    if (
+        typeof err === 'object' &&
+        err !== null &&
+        'name' in err &&
+        err.name === 'AbortError'
+    ) {
+        return `The request ${method} ${url} was cancelled before the Lightdash server responded.`;
+    }
+    // fetch() rejects with a TypeError when no response came back at all:
+    // DNS, CORS, connection reset, or a proxy dropping the request.
+    if (err instanceof TypeError) {
+        return `The request ${method} ${url} never reached the Lightdash server. Your browser, network, VPN or a corporate proxy may have blocked it. Check the Network tab in your browser developer tools, or try again from another network.`;
+    }
+    return GENERIC_NETWORK_ERROR_MESSAGE;
+};
+
+const handleError = (err: unknown, request: RequestDescriptor): ApiError => {
+    if (isApiError(err) && err.error?.statusCode && err.error?.name) {
         if (
-            err.error?.name === 'DeactivatedAccountError' &&
+            err.error.name === 'DeactivatedAccountError' &&
             window.location.pathname !== '/login'
         ) {
             // redirect to login page when account is deactivated
@@ -122,9 +173,8 @@ const handleError = (err: any): ApiError => {
         error: {
             name: 'NetworkError',
             statusCode: 500,
-            message:
-                'We are currently unable to reach the Lightdash server. Please try again in a few moments.',
-            data: err,
+            message: networkErrorMessage(err, request),
+            data: { cause: getErrorMessage(err) },
         },
     };
 };
@@ -196,14 +246,14 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         .then((r) => {
             recordServerBuildHash(r);
             if (!r.ok) {
-                return r.json().then((d) => {
+                return parseJsonBody(r).then((d) => {
                     throw d;
                 });
             }
             return r;
         })
         .then(async (r) => {
-            const js = await r.json();
+            const js = await parseJsonBody(r);
             networkHistory.push(
                 sensitive
                     ? {
@@ -256,7 +306,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
             // only store last MAX_NETWORK_HISTORY requests
             if (networkHistory.length > MAX_NETWORK_HISTORY)
                 networkHistory.shift();
-            throw handleError(err);
+            throw handleError(err, { method, url });
         });
 };
 
@@ -300,16 +350,8 @@ export const lightdashApiStream = ({
         signal,
     }).then(async (r) => {
         if (!r.ok) {
-            let error: unknown;
-            try {
-                error = await r.json();
-            } catch {
-                throw new Error(
-                    'We are currently unable to reach the Lightdash server. Please try again in a few moments.',
-                );
-            }
-
-            throw new Error(handleError(error).error.message);
+            const error: unknown = await parseJsonBody(r).catch((e) => e);
+            throw new Error(handleError(error, { method, url }).error.message);
         }
         return r;
     });

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -19,6 +19,10 @@ import MantineIcon from '../../components/common/MantineIcon';
 import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
 import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
 import { getFromInMemoryStorage } from '../../utils/inMemoryStorage';
+import {
+    formatNetworkDiagnostics,
+    isNetworkDiagnostics,
+} from '../../utils/networkDiagnostics';
 import { useGoogleLoginPopup } from '../gdrive/useGdrive';
 import useHealth from '../health/useHealth';
 import styles from './ApiErrorDisplay.module.css';
@@ -136,6 +140,59 @@ const CopyErrorIdButton = ({ value }: { value: string }) => (
     </CopyButton>
 );
 
+const openSupportModal = () =>
+    modals.open({
+        title: 'Share with Lightdash Support',
+        size: 'lg',
+        children: <SupportDrawerContent />,
+        yOffset: 100,
+        zIndex: 1000,
+    });
+
+// A request that failed before Lightdash answered. The message already says
+// what was diagnosed; the buttons hand the user the evidence to act on it.
+const NetworkFailureMessage = ({
+    apiError,
+    showSupportButton,
+}: {
+    apiError: ApiErrorDetail;
+    showSupportButton: boolean;
+}) => {
+    const diagnostics = isNetworkDiagnostics(apiError.data)
+        ? formatNetworkDiagnostics(apiError.data)
+        : apiError.message;
+    return (
+        <Stack gap="xxs" align="start">
+            <Text mb={0} fz="xs">
+                {apiError.message}
+            </Text>
+            <Group gap="xs">
+                <CopyButton value={diagnostics}>
+                    {({ copied, copy }) => (
+                        <Button
+                            size="compact-xs"
+                            variant="default"
+                            leftSection={
+                                <MantineIcon
+                                    icon={copied ? IconCheck : IconCopy}
+                                />
+                            }
+                            onClick={copy}
+                        >
+                            {copied ? 'Copied' : 'Copy diagnostics'}
+                        </Button>
+                    )}
+                </CopyButton>
+                {showSupportButton && (
+                    <Button size="compact-xs" onClick={openSupportModal}>
+                        Notify support
+                    </Button>
+                )}
+            </Group>
+        </Stack>
+    );
+};
+
 const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
     const { mutate: openLoginPopup } = useGoogleLoginPopup('gdrive');
 
@@ -167,6 +224,13 @@ const ApiErrorDisplayStatic = ({
                 <Text mb={0} fz="xs">
                     {apiError.message}
                 </Text>
+            );
+        case 'NetworkError':
+            return (
+                <NetworkFailureMessage
+                    apiError={apiError}
+                    showSupportButton={false}
+                />
             );
         default:
             break;
@@ -227,9 +291,19 @@ const ApiErrorDisplayWithHealth = ({
         health.data?.siteUrl === 'https://eu1.lightdash.cloud'
     );
 
+    const showSupportButton =
+        (isCloudCustomer && isNotMultiTenantCloud) || isDevelopment;
+
     switch (apiError.name) {
         case 'GoogleSheetsScopeError':
             return <GoogleSheetsReauthMessage message={apiError.message} />;
+        case 'NetworkError':
+            return (
+                <NetworkFailureMessage
+                    apiError={apiError}
+                    showSupportButton={showSupportButton}
+                />
+            );
         case 'SnowflakeTokenError':
             return (
                 <>
@@ -264,8 +338,6 @@ const ApiErrorDisplayWithHealth = ({
         default:
             break;
     }
-    const showSupportButton =
-        (isCloudCustomer && isNotMultiTenantCloud) || isDevelopment;
 
     if (apiError.sentryEventId || apiError.sentryTraceId) {
         // Cloud/dev: show button only, no IDs
@@ -278,18 +350,7 @@ const ApiErrorDisplayWithHealth = ({
                         defaultExpanded={defaultExpanded}
                     />
                     <Group gap="xs">
-                        <Button
-                            size="compact-xs"
-                            onClick={() => {
-                                modals.open({
-                                    title: 'Share with Lightdash Support',
-                                    size: 'lg',
-                                    children: <SupportDrawerContent />,
-                                    yOffset: 100,
-                                    zIndex: 1000,
-                                });
-                            }}
-                        >
+                        <Button size="compact-xs" onClick={openSupportModal}>
                             Notify support
                         </Button>
                         <CopyErrorIdButton

--- a/packages/frontend/src/utils/networkDiagnostics.test.ts
+++ b/packages/frontend/src/utils/networkDiagnostics.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    diagnoseTransportFailure,
+    formatNetworkDiagnostics,
+    isNetworkDiagnostics,
+    networkFailureMessage,
+    UnexpectedResponseError,
+} from './networkDiagnostics';
+
+const request = {
+    apiPrefix: 'http://test.lightdash/api/v1',
+    method: 'PATCH',
+    url: '/projects/abc',
+    traceId: 'trace-1',
+};
+
+const healthOk = () =>
+    new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+
+describe('diagnoseTransportFailure', () => {
+    let previousFetch: typeof fetch;
+
+    beforeEach(() => {
+        previousFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = previousFetch;
+        vi.restoreAllMocks();
+    });
+
+    it('reports blocked when fetch rejected but the server answers a probe', async () => {
+        const probe = vi.fn().mockResolvedValue(healthOk());
+        globalThis.fetch = probe;
+
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new TypeError('Failed to fetch'),
+        });
+
+        expect(d.kind).toBe('blocked');
+        expect(d.probe).toMatchObject({ ok: true, status: 200 });
+        expect(d.cause).toBe('Failed to fetch');
+        expect(d.path).toBe('http://test.lightdash/api/v1/projects/abc');
+        expect(probe).toHaveBeenCalledTimes(1);
+        expect(String(probe.mock.calls[0][0])).toContain('/health');
+    });
+
+    it('reports unreachable when the probe fails too', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch'));
+
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new TypeError('Failed to fetch'),
+        });
+
+        expect(d.kind).toBe('unreachable');
+        expect(d.probe).toMatchObject({ ok: false, status: null });
+    });
+
+    it('reports offline without probing', async () => {
+        vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+        const probe = vi.fn();
+        globalThis.fetch = probe;
+
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new TypeError('Failed to fetch'),
+        });
+
+        expect(d.kind).toBe('offline');
+        expect(d.online).toBe(false);
+        expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('reports intercepted with the status of the foreign response', async () => {
+        const probe = vi.fn();
+        globalThis.fetch = probe;
+
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new UnexpectedResponseError(502),
+        });
+
+        expect(d.kind).toBe('intercepted');
+        expect(d.responseStatus).toBe(502);
+        expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('reports cancelled for aborted requests', async () => {
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new DOMException('Aborted', 'AbortError'),
+        });
+
+        expect(d.kind).toBe('cancelled');
+    });
+});
+
+describe('networkFailureMessage', () => {
+    it('names the request and the likely culprit per kind', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(healthOk());
+        const blocked = await diagnoseTransportFailure({
+            ...request,
+            error: new TypeError('Failed to fetch'),
+        });
+        expect(networkFailureMessage(blocked)).toContain(
+            'Lightdash is reachable, but PATCH http://test.lightdash/api/v1/projects/abc was blocked',
+        );
+
+        const intercepted = await diagnoseTransportFailure({
+            ...request,
+            error: new UnexpectedResponseError(403),
+        });
+        expect(networkFailureMessage(intercepted)).toContain('HTTP 403');
+    });
+});
+
+describe('formatNetworkDiagnostics', () => {
+    it('produces a pasteable report', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(healthOk());
+        const d = await diagnoseTransportFailure({
+            ...request,
+            error: new TypeError('Failed to fetch'),
+        });
+
+        const text = formatNetworkDiagnostics(d);
+
+        expect(text).toContain(
+            'Request: PATCH http://test.lightdash/api/v1/projects/abc',
+        );
+        expect(text).toContain(
+            'Outcome: request never reached the server, server is reachable',
+        );
+        expect(text).toContain('Lightdash reachable: yes (GET /health 200');
+        expect(text).toContain('Error: Failed to fetch');
+        expect(text).toContain('Trace ID: trace-1');
+        expect(isNetworkDiagnostics(d)).toBe(true);
+        expect(isNetworkDiagnostics({ message: 'nope' })).toBe(false);
+    });
+});

--- a/packages/frontend/src/utils/networkDiagnostics.ts
+++ b/packages/frontend/src/utils/networkDiagnostics.ts
@@ -1,0 +1,185 @@
+import { assertUnreachable, getErrorMessage } from '@lightdash/common';
+
+// A response arrived but its body is not the Lightdash API JSON envelope, e.g.
+// a proxy block page, a gateway error page, or a load balancer timeout.
+export class UnexpectedResponseError extends Error {
+    readonly status: number;
+
+    constructor(status: number) {
+        super(`Unexpected response with HTTP status ${status}`);
+        this.name = 'UnexpectedResponseError';
+        this.status = status;
+    }
+}
+
+export type TransportFailureKind =
+    | 'offline'
+    | 'blocked'
+    | 'unreachable'
+    | 'intercepted'
+    | 'cancelled';
+
+export type ServerProbe = {
+    ok: boolean;
+    status: number | null;
+    durationMs: number;
+};
+
+export type NetworkDiagnostics = {
+    kind: TransportFailureKind;
+    at: string;
+    method: string;
+    path: string;
+    responseStatus: number | null;
+    online: boolean;
+    probe: ServerProbe | null;
+    cause: string;
+    traceId: string | null;
+    appVersion: string;
+    userAgent: string;
+};
+
+const PROBE_TIMEOUT_MS = 4000;
+
+const isAbortError = (err: unknown): boolean =>
+    typeof err === 'object' &&
+    err !== null &&
+    'name' in err &&
+    err.name === 'AbortError';
+
+const isOnline = (): boolean =>
+    typeof navigator === 'undefined' || navigator.onLine !== false;
+
+// A cheap GET to the health endpoint. If it succeeds right after another
+// request failed, the failure was specific to that request, not the network.
+const probeServer = async (apiPrefix: string): Promise<ServerProbe> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const started = Date.now();
+    try {
+        const response = await fetch(
+            `${apiPrefix}/health?skipMigrationCheck=true`,
+            { method: 'GET', cache: 'no-store', signal: controller.signal },
+        );
+        return {
+            ok: response.ok,
+            status: response.status,
+            durationMs: Date.now() - started,
+        };
+    } catch {
+        return { ok: false, status: null, durationMs: Date.now() - started };
+    } finally {
+        clearTimeout(timer);
+    }
+};
+
+export const diagnoseTransportFailure = async ({
+    apiPrefix,
+    method,
+    url,
+    error,
+    traceId,
+}: {
+    apiPrefix: string;
+    method: string;
+    url: string;
+    error: unknown;
+    traceId: string | null;
+}): Promise<NetworkDiagnostics> => {
+    const base = {
+        at: new Date().toISOString(),
+        method,
+        path: `${apiPrefix}${url}`,
+        online: isOnline(),
+        cause: getErrorMessage(error),
+        traceId,
+        appVersion: __APP_VERSION__,
+        userAgent:
+            typeof navigator === 'undefined' ? 'unknown' : navigator.userAgent,
+    };
+
+    if (error instanceof UnexpectedResponseError) {
+        return {
+            ...base,
+            kind: 'intercepted',
+            responseStatus: error.status,
+            probe: null,
+        };
+    }
+    if (isAbortError(error)) {
+        return {
+            ...base,
+            kind: 'cancelled',
+            responseStatus: null,
+            probe: null,
+        };
+    }
+    if (!base.online) {
+        return { ...base, kind: 'offline', responseStatus: null, probe: null };
+    }
+    const probe = await probeServer(apiPrefix);
+    return {
+        ...base,
+        kind: probe.ok ? 'blocked' : 'unreachable',
+        responseStatus: null,
+        probe,
+    };
+};
+
+export const networkFailureMessage = (d: NetworkDiagnostics): string => {
+    const request = `${d.method} ${d.path}`;
+    switch (d.kind) {
+        case 'offline':
+            return 'You appear to be offline. Check your internet connection and try again.';
+        case 'blocked':
+            return `Lightdash is reachable, but ${request} was blocked before it arrived. A corporate proxy, VPN or security software on your network most likely intercepted it. Try again from another network, or copy the diagnostics for your IT team.`;
+        case 'unreachable':
+            return `Lightdash cannot be reached from your network right now (${request}). Check your connection or VPN and try again.`;
+        case 'intercepted':
+            return `Something between you and Lightdash answered ${request} with HTTP ${d.responseStatus} instead of Lightdash. A proxy, firewall or load balancer intercepted it. Try again in a few moments, or copy the diagnostics for your IT team.`;
+        case 'cancelled':
+            return `${request} was cancelled before Lightdash responded.`;
+        default:
+            return assertUnreachable(d.kind, 'Unknown transport failure');
+    }
+};
+
+const outcomeLabel: Record<TransportFailureKind, string> = {
+    offline: 'browser is offline',
+    blocked: 'request never reached the server, server is reachable',
+    unreachable: 'request never reached the server, server is not reachable',
+    intercepted: 'a non-Lightdash response was returned',
+    cancelled: 'request was cancelled by the browser',
+};
+
+export const formatNetworkDiagnostics = (d: NetworkDiagnostics): string => {
+    const probe = d.probe
+        ? `${d.probe.ok ? 'yes' : 'no'} (GET /health ${
+              d.probe.status ?? 'no response'
+          } in ${d.probe.durationMs}ms)`
+        : 'not checked';
+    return [
+        'Lightdash request diagnostics',
+        `Time: ${d.at}`,
+        `Request: ${d.method} ${d.path}`,
+        `Outcome: ${outcomeLabel[d.kind]}`,
+        `Response status: ${d.responseStatus ?? 'none'}`,
+        `Lightdash reachable: ${probe}`,
+        `Browser online: ${d.online ? 'yes' : 'no'}`,
+        `Error: ${d.cause}`,
+        `Trace ID: ${d.traceId ?? 'n/a'}`,
+        `App version: ${d.appVersion}`,
+        `Browser: ${d.userAgent}`,
+    ].join('\n');
+};
+
+export const isNetworkDiagnostics = (
+    data: unknown,
+): data is NetworkDiagnostics =>
+    typeof data === 'object' &&
+    data !== null &&
+    'kind' in data &&
+    typeof data.kind === 'string' &&
+    'at' in data &&
+    'method' in data &&
+    'path' in data;


### PR DESCRIPTION
## Problem

Every request that fails outside the API envelope showed the same toast: "We are currently unable to reach the Lightdash server. Please try again in a few moments." That one string covered four different situations: the browser is offline, `fetch()` rejected before any response (DNS, CORS, connection reset, a VPN or corporate proxy dropping the request), a response arrived but is not our JSON (a proxy block page, a gateway error, a load balancer timeout), or the request was cancelled.

A customer hit the second case this week saving a Redshift connection with an SSH tunnel. The screenshot showed the generic toast, the backend had no matching request, and it took load balancer logs to establish that the PATCH never left their network. Meanwhile a health poll from the same browser, in the same second, had reached us fine. The app had everything it needed to say "this request was blocked, the server is reachable", and said nothing.

## Change

**Diagnose instead of guess** (`src/utils/networkDiagnostics.ts`). When a request fails at the transport level the client immediately probes `GET /api/v1/health` with a 4 second timeout. The outcome picks one of five kinds, each with its own message that names the method and path:

| Kind | When | Toast message |
|---|---|---|
| `offline` | `navigator.onLine === false` | You appear to be offline. Check your internet connection and try again. |
| `blocked` | fetch rejected, probe succeeded | Lightdash is reachable, but PATCH …/projects/… was blocked before it arrived. A corporate proxy, VPN or security software on your network most likely intercepted it. Try again from another network, or copy the diagnostics for your IT team. |
| `unreachable` | fetch rejected, probe failed | Lightdash cannot be reached from your network right now (PATCH …). Check your connection or VPN and try again. |
| `intercepted` | response body is not the API envelope | Something between you and Lightdash answered PATCH … with HTTP 502 instead of Lightdash. A proxy, firewall or load balancer intercepted it. Try again in a few moments, or copy the diagnostics for your IT team. |
| `cancelled` | `AbortError` | PATCH … was cancelled before Lightdash responded. |

No probe runs for offline, intercepted or cancelled; those are already conclusive.

**Hand the user the evidence** (`ApiErrorDisplay.tsx`). A `NetworkError` toast now renders the message plus a **Copy diagnostics** button, and **Notify support** on cloud and dev. The copied report is plain text a user can paste to their IT team or to us:

```
Lightdash request diagnostics
Time: 2026-09-08T15:23:04.123Z
Request: PATCH /api/v1/projects/f6a1ef8f-…
Outcome: request never reached the server, server is reachable
Response status: none
Lightdash reachable: yes (GET /health 200 in 118ms)
Browser online: yes
Error: Failed to fetch
Trace ID: f6be28a5a05f4791939063aeb0839f94
App version: 2.163.2
Browser: Mozilla/5.0 (Windows NT 10.0; …) Chrome/152.0.0.0
```

**Make it reach support without the user doing anything.** The same diagnostics object is `error.data` on the `ApiError`, is what the network history entry now records (the support drawer already sends that history), and is added as a Sentry breadcrumb so the session replay carries it.

Other details:

- `lightdashApiStream` shares the same diagnosis instead of its own copy of the generic string.
- `handleError` takes `unknown` and narrows with `isApiError` instead of `any`.
- The network history entry stores `error.error` with a 1000 character cap (was the whole envelope at 500, which truncated before the diagnostics).

## Regression analysis

- `error.name` stays `NetworkError` and `statusCode` stays 500 for every kind, so the global retry policy in `createQueryClient.ts` and `useQueryRetry.ts` is unchanged. Their tests only assert on the name.
- Real API errors (`{ status: 'error', error: { name, statusCode } }`) pass through untouched, covered by a new test. The `DeactivatedAccountError` redirect is unchanged.
- `handleError` is now async. Both call sites already sat inside promise chains, so the only observable difference is that a transport failure rejects up to 4 seconds later while the probe runs. Successful requests and API errors are not delayed.
- The probe uses raw `fetch`, not `lightdashApi`, so it cannot recurse. It carries no embed JWT header; the health endpoint is public.
- `RenderedSql.tsx` renders `error.data` entries generically. It previously got the raw `Error` (no enumerable keys, empty alert) and now gets the diagnostics fields, which is more useful, not a break.
- The embed hooks test and the Toaster story hardcode the old generic string in their own mocks; they do not import it, so they are unaffected.
- The toast is app chrome for logged-in users, not the dashboard viewer surface, so it does not go through the `uiStrings` registry.

## Tests

- `src/utils/networkDiagnostics.test.ts`: blocked, unreachable, offline (no probe), intercepted (no probe), cancelled, message content, report format, type guard.
- `src/api.test.ts`: the same five kinds end to end through `lightdashApi`, network history content, API error passthrough, and the stream path.

Not verified in a browser. The message goes through the existing toast clamp and the buttons reuse the patterns already in `ApiErrorDisplay`.

## Follow-up (not in this PR)

For projects whose dbt connection is CLI, the button reads "Save and test" but the backend marks the job done without opening the SSH tunnel or testing the warehouse (`ProjectService.updateAndScheduleAsyncWork`, the `DbtProjectType.NONE` branch). A tunnel misconfiguration only surfaces on the first query. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7mz4QntZ4oavrv9MNoVLE
