### PR TITLE
fix(dashboards): fire auto-refresh on the chosen interval instead of continuously

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -1,5 +1,4 @@
 import { ActionIcon, Menu, Text, Tooltip } from '@mantine/core';
-import { useInterval } from '@mantine/hooks';
 import { IconCheck, IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import {
     memo,
@@ -9,6 +8,7 @@ import {
     useState,
     type FC,
 } from 'react';
+import { useInterval } from 'react-use';
 import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
 import useToaster from '../../../hooks/toaster/useToaster';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
@@ -90,9 +90,12 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
             invalidateDashboardResultsQueries,
         ]);
 
-        const interval = useInterval(
-            () => invalidateAndSetRefreshTime(),
-            refreshInterval ? refreshInterval * 1000 * 60 : 0,
+        // Keyed on the interval only; a paused (null) delay stops the timer.
+        useInterval(
+            () => {
+                void invalidateAndSetRefreshTime();
+            },
+            refreshInterval === undefined ? null : refreshInterval * 60 * 1000,
         );
 
         useEffect(() => {
@@ -102,16 +105,9 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
             };
         }, [hasInterval, onIntervalChange]);
 
-        useEffect(() => {
-            if (refreshInterval !== undefined) {
-                interval.start();
-            }
-            return interval.stop;
-        }, [interval, refreshInterval]);
-
         return (
             <ActionIcon.Group>
-                {interval.active && refreshInterval ? (
+                {refreshInterval !== undefined ? (
                     <ActionIcon.GroupSection
                         variant="default"
                         size="md"


### PR DESCRIPTION
Turning on dashboard auto-refresh made the dashboard refresh continuously instead of once per chosen interval, flooding the API with roughly a thousand requests in ten seconds until the page crashed with "unable to reach the Lightdash server". The `@mantine/hooks` bump to 8.3.18 in 1.105.0 changed `useInterval` to capture the interval from the component's first render, and the refresh button passes 0 until an interval is chosen, so every instance since then has been affected and each open tab re-ran every tile against the warehouse with the cache bypassed.

Closes: #28873
