### PR TITLE
fix(learn): recover walkthroughs from disabled action controls

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,9 +1,9 @@
 import { Button, Popover, TextInput } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState, type FC } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import MantineModal from '../MantineModal';
 import { GuidedTour, type GuidedTourStep } from './GuidedTour';
@@ -523,4 +523,73 @@ describe('GuidedTour and the menus a step opens', () => {
         expect(closeDialog).not.toHaveBeenCalled();
         expect(screen.getByText('Chart name')).toBeInTheDocument();
     });
+});
+
+describe('GuidedTour action recovery', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        Reflect.deleteProperty(document, 'elementsFromPoint');
+    });
+
+    it.each([
+        { disabled: true },
+        { 'aria-disabled': true as const },
+        { 'data-disabled': true },
+    ])(
+        'lets the learner retry before a disabled target (%j)',
+        async (disabledProps) => {
+            vi.useFakeTimers();
+            document.elementsFromPoint = () => [];
+            const onStepChange = vi.fn();
+            const retry = vi.fn();
+            const recoverySteps: GuidedTourStep[] = [
+                {
+                    target: '#save-chart',
+                    title: 'Save chart',
+                    body: '',
+                    interactive: true,
+                    advanceOnTargetClick: true,
+                    via: ['#run-query', '#unavailable-action'],
+                },
+                { target: null, title: 'Name chart', body: '' },
+            ];
+            const renderTour = (ready: boolean) => (
+                <>
+                    <Button id="run-query" onClick={retry}>
+                        Run query
+                    </Button>
+                    <Button id="unavailable-action" disabled>
+                        Unavailable
+                    </Button>
+                    <Button id="save-chart" {...(ready ? {} : disabledProps)}>
+                        Save
+                    </Button>
+                    <GuidedTour
+                        steps={recoverySteps}
+                        opened
+                        onClose={vi.fn()}
+                        onStepChange={onStepChange}
+                    />
+                </>
+            );
+            const { rerender } = renderWithProviders(renderTour(false));
+            await act(async () => vi.advanceTimersByTime(2000));
+            const run = screen.getByRole('button', { name: 'Run query' });
+            expect(run).toHaveAttribute('data-tour-active');
+            fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+            expect(onStepChange).not.toHaveBeenCalled();
+            fireEvent.click(run);
+            expect(retry).toHaveBeenCalledOnce();
+            expect(onStepChange).not.toHaveBeenCalled();
+
+            rerender(renderTour(true));
+            await act(async () => vi.advanceTimersByTime(300));
+            const save = screen.getByRole('button', {
+                name: 'Save',
+            });
+            expect(save).toHaveAttribute('data-tour-active');
+            fireEvent.click(save);
+            expect(onStepChange).toHaveBeenCalledWith(1, expect.anything());
+        },
+    );
 });

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -135,6 +135,9 @@ const INPUT_SETTLE_MS = 900;
 /** Used until the card has been measured. */
 const CARD_FALLBACK_HEIGHT = 220;
 
+const isDisabled = (el: Element) =>
+    el.matches(':disabled, [aria-disabled="true"], [data-disabled]');
+
 const clips = (style: CSSStyleDeclaration) =>
     /(auto|scroll|hidden)/.test(style.overflowY) ||
     /(auto|scroll|hidden)/.test(style.overflowX);
@@ -254,11 +257,12 @@ type Resolved = {
 };
 
 /**
- * Which selector to spotlight right now: the step's target when it is on the
- * page, else a `detour` control that is (the way to the target on this
- * instance), else the deepest `via` control that is (later controls only
+ * Which selector to spotlight right now: the step's target when it is ready,
+ * else a `detour` control that is on the page (the way to the target on this
+ * instance), else the deepest enabled `via` control (later controls only
  * exist once earlier ones were clicked, and earlier ones such as a nav
- * button stay on the page), else nothing.
+ * button stay on the page), else nothing. A control the learner cannot press
+ * is never spotlit.
  */
 const useResolvedSelector = (
     step: GuidedTourStep | undefined,
@@ -267,6 +271,8 @@ const useResolvedSelector = (
     const target = active ? (step?.target ?? null) : null;
     const via = active ? step?.via : undefined;
     const detour = active ? step?.detour : undefined;
+    const requiresEnabledTarget =
+        !!step?.advanceOnTargetClick || !!step?.advanceOnTargetInput;
     const [resolved, setResolved] = useState<Resolved>({
         selector: target,
         detourTitle: null,
@@ -279,22 +285,28 @@ const useResolvedSelector = (
             setResolved({ selector: target, detourTitle: null });
             return undefined;
         }
-        // Fallbacks are for a menu the learner closed by accident, not for a
+        // Fallbacks let learners reopen a menu or retry a failed action, not a
         // control that is still loading after their click (a page, a list the
         // server fills in): until the target has been seen once, wait for it
         // as long as patience allows; once seen and gone, give it a moment
         // before dropping back to an earlier control on the path. A detour
         // is different: the product says that control leads here, so it is
-        // taken the moment it is on the page.
+        // taken the moment it is on the page and can be pressed.
         const since = Date.now();
         let seen = false;
         const tick = () => {
-            if (document.querySelector(target)) {
+            const targetElement = document.querySelector(target);
+            if (targetElement) {
                 seen = true;
-                setResolved({ selector: target, detourTitle: null });
-                return;
+                if (!requiresEnabledTarget || !isDisabled(targetElement)) {
+                    setResolved({ selector: target, detourTitle: null });
+                    return;
+                }
             }
-            const hop = detour?.find((d) => document.querySelector(d.target));
+            const hop = detour?.find((d) => {
+                const el = document.querySelector(d.target);
+                return el && !isDisabled(el);
+            });
             if (hop) {
                 setResolved({ selector: hop.target, detourTitle: hop.title });
                 return;
@@ -306,17 +318,17 @@ const useResolvedSelector = (
             }
             setResolved({
                 selector:
-                    [...(via ?? [])]
-                        .reverse()
-                        .find((selector) => document.querySelector(selector)) ??
-                    null,
+                    [...(via ?? [])].reverse().find((selector) => {
+                        const el = document.querySelector(selector);
+                        return el && !isDisabled(el);
+                    }) ?? null,
                 detourTitle: null,
             });
         };
         tick();
         const poll = window.setInterval(tick, 150);
         return () => window.clearInterval(poll);
-    }, [target, via, detour]);
+    }, [target, via, detour, requiresEnabledTarget]);
 
     return resolved;
 };
@@ -823,6 +835,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         if (!advanceSelector) return undefined;
         let el: Element | null = null;
         const onClick = () => {
+            if (!el || isDisabled(el)) return;
             advanceByClickRef.current = true;
             const at = el?.getBoundingClientRect();
             clickPointRef.current = at


### PR DESCRIPTION
## What changed

## Summary
- Extend guided-tour recovery paths to disabled action targets, allowing learners blocked on **Save chart** to retry **Run query**.
- Skip disabled recovery controls and return the spotlight to the intended action when it becomes enabled.
- Prevent disabled-target clicks from advancing the walkthrough; cover native, ARIA, and Mantine disabled states.

## Investigation boundary
The provided tutorial query succeeds for a viewer in their personal training copy. A simulated first-request 403 reproduced the blocked state; retrying with this change returned five rows, saved the chart, and reached step 12 without reloading. This fixes the recovery trap, not an established permissions defect: the original access denial was not independently reproduced, and permissions are unchanged.

Independent standards and spec reviews reported no findings.

## Verification

Passed:
- `pnpm -F frontend test src/components/common/GuidedTour/GuidedTour.test.tsx` — 8 tests; the three recovery cases first failed against the original implementation and passed after the fix.
- `pnpm -F frontend exec vitest related src/components/common/GuidedTour/GuidedTour.tsx src/components/common/GuidedTour/GuidedTour.test.tsx --run` — 4 files, 22 tests passed.
- `pnpm -F frontend lint` — zero errors/warnings.
- `pnpm -F frontend typecheck` — passed after correcting test query options.
- `pnpm -F frontend exec oxfmt src/components/common/GuidedTour/GuidedTour.tsx src/components/common/GuidedTour/GuidedTour.test.tsx --check` — passed.
- `git diff --check` — passed.

Runtime:
- `node /tmp/ae774-repro.cjs` — local viewer executed the provided tutorial SQL successfully, returning five rows.
- `node /tmp/ae774-recovery.cjs` — one-off Playwright flow injected a single 403 for the first SQL POST, verified Run query became highlighted, retried without reload, received real backend results, saved Orders by status to Shared, and reached step 12 with the success notification. Local demo role was restored afterward.
- Backend PM2 logs and Maple traces corroborated successful SQL execution and result retrieval. The initial 403 was browser-injected, not a reproduced backend permission failure.
- Captured screenshot of the saved chart; observations confirm the chart title, result rows, and Edit chart control are visible.

Both worktrees are clean; only lightdash/lightdash changed.

## Visual evidence

### Saved Orders by status chart in the learner’s training copy after a simulated first-request permission error was retried without reloading (recovery verified separately with Playwright).

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/da6936e4fb51937c21222bc40bbe7d419426a5a8602c9574a7ac34339c0aa8c8.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-ae-774-15e92884fa18.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [AE-774](https://linear.app/lightdash/issue/AE-774)

