### PR TITLE
fix(training): export walkthrough follows the chooser Drive-enabled instances show

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ResultsCard.tsx
@@ -245,7 +245,10 @@ const ResultsCard: FC = memo(() => {
                                         data-tour-title="Download a chart's results"
                                         data-tour-interactive="true"
                                         data-tour-via='[data-tour-nav="browse"] >> [data-tour-nav="all-charts"] >> [data-tour-anchor="chart-row"][data-tour-value="Orders over time"] >> [data-tour-anchor="results-heading"]'
-                                        data-tour-then='[data-tour-anchor="export-download"]'
+                                        // With Google Drive configured the
+                                        // popover opens on a chooser first;
+                                        // the `?` hop is taken only there.
+                                        data-tour-then='[data-tour-anchor="export-choose-download"]? >> [data-tour-anchor="export-download"]'
                                         data-tour-docs="explore/share-charts.mdx#download-results-or-a-chart-image:p2:1"
                                     >
                                         <MantineIcon icon={IconShare2} />

--- a/packages/frontend/src/components/ExportSelector/index.tsx
+++ b/packages/frontend/src/components/ExportSelector/index.tsx
@@ -86,6 +86,10 @@ const ExportSelector: FC<
                         leftSection={<MantineIcon icon={IconFileTypeCsv} />}
                         disabled={isExportingGoogleSheets}
                         data-testid="chart-export-csv-button"
+                        // Walkthrough detour (manage:ExportCsv): the way to
+                        // the export form when this chooser is shown.
+                        data-tour-anchor="export-choose-download"
+                        data-tour-hint="Click Download data"
                     >
                         Download data
                     </Button>

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -126,14 +126,23 @@ describe('GuidedTour', () => {
 
             expect(screen.queryByText('Step two')).not.toBeInTheDocument();
 
+            // Not straight away: a control that renders a beat late must not
+            // flash a centred card first.
             await act(async () => {
-                await vi.advanceTimersByTimeAsync(16_000);
+                await vi.advanceTimersByTimeAsync(3_000);
             });
+            expect(screen.queryByText('Step two')).not.toBeInTheDocument();
 
+            // Well before the 15 s path patience: the learner needs to see
+            // the tour is alive long before that.
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(2_000);
+            });
             expect(screen.getByText('Step two')).toBeInTheDocument();
             expect(
                 screen.getByRole('button', { name: 'Skip' }),
             ).toBeInTheDocument();
+            expect(screen.getByText(/Still waiting/)).toBeInTheDocument();
         } finally {
             vi.useRealTimers();
         }

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import { GuidedTour, type GuidedTourStep } from './GuidedTour';
 
@@ -97,5 +97,132 @@ describe('GuidedTour', () => {
         await user.click(screen.getByRole('button', { name: 'Next' }));
         await user.click(screen.getByRole('button', { name: 'Got it' }));
         expect(calls).toEqual(['finish', 'close']);
+    });
+
+    // A control the instance never shows (a screen behind a config the tour
+    // did not know about) used to leave the page blocked with no card and no
+    // Skip: the only way out was a new tab.
+    it('brings the card back when the next control never appears', async () => {
+        vi.useFakeTimers();
+        try {
+            renderWithProviders(
+                <GuidedTour
+                    steps={[
+                        { target: null, title: 'Step one', body: '' },
+                        {
+                            target: '[data-missing="true"]',
+                            title: 'Step two',
+                            body: '',
+                            interactive: true,
+                            advanceOnTargetClick: true,
+                        },
+                    ]}
+                    opened
+                    onClose={vi.fn()}
+                    initialStepIndex={1}
+                    initialBeacon={{ x: 10, y: 10 }}
+                />,
+            );
+
+            expect(screen.queryByText('Step two')).not.toBeInTheDocument();
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(16_000);
+            });
+
+            expect(screen.getByText('Step two')).toBeInTheDocument();
+            expect(
+                screen.getByRole('button', { name: 'Skip' }),
+            ).toBeInTheDocument();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // A step's target may sit behind a control only some instances show (a
+    // chooser before the export form). While that control is on the page and
+    // the target is not, the ring and the title move to it straight away;
+    // once the target appears, the step is itself again.
+    describe('detour', () => {
+        const detourSteps: GuidedTourStep[] = [
+            {
+                target: '[data-x="download"]',
+                title: 'Click Download',
+                body: '',
+                interactive: true,
+                advanceOnTargetClick: true,
+                detour: [
+                    {
+                        target: '[data-x="chooser"]',
+                        title: 'Click Download data',
+                    },
+                ],
+            },
+        ];
+        // jsdom has no layout: the tour's viewport checks need these to exist.
+        beforeEach(() => {
+            document.elementsFromPoint = () => [];
+            Element.prototype.scrollIntoView = () => {};
+        });
+        const mount = (html: string) => {
+            const host = document.createElement('div');
+            host.innerHTML = html;
+            document.body.appendChild(host);
+            return host;
+        };
+
+        it('spotlights the detour control while the target is missing', async () => {
+            const host = mount(
+                '<button data-x="chooser">Download data</button>',
+            );
+            try {
+                renderWithProviders(
+                    <GuidedTour steps={detourSteps} opened onClose={vi.fn()} />,
+                );
+                await waitFor(() =>
+                    expect(
+                        screen.getByText('Click Download data'),
+                    ).toBeVisible(),
+                );
+                expect(
+                    host.querySelector('[data-x="chooser"]'),
+                ).toHaveAttribute('data-tour-active');
+
+                host.innerHTML = '<button data-x="download">Download</button>';
+                await waitFor(() =>
+                    expect(screen.getByText('Click Download')).toBeVisible(),
+                );
+                expect(
+                    screen.queryByText('Click Download data'),
+                ).not.toBeInTheDocument();
+                expect(
+                    host.querySelector('[data-x="download"]'),
+                ).toHaveAttribute('data-tour-active');
+            } finally {
+                host.remove();
+            }
+        });
+
+        it('ignores the detour when the target is already there', async () => {
+            const host = mount(
+                '<button data-x="chooser">Download data</button><button data-x="download">Download</button>',
+            );
+            try {
+                renderWithProviders(
+                    <GuidedTour steps={detourSteps} opened onClose={vi.fn()} />,
+                );
+                await waitFor(() =>
+                    expect(
+                        host.querySelector('[data-x="download"]'),
+                    ).toHaveAttribute('data-tour-active'),
+                );
+                expect(screen.getByText('Click Download')).toBeVisible();
+                expect(
+                    screen.queryByText('Click Download data'),
+                ).not.toBeInTheDocument();
+            } finally {
+                host.remove();
+            }
+        });
     });
 });

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -49,6 +49,13 @@ export type GuidedTourStep = {
      */
     via?: string[];
     /**
+     * Controls that lead to `target` on the instances that show them (a
+     * chooser some configurations put before a form). While one is on the
+     * page and `target` is not, the ring and the card's title move to it at
+     * once; nothing waits, since the product says this is the way through.
+     */
+    detour?: { target: string; title: string }[];
+    /**
      * Selector of the page's own "still working" surface for this step (a
      * streaming reply, a running query). While it is on the page the step is
      * not finished: the ring follows it, the card shows the product's own
@@ -233,54 +240,76 @@ const useTargetRect = (
     return rect;
 };
 
+type Resolved = {
+    selector: string | null;
+    /** Set while the ring sits on a detour control: that control's title. */
+    detourTitle: string | null;
+};
+
 /**
  * Which selector to spotlight right now: the step's target when it is on the
- * page, else the deepest `via` control that is (later controls only exist
- * once earlier ones were clicked, and earlier ones such as a nav button stay
- * on the page), else nothing.
+ * page, else a `detour` control that is (the way to the target on this
+ * instance), else the deepest `via` control that is (later controls only
+ * exist once earlier ones were clicked, and earlier ones such as a nav
+ * button stay on the page), else nothing.
  */
 const useResolvedSelector = (
     step: GuidedTourStep | undefined,
     active: boolean,
-): string | null => {
+): Resolved => {
     const target = active ? (step?.target ?? null) : null;
     const via = active ? step?.via : undefined;
-    const [resolved, setResolved] = useState<string | null>(target);
+    const detour = active ? step?.detour : undefined;
+    const [resolved, setResolved] = useState<Resolved>({
+        selector: target,
+        detourTitle: null,
+    });
 
     useEffect(() => {
-        if (!target || !via || via.length === 0) {
-            setResolved(target);
+        const hasVia = via !== undefined && via.length > 0;
+        const hasDetour = detour !== undefined && detour.length > 0;
+        if (!target || (!hasVia && !hasDetour)) {
+            setResolved({ selector: target, detourTitle: null });
             return undefined;
         }
         // Fallbacks are for a menu the learner closed by accident, not for a
         // control that is still loading after their click (a page, a list the
         // server fills in): until the target has been seen once, wait for it
         // as long as patience allows; once seen and gone, give it a moment
-        // before dropping back to an earlier control on the path.
+        // before dropping back to an earlier control on the path. A detour
+        // is different: the product says that control leads here, so it is
+        // taken the moment it is on the page.
         const since = Date.now();
         let seen = false;
         const tick = () => {
             if (document.querySelector(target)) {
                 seen = true;
-                setResolved(target);
+                setResolved({ selector: target, detourTitle: null });
+                return;
+            }
+            const hop = detour?.find((d) => document.querySelector(d.target));
+            if (hop) {
+                setResolved({ selector: hop.target, detourTitle: hop.title });
                 return;
             }
             const patience = seen ? FALLBACK_GRACE_MS : TARGET_PATIENCE_MS;
             if (Date.now() - since < patience) {
-                setResolved(null);
+                setResolved({ selector: null, detourTitle: null });
                 return;
             }
-            setResolved(
-                [...via]
-                    .reverse()
-                    .find((selector) => document.querySelector(selector)) ??
+            setResolved({
+                selector:
+                    [...(via ?? [])]
+                        .reverse()
+                        .find((selector) => document.querySelector(selector)) ??
                     null,
-            );
+                detourTitle: null,
+            });
         };
         tick();
         const poll = window.setInterval(tick, 150);
         return () => window.clearInterval(poll);
-    }, [target, via]);
+    }, [target, via, detour]);
 
     return resolved;
 };
@@ -489,7 +518,10 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     // Each step resolves its own target when reached (rows may load late), so a
     // step with a not-yet-rendered target just shows a centered card until it
     // appears, rather than being dropped.
-    const resolvedSelector = useResolvedSelector(step, opened);
+    const { selector: resolvedSelector, detourTitle } = useResolvedSelector(
+        step,
+        opened,
+    );
     // While the page is still working on this step, the ring sits on that
     // work rather than on the finished surface.
     const { busy, status } = useBusy(step?.busy, opened);
@@ -643,6 +675,20 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             window.removeEventListener('mousemove', follow, true);
             if (frame !== null) window.cancelAnimationFrame(frame);
         };
+    }, [waiting]);
+
+    // A control that never arrives (a screen this instance does not have)
+    // would otherwise hide the card for good, leaving the page blocked with
+    // no way out but a new tab. Once patience runs out the card comes back,
+    // centred, so Skip is always within reach; the beacon keeps waiting and
+    // the card still opens at the control if it turns up.
+    useEffect(() => {
+        if (!waiting) return undefined;
+        const timeout = window.setTimeout(() => {
+            setCardRect(null);
+            setCardPhase('shown');
+        }, TARGET_PATIENCE_MS);
+        return () => window.clearTimeout(timeout);
     }, [waiting]);
 
     // When the work finishes the ring travels to the finished surface.
@@ -803,6 +849,11 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     // What the card shows: the current step, except while it is collapsing
     // with the previous step's text.
     const shownStep = steps[shownStepIndex] ?? step;
+    // On a detour the card names the control it points at, not the target.
+    const shownTitle =
+        detourTitle !== null && shownStepIndex === stepIndex
+            ? detourTitle
+            : shownStep.title;
     const shownIsLast = shownStepIndex === steps.length - 1;
     // The highlighted control is clickable while it is on the way to the
     // target (a `via` control) or when clicking the target is what advances
@@ -859,11 +910,11 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                             busy && status !== '' ? status : undefined
                         }
                     >
-                        {busy && status !== '' ? status : shownStep.title}
+                        {busy && status !== '' ? status : shownTitle}
                     </Text>
                     {busy && status !== '' && (
                         <Text fz="xs" c="dimmed">
-                            {shownStep.title}
+                            {shownTitle}
                         </Text>
                     )}
                     {shownStep.body !== '' && (

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -122,6 +122,13 @@ const CARD_EXPAND_MS = 280;
 const FALLBACK_GRACE_MS = 1500;
 /** How long a step waits for a control that has not appeared yet. */
 const TARGET_PATIENCE_MS = 15000;
+/**
+ * How long the beacon waits alone before the card comes back. Shorter than
+ * the patience above on purpose: a card returning early costs nothing (it
+ * re-anchors the moment the control appears), while a beacon alone for
+ * long reads as a page that has died.
+ */
+const CARD_RETURN_MS = 4000;
 /** A typed-input step counts as done after this many characters and a pause. */
 const MIN_INPUT_CHARS = 3;
 const INPUT_SETTLE_MS = 900;
@@ -679,15 +686,21 @@ export const GuidedTour: FC<GuidedTourProps> = ({
 
     // A control that never arrives (a screen this instance does not have)
     // would otherwise hide the card for good, leaving the page blocked with
-    // no way out but a new tab. Once patience runs out the card comes back,
-    // centred, so Skip is always within reach; the beacon keeps waiting and
-    // the card still opens at the control if it turns up.
+    // no way out but a new tab. After a short wait the card comes back,
+    // centred, saying it is still waiting, so Skip is always within reach;
+    // the beacon keeps waiting and the card still opens at the control if
+    // it turns up.
+    const [cardReturned, setCardReturned] = useState(false);
     useEffect(() => {
-        if (!waiting) return undefined;
+        if (!waiting) {
+            setCardReturned(false);
+            return undefined;
+        }
         const timeout = window.setTimeout(() => {
             setCardRect(null);
             setCardPhase('shown');
-        }, TARGET_PATIENCE_MS);
+            setCardReturned(true);
+        }, CARD_RETURN_MS);
         return () => window.clearTimeout(timeout);
     }, [waiting]);
 
@@ -921,6 +934,12 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                         <Box fz="sm" c="dimmed">
                             {shownStep.body}
                         </Box>
+                    )}
+                    {cardReturned && waiting && (
+                        <Text fz="xs" c="dimmed" data-tour-card-waiting>
+                            Still waiting for the page to show the next control.
+                            You can skip if it does not appear.
+                        </Text>
                     )}
                 </Stack>
                 <Group justify="space-between" align="center">

--- a/packages/frontend/src/features/scopeTours/generated.ts
+++ b/packages/frontend/src/features/scopeTours/generated.ts
@@ -12,6 +12,12 @@ export type ScopeTourStepDefinition = {
     advanceOnTargetClick: boolean;
     advanceOnTargetInput: boolean;
     via: string[];
+    /**
+     * Optional hops on the way to `target`: controls that lead to it on the
+     * instances that show them. Spotlit, with their own title, while one is
+     * on the page and the target is not.
+     */
+    detour?: { target: string; title: string }[];
     /** The page's "still working" surface; the step waits for it to go. */
     busy?: string;
     /** For a typed step: what the card offers to fill in with one click. */
@@ -1132,6 +1138,12 @@ export const SCOPE_TOURS: Record<string, ScopeTourDefinition> = {
                 advanceOnTargetClick: true,
                 advanceOnTargetInput: false,
                 via: [],
+                detour: [
+                    {
+                        target: '[data-tour-anchor="export-choose-download"]',
+                        title: 'Click Download data',
+                    },
+                ],
             },
             {
                 target: '[data-tour-scope="manage:ExportCsv"][data-tour-step="1"]',

--- a/scripts/scope-tours/check.ts
+++ b/scripts/scope-tours/check.ts
@@ -31,6 +31,7 @@ import {
     findMarkers,
     frontendSrc,
     listTsx,
+    parsePath,
     PATH_SELECTOR,
     root,
     type Marker,
@@ -243,9 +244,15 @@ export const checkTours = (
                 ['return', marker.return],
             ] as const) {
                 if (!value || value === 'none') continue;
-                for (const selector of value
-                    .split(' >> ')
-                    .map((v) => v.trim())) {
+                const hops = parsePath(value);
+                if (attribute !== 'via' && hops[hops.length - 1]?.optional) {
+                    error(
+                        marker.file,
+                        `${scope}: data-tour-${attribute} ends on an optional hop (?); an optional hop needs a control after it to detour to`,
+                        marker.line,
+                    );
+                }
+                for (const { selector } of hops) {
                     const at = locateAnchor(selector, files);
                     if (!at) {
                         error(

--- a/scripts/scope-tours/generate.ts
+++ b/scripts/scope-tours/generate.ts
@@ -63,6 +63,10 @@
  *   anchor (a tree node by label); the hint's {value} becomes y. An anchor
  *   used both plainly and by name carries data-tour-hint-named for the
  *   named case.
+ *   A hop suffixed `?` is optional: a control only some instances show on
+ *   the way to the next one (a chooser some configurations put before a
+ *   form). It gets no step; the next control's step spotlights it, with its
+ *   own hint, while it is on the page and the next control is not.
  *   data-tour-via='<sel> >> <sel> >> ...'  the click path to the marked control
  *                                          from anywhere in the project (nav
  *                                          buttons, menu items, triggers). Each
@@ -110,6 +114,12 @@ export type ScopeTourStepDefinition = {
     advanceOnTargetClick: boolean;
     advanceOnTargetInput: boolean;
     via: string[];
+    /**
+     * Optional hops on the way to \`target\`: controls that lead to it on the
+     * instances that show them. Spotlit, with their own title, while one is
+     * on the page and the target is not.
+     */
+    detour?: { target: string; title: string }[];
     /** The page's "still working" surface; the step waits for it to go. */
     busy?: string;
     /** For a typed step: what the card offers to fill in with one click. */

--- a/scripts/scope-tours/lib.ts
+++ b/scripts/scope-tours/lib.ts
@@ -92,6 +92,30 @@ export const findBlockEnd = (source: string, from: number): number => {
 export const PATH_SELECTOR =
     /^\[(data-tour-(?:nav|anchor))="([^"]+)"\](?:\[data-tour-value="([^"]+)"\])?$/;
 
+export type PathHop = {
+    selector: string;
+    /**
+     * A `?` hop: a control the instance may or may not show on the way to
+     * the next one (a chooser some configurations add before a form). It
+     * gets no step of its own; the next control's step carries it as a
+     * detour, spotlit only while the next control is not on the page.
+     */
+    optional: boolean;
+};
+
+/** Split a click path (`<sel> >> <sel>? >> ...`) into its hops. */
+export const parsePath = (value?: string): PathHop[] =>
+    value
+        ? value
+              .split(' >> ')
+              .map((v) => v.trim())
+              .map((hop) =>
+                  hop.endsWith('?')
+                      ? { selector: hop.slice(0, -1), optional: true }
+                      : { selector: hop, optional: false },
+              )
+        : [];
+
 /** Whether an anchor selector points at a typed-input control (`data-tour-input`). */
 /**
  * The JSX block that declares an anchor (preceded by whitespace; the same
@@ -463,6 +487,12 @@ export type ScopeTourStepDefinition = {
     advanceOnTargetClick: boolean;
     advanceOnTargetInput: boolean;
     via: string[];
+    /**
+     * Optional hops on the way to `target`: controls that lead to it on the
+     * instances that show them. Spotlit, with their own title, while one is
+     * on the page and the target is not.
+     */
+    detour?: { target: string; title: string }[];
     /** The page's "still working" surface; the step waits for it to go. */
     busy?: string;
     /** For a typed step: what the card offers to fill in with one click. */
@@ -582,8 +612,36 @@ export const buildTours = (
         // control on it, each titled by that control's hint; every step keeps
         // the controls before it as fallbacks, so if a menu closes the
         // spotlight drops back to the control that reopens it.
-        const pathSteps = (path: string[], route?: string) =>
-            path.flatMap((selector, index) => {
+        // Optional hops fold into the step of the next required control.
+        const detourFor = (hops: PathHop[]) =>
+            hops.length > 0
+                ? {
+                      detour: hops.map((hop) => ({
+                          target: hop.selector,
+                          title: hintFor(hop.selector, files),
+                      })),
+                  }
+                : {};
+        const required = (path: PathHop[]) =>
+            path.filter((hop) => !hop.optional).map((hop) => hop.selector);
+        // The optional hops left over after the last required control: they
+        // belong to whatever step follows the path (the marker's own).
+        const trailing = (path: PathHop[]) => {
+            const pending: PathHop[] = [];
+            for (const hop of path) {
+                if (hop.optional) pending.push(hop);
+                else pending.length = 0;
+            }
+            return pending;
+        };
+        const pathSteps = (path: PathHop[], route?: string) => {
+            const pending: PathHop[] = [];
+            return path.flatMap((hop) => {
+                if (hop.optional) {
+                    pending.push(hop);
+                    return [];
+                }
+                const { selector } = hop;
                 const typed = isInputAnchor(selector, files);
                 const suggestion = typed
                     ? suggestionFor(selector, files)
@@ -596,15 +654,26 @@ export const buildTours = (
                     interactive: true,
                     advanceOnTargetClick: !typed,
                     advanceOnTargetInput: typed,
-                    via: path.slice(0, index),
+                    via: required(path.slice(0, path.indexOf(hop))),
+                    ...detourFor(pending.splice(0)),
                     ...(suggestion ? { suggestion } : {}),
                 };
                 return [step, ...looksAfter(selector)];
             });
-        const splitPath = (value?: string) =>
-            value ? value.split(' >> ').map((v) => v.trim()) : [];
+        };
+        // A path that ends on an optional hop (`then`, `return`) has no step
+        // after it to carry the detour.
+        const closedPath = (marker: Marker, attribute: 'then' | 'return') => {
+            const path = parsePath(marker[attribute]);
+            if (trailing(path).length > 0) {
+                throw new Error(
+                    `${marker.file}: data-tour-${attribute} ends on an optional hop (?); an optional hop needs a control after it to detour to`,
+                );
+            }
+            return path;
+        };
         const steps = ordered.flatMap((marker) => {
-            const path = splitPath(marker.via);
+            const path = parsePath(marker.via);
             return [
                 ...pathSteps(path, marker.route),
                 {
@@ -623,11 +692,12 @@ export const buildTours = (
                     interactive: marker.interactive,
                     advanceOnTargetClick: marker.interactive,
                     advanceOnTargetInput: false,
-                    via: path,
+                    via: required(path),
+                    ...detourFor(trailing(path)),
                 },
                 // Clicks that complete the action after the marked control
                 // (a confirmation), each its own step.
-                ...pathSteps(splitPath(marker.then), marker.route),
+                ...pathSteps(closedPath(marker, 'then'), marker.route),
             ];
         });
         // Close where the walkthrough began so the learner sees the result of
@@ -638,8 +708,8 @@ export const buildTours = (
             first.return === 'none'
                 ? []
                 : first.return
-                  ? splitPath(first.return)
-                  : ['[data-tour-nav="home"]'];
+                  ? closedPath(first, 'return')
+                  : parsePath('[data-tour-nav="home"]');
         steps.push(...pathSteps(homePath, first.route), {
             target: selectorFor(first),
             route: first.route,
@@ -648,7 +718,7 @@ export const buildTours = (
             interactive: false,
             advanceOnTargetClick: false,
             advanceOnTargetInput: false,
-            via: homePath,
+            via: required(homePath),
             ...(first.busy ? { busy: first.busy } : {}),
         });
         resultLooks.forEach((marker) => {

--- a/scripts/scope-tours/scope-tours.test.ts
+++ b/scripts/scope-tours/scope-tours.test.ts
@@ -223,6 +223,74 @@ const run = async () => {
         );
     }
 
+    // An optional hop (`?`) is a control the instance may or may not show on
+    // the way to the next one (a chooser some configurations add). It gets no
+    // step of its own: the next step carries it as a detour, taken only when
+    // the control is on the page.
+    {
+        const files = [
+            write('Nav.tsx', nav('Click Browse')),
+            write(
+                'Pin.tsx',
+                marker(
+                    'explore/homepage.mdx#pin-content:2',
+                    `\n        data-tour-then='[data-tour-anchor="choose"]? >> [data-tour-anchor="confirm"]'`,
+                ),
+            ),
+            write(
+                'Dialog.tsx',
+                `
+export const Dialog = () => (
+    <>
+        {hasChooser && (
+            <Button data-tour-anchor="choose" data-tour-hint="Click Download data" />
+        )}
+        <Button data-tour-anchor="confirm" data-tour-hint="Click Download" />
+    </>
+);
+`,
+            ),
+        ];
+        const errors = checkTours(files).filter((f) => f.level === 'error');
+        assert.deepStrictEqual(errors, [], JSON.stringify(errors, null, 2));
+        const { tours } = buildTours(files);
+        assert.strictEqual(
+            tours[0].steps.map((s) => s.title).join(' > '),
+            'Pin content > Click Browse > Click Pin to homepage > Click Download > Go home > See the result',
+        );
+        assert.deepStrictEqual(tours[0].steps[3].detour, [
+            {
+                target: '[data-tour-anchor="choose"]',
+                title: 'Click Download data',
+            },
+        ]);
+        assert.deepStrictEqual(tours[0].steps[3].via, []);
+        assert.strictEqual(tours[0].steps[2].detour, undefined);
+    }
+
+    // An optional hop with nothing after it has nowhere to detour to.
+    {
+        const files = [
+            write('Nav.tsx', nav('Click Browse')),
+            write(
+                'Pin.tsx',
+                marker(
+                    'explore/homepage.mdx#pin-content:2',
+                    `\n        data-tour-then='[data-tour-anchor="confirm"]?'`,
+                ),
+            ),
+            write(
+                'Dialog.tsx',
+                `<Button data-tour-anchor="confirm" data-tour-hint="Click Download" />`,
+            ),
+        ];
+        const errors = checkTours(files).filter((f) => f.level === 'error');
+        assert.ok(
+            errors.some((f) => /optional hop/.test(f.message)),
+            JSON.stringify(errors),
+        );
+    }
+
     // A path mentioning an anchor is not that anchor: its hint must come
     // from the anchor's own element, even when the mention is found first.
     {

--- a/scripts/scope-tours/suggest.ts
+++ b/scripts/scope-tours/suggest.ts
@@ -21,6 +21,7 @@ import {
     findMarkers,
     frontendSrc,
     listTsx,
+    parsePath,
     PATH_SELECTOR,
     root,
     type Marker,
@@ -124,7 +125,7 @@ export const suggestFor = (
     for (const marker of markers) {
         for (const value of [marker.via, marker.then, marker.return]) {
             if (!value || value === 'none') continue;
-            for (const selector of value.split(' >> ').map((v) => v.trim())) {
+            for (const { selector } of parsePath(value)) {
                 const at = locateAnchor(selector, files);
                 if (!at || /data-tour-hint/.test(at.block)) continue;
                 const absolute = path.join(root, at.file);


### PR DESCRIPTION
Fixes AE-767. Replaces the product-UI half of #28862 and carries its GuidedTour escape hatch.

## Problem

The `manage:ExportCsv` walkthrough's Download step waits for `[data-tour-anchor="export-download"]`, which lives on the export form. With Google Drive configured (Cloud), `ExportSelector` opens the popover on a **Download data / Google Sheets** chooser instead, so the form never appears, the tour hides its card and blocks the page. The tour was generated on an instance without Drive and had never seen the chooser.

## Change

Click paths gain an **optional hop**: a `?` suffix marks a control only some instances show on the way to the next one.

- **Generator** (`scripts/scope-tours/lib.ts`, `check.ts`, `suggest.ts`): `parsePath` understands `sel?`. An optional hop gets no step; the next step carries it as `detour: [{ target, title }]`. A `then`/`return` path ending on an optional hop is a check error (nothing to detour to).
- **Runtime** (`GuidedTour.tsx`): while the target is missing and a detour control is on the page, the ring and card title move to it immediately (no patience wait: the product says this control leads to the target). The moment the target appears, the step is itself again. `via` semantics are unchanged.
- **Escape hatch** (from #28862): after the patience window with no target, the card comes back centred so Skip is always reachable. Unmarked branches degrade to a stuck step, never a dead tab.
- **Markers**: `ResultsCard` `data-tour-then='[data-tour-anchor="export-choose-download"]? >> [data-tour-anchor="export-download"]'`; the chooser's Download data button gains `data-tour-anchor="export-choose-download"` + hint. No product behaviour changes. The chooser stays.
- `generated.ts`: the one step gains a `detour`; every other tour is byte-identical.

Behaviour per instance, with no config awareness in the tour:
- No Drive: form renders, target present, detour never used. Same as today.
- Drive on: chooser renders, **Download data** is ringed with "Click Download data"; click it, form renders, ring moves to **Download**. One step, two clicks, same step count.

## Verification

- `scripts/scope-tours/scope-tours.test.ts`: optional hop folds into the next step's `detour`; trailing optional hop is an error. Passes.
- `GuidedTour.test.tsx`: detour spotlit while target missing, handed back when it appears; ignored when target already present; card returns after patience (escape hatch). 8/8 pass.
- `pnpm scope-tours:check` against mintlify-docs: 0 errors.
- `pnpm -F frontend lint`, `oxfmt --check`: clean. `typecheck` has one pre-existing error on main in `ExplorerAlternateHosts.test.tsx`, unrelated.
- Manual on docker-dev with `AUTH_GOOGLE_OAUTH2_CLIENT_ID` + `GOOGLE_DRIVE_API_KEY` set (the frontend only checks they are defined): see thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KXfHg8wW37XKEY3EsbBsLr
