### PR TITLE
chore: build common and warehouses for the rungs that import them

### DIFF
--- a/rainbow.toml
+++ b/rainbow.toml
@@ -152,6 +152,24 @@ name = "formula-build"
 files = ["packages/formula/**"]
 run = "pnpm formula:build"         # the backend imports formula's dist and nothing watches it
 
+# `pnpm dev` runs tsc watchers over common and warehouses, so a change to
+# either is a hot reload for a serving environment. The rungs below are the
+# exception: they import those packages' `dist` and they run seconds after
+# the fork, with the app's units stopped, before any watcher has caught up.
+# Without these two they read the parent's build — `migrate` died on a
+# half-written barrel, and `tsoa` could not resolve types the branch had
+# just added (2026-09-08). Each fires only when its own package changes.
+[[tier]]
+name = "common-build"
+files = ["packages/common/**"]
+run = "pnpm common-build"
+memory = "12gb"                    # the barrel is large; the same headroom migrate takes
+
+[[tier]]
+name = "warehouses-build"
+files = ["packages/warehouses/**"]
+run = "pnpm warehouses-build"
+
 [[tier]]
 name = "migrate"
 files = ["packages/backend/src/database/migrations/**"]


### PR DESCRIPTION
## What

Adds two `run` rungs to `rainbow.toml`, above `migrate` and `api-routes`:

```toml
[[tier]]
name = "common-build"
files = ["packages/common/**"]
run = "pnpm common-build"
memory = "12gb"

[[tier]]
name = "warehouses-build"
files = ["packages/warehouses/**"]
run = "pnpm warehouses-build"
```

## Why

`pnpm dev` runs tsc watchers over `common` and `warehouses`, so the recipe left their `dist` to the watchers. That holds for a preview once it is serving. It does not hold for the `run` rungs: they execute seconds after the fork, with the app's units stopped, and they import a `dist` no watcher has rebuilt yet.

Both failure modes are live today:

- **`migrate`** imported a `packages/common/dist/cjs/index.js` whose barrel required a module the stopped watcher never emitted. That was the red preview status on #28856.
- **`generate-api`** fails whenever a branch adds a type in `packages/common` and references it from a controller. `tsoa` resolves through the built output, so it reports `No declarations found for referenced type …`. #28847 and #28878 both hit it today, on `ApiLearnAccessResponse` and `ApiWarehouseConnectionTestResponse` respectively.

## Cost

Each rung fires only when its own package changes, and both build incrementally on the parent's output rather than from cold. Measured on #28878's branch:

| rung | time |
| --- | --- |
| `common-build` | 7.9s |
| `warehouses-build` | 3.5s |
| `api-routes` | 16.0s — **passed**, where the same branch without these rungs failed |

## Verification

Ran #28878's head with these rungs applied on a Rainbow environment: both rungs ran, `generate-api` then succeeded, and the app came back healthy (`/api/v1/health` 200) with `ApiWarehouseConnectionTestResponse` present in common's built `.d.ts`.

Nothing outside `rainbow.toml` changes, and the watchers still own hot reload for a serving preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)