### PR TITLE
fix(merge-queries): align join-type help icon with text

### DIFF
--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
@@ -135,7 +135,14 @@
     transform: scale(0.98);
 }
 
+.joinTypeOption {
+    justify-content: center;
+    align-items: center;
+    padding: 6px;
+}
+
 .joinTypeDiagram {
+    display: block;
     width: 36px;
     height: 21px;
     flex: none;

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.module.css
@@ -192,12 +192,14 @@
 }
 
 .note {
-    display: flex;
-    gap: 6px;
-    align-items: flex-start;
+    align-items: center;
 }
 
 .noteIcon {
     flex: none;
-    margin-top: 2px;
+}
+
+.noteText {
+    flex: 1;
+    min-width: 0;
 }

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -137,9 +137,9 @@ const JoinTypePicker: FC<{
                     withBorder={false}
                     aria-label={`${option.label}: ${option.help}`}
                 >
-                    <Group justify="center" gap={6} wrap="nowrap" p={6}>
+                    <Group className={styles.joinTypeOption} gap={6} wrap="nowrap">
                         <JoinTypeDiagram type={option.value} />
-                        <Text size="xs" fw={600} ta="center" truncate>
+                        <Text span size="xs" fw={600} truncate>
                             {option.label}
                         </Text>
                     </Group>

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -36,16 +36,22 @@ const Note: FC<{ tone: 'muted' | 'warn'; children: ReactNode }> = ({
     tone,
     children,
 }) => (
-    <Box className={styles.note}>
+    <Group className={styles.note} gap={6} wrap="nowrap">
         <MantineIcon
             className={styles.noteIcon}
             icon={tone === 'warn' ? IconAlertTriangle : IconInfoCircle}
-            color={tone === 'warn' ? 'orange.7' : 'gray.6'}
+            color={tone === 'warn' ? 'orange.7' : 'dimmed'}
+            size={14}
         />
-        <Text size="xs" c={tone === 'warn' ? undefined : 'dimmed'}>
+        <Text
+            span
+            size="xs"
+            className={styles.noteText}
+            c={tone === 'warn' ? undefined : 'dimmed'}
+        >
             {children}
         </Text>
-    </Box>
+    </Group>
 );
 
 type JoinTypeOption = {

--- a/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
+++ b/packages/frontend/src/features/mergeQuery/components/MergeJoinBar.tsx
@@ -137,7 +137,11 @@ const JoinTypePicker: FC<{
                     withBorder={false}
                     aria-label={`${option.label}: ${option.help}`}
                 >
-                    <Group className={styles.joinTypeOption} gap={6} wrap="nowrap">
+                    <Group
+                        className={styles.joinTypeOption}
+                        gap={6}
+                        wrap="nowrap"
+                    >
                         <JoinTypeDiagram type={option.value} />
                         <Text span size="xs" fw={600} truncate>
                             {option.label}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates: merge-queries join type UI

### Description:

The join-type picker in merge queries had two icon+text rows that sat off-center:

- The help row under the picker top-aligned a default 16px info icon with paragraph copy, so the icon sat high.
- Each Inner / Left / Full outer card used paragraph text next to the Venn diagram, so the label hung below the icon.

This change:
- Centers the help icon on a 14px `span` of `xs` copy
- Renders each join-type label as a `span` and treats the diagram as a block so they share one vertical center

Verified in the browser on the Jaffle shop Orders + Customers merge: clicking Inner, Left, and Full outer updates the help row, and both the card icons and the info icon sit on the text.

[Join type control after alignment fix](https://cursor.com/agents/bc-bdf95106-9d96-5de5-b84d-5167bb83e15f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjoin_type_control_after.webp)

[join_type_icon_text_alignment.mp4](https://cursor.com/agents/bc-bdf95106-9d96-5de5-b84d-5167bb83e15f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjoin_type_icon_text_alignment.mp4)

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C0AD7R21BLG/p1788890338873669?thread_ts=1788890338.873669&cid=C0AD7R21BLG)

<div><a href="https://cursor.com/agents/bc-bdf95106-9d96-5de5-b84d-5167bb83e15f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf95106-9d96-5de5-b84d-5167bb83e15f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

