### PR TITLE
fix(learn): allow category chip selection to advance the metric tutorial

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.test.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.test.tsx
@@ -1,0 +1,61 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GuidedTour } from '../../../components/common/GuidedTour';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { SCOPE_TOURS } from '../../scopeTours/generated';
+import { MetricCatalogCategoryFormItem } from './MetricCatalogCategoryFormItem';
+
+const category = {
+    name: 'Revenue',
+    color: 'blue',
+    tagUuid: 'revenue-tag',
+    yamlReference: null,
+};
+
+describe('MetricCatalogCategoryFormItem', () => {
+    const elementsFromPoint = document.elementsFromPoint;
+    beforeEach(() => {
+        // jsdom has no layout/hit testing; exercise real tour click handling.
+        document.elementsFromPoint = () => [];
+    });
+    afterEach(() => {
+        document.elementsFromPoint = elementsFromPoint;
+    });
+    it.each(['click', 'Enter', ' '] as const)(
+        'selects the category and advances the tutorial from step 4 to step 5 using %s',
+        async (action) => {
+            const user = userEvent.setup();
+            const onClick = vi.fn();
+            const onStepChange = vi.fn();
+            renderWithProviders(
+                <>
+                    <MetricCatalogCategoryFormItem
+                        category={category}
+                        onClick={onClick}
+                        canEdit={false}
+                    />
+                    <GuidedTour
+                        steps={SCOPE_TOURS['manage:Tags'].steps}
+                        initialStepIndex={3}
+                        opened
+                        onClose={vi.fn()}
+                        onStepChange={onStepChange}
+                    />
+                </>,
+            );
+
+            if (action === 'click') {
+                await user.click(screen.getByText('Revenue'));
+            } else {
+                screen.getByRole('button', { name: 'Revenue' }).focus();
+                await user.keyboard(action === 'Enter' ? '{Enter}' : ' ');
+            }
+
+            expect(onClick).toHaveBeenCalledTimes(1);
+            await waitFor(() =>
+                expect(onStepChange).toHaveBeenCalledWith(4, expect.anything()),
+            );
+        },
+    );
+});

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx
@@ -185,16 +185,6 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
 }) => {
     const { ref: hoverRef, hovered } = useHover<HTMLDivElement>();
 
-    const handleKeyDown = useCallback(
-        (e: React.KeyboardEvent<HTMLDivElement>) => {
-            if (e.key === 'Enter') {
-                e.preventDefault();
-                onClick?.();
-            }
-        },
-        [onClick],
-    );
-
     return (
         <Group
             ref={hoverRef}
@@ -202,17 +192,12 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
             py={3}
             pos="relative"
             justify="space-between"
-            tabIndex={0}
-            role="button"
-            onKeyDown={handleKeyDown}
+            wrap="nowrap"
             className={styles.categoryFormItem}
         >
             <UnstyledButton
                 onClick={onClick}
-                h="100%"
-                w="90%"
-                pos="absolute"
-                tabIndex={-1}
+                flex={1}
                 // Walkthrough action for manage:Tags: every category in the
                 // open form carries it; the first one is the pick. See
                 // scripts/scope-tours.
@@ -224,8 +209,9 @@ export const MetricCatalogCategoryFormItem: FC<Props> = ({
                 data-tour-interactive="true"
                 data-tour-via='[data-tour-nav="metrics"] >> [data-tour-anchor="metric-categories"][data-tour-value="Total revenue"]'
                 data-tour-docs="explore/metrics-catalog/curate-the-catalog.mdx#browsing-the-catalog:li3:3"
-            />
-            <CatalogCategory category={category} onClick={onClick} />
+            >
+                <CatalogCategory category={category} />
+            </UnstyledButton>
 
             {canEdit && (
                 <EditPopover


### PR DESCRIPTION
## What changed

## Summary
- Place the visible category chip inside the tutorial-targeted selection button instead of beside an invisible overlay button, so category selection also advances the tutorial.
- Preserve separate category editing controls and use native button keyboard activation without duplicate selection handlers.
- Add regression coverage using the real GuidedTour and generated manage:Tags steps for click, Enter, and Space.

Standards and specification reviews found no issues. No changes were needed in lightdash-university.

## Verification

Passed:
- `pnpm -F frontend exec oxfmt src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.test.tsx --check`
- `pnpm -F frontend lint` — 0 warnings/errors.
- `pnpm -F frontend typecheck`
- `pnpm -F frontend exec vitest related src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.tsx src/features/metricsCatalog/components/MetricCatalogCategoryFormItem.test.tsx --run` — 3 files, 32 tests passed.
- `pnpm -F frontend test src/components/common/GuidedTour/GuidedTour.test.tsx src/features/scopeTours/ScopeTourHost.test.tsx` — 2 files, 11 tests passed.
- `git diff --check`

Red/green: the new chip-click test failed before the fix because onStepChange never reached step index 4; all three activation cases pass after the fix.

Limitations: jsdom has no hit-testing (elementsFromPoint is stubbed). Live tutorial verification was unavailable: POST /api/v1/org/training-project returned 'Learn is not enabled on this instance'. A category-picker evidence capture also timed out locating the metric-category control; no visual evidence was captured. Browser-level overlay interaction and category-editing layout should be smoke-tested on a Learn-enabled instance.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-ae-772-1931c558405c.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [AE-772](https://linear.app/lightdash/issue/AE-772)

