### PR TITLE
fix(mcp): remove stale writeback option

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
@@ -168,11 +168,11 @@ const runSnapshot = (overrides: Record<string, unknown> = {}) => ({
 const createServerWithWriteback = async (
     aiWritebackService: Record<string, unknown>,
 ) => {
+    const mcpService = makeMcpService({ aiWritebackService });
     mockRegisteredMcpTools.clear();
     mockRegisteredRequestHandlers.clear();
     mockRegisterCapabilities.mockClear();
-    const mcpService = makeMcpService({ aiWritebackService });
-    await mcpService.createServer({ aiWritebackEnabled: true });
+    await mcpService.createServer();
 };
 
 describe('McpService AI writeback MCP tasks', () => {
@@ -193,12 +193,27 @@ describe('McpService AI writeback MCP tasks', () => {
             );
         });
 
-        it('does not register task handlers when writeback is disabled', async () => {
-            mockRegisteredRequestHandlers.clear();
+        it('registers writeback tools without optional query or content capabilities', async () => {
             const mcpService = makeMcpService({ aiWritebackService: {} });
-            await mcpService.createServer({ aiWritebackEnabled: false });
+            mockRegisteredMcpTools.clear();
+            mockRegisteredRequestHandlers.clear();
+            await mcpService.createServer({
+                projectPinned: true,
+                runSqlEnabled: false,
+                runMetricQueryEnabled: false,
+                mcpContentWritesEnabled: false,
+                scheduledDeliveryEnabled: false,
+            });
 
-            expect(mockRegisteredRequestHandlers.size).toBe(0);
+            expect(
+                mockRegisteredMcpTools.has(McpToolName.RUN_AI_WRITEBACK),
+            ).toBe(true);
+            expect(
+                mockRegisteredMcpTools.has(McpToolName.GET_AI_WRITEBACK_STATUS),
+            ).toBe(true);
+            expect([...mockRegisteredRequestHandlers.keys()]).toEqual(
+                expect.arrayContaining(['tasks/get', 'tasks/cancel']),
+            );
         });
     });
 

--- a/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.listContent.test.ts
@@ -24,6 +24,10 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
         // eslint-disable-next-line prefer-arrow-callback
         function MockMcpServer() {
             return {
+                server: {
+                    registerCapabilities: vi.fn(),
+                    setRequestHandler: vi.fn(),
+                },
                 registerResource: vi.fn(),
                 registerPrompt: vi.fn(),
                 registerTool: vi.fn(

--- a/packages/backend/src/ee/services/McpService/McpService.mcpAgentsEnabled.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.mcpAgentsEnabled.test.ts
@@ -22,6 +22,10 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
         // eslint-disable-next-line prefer-arrow-callback
         function MockMcpServer() {
             return {
+                server: {
+                    registerCapabilities: vi.fn(),
+                    setRequestHandler: vi.fn(),
+                },
                 registerResource: vi.fn(),
                 registerPrompt: vi.fn(),
                 registerTool: vi.fn(

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -36,6 +36,10 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
         // eslint-disable-next-line prefer-arrow-callback
         function MockMcpServer() {
             return {
+                server: {
+                    registerCapabilities: vi.fn(),
+                    setRequestHandler: vi.fn(),
+                },
                 registerResource: vi.fn(),
                 registerPrompt: vi.fn(),
                 registerTool: vi.fn(
@@ -602,7 +606,6 @@ const makeMcpService = ({
     mockRegisteredMcpToolInputSchemas.clear();
     service.setupHandlers({
         projectPinned: false,
-        aiWritebackEnabled: false,
         mcpContentWritesEnabled: true,
         scheduledDeliveryEnabled: true,
         runSqlEnabled: true,

--- a/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.routeAgent.test.ts
@@ -23,6 +23,10 @@ vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
         // eslint-disable-next-line prefer-arrow-callback
         function MockMcpServer() {
             return {
+                server: {
+                    registerCapabilities: vi.fn(),
+                    setRequestHandler: vi.fn(),
+                },
                 registerResource: vi.fn(),
                 registerPrompt: vi.fn(),
                 registerTool: vi.fn(

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -459,7 +459,6 @@ const getMcpContext = (
 
 export type McpServerToolOptions = {
     projectPinned?: boolean;
-    aiWritebackEnabled?: boolean;
     mcpContentWritesEnabled?: boolean;
     scheduledDeliveryEnabled?: boolean;
     runSqlEnabled?: boolean;
@@ -1927,7 +1926,6 @@ export class McpService extends BaseService {
     setupHandlers(
         options: {
             projectPinned: boolean;
-            aiWritebackEnabled: boolean;
             mcpContentWritesEnabled: boolean;
             scheduledDeliveryEnabled: boolean;
             runSqlEnabled: boolean;
@@ -1935,7 +1933,6 @@ export class McpService extends BaseService {
             filterExpressionsEnabled: boolean;
         } = {
             projectPinned: false,
-            aiWritebackEnabled: false,
             mcpContentWritesEnabled: true,
             scheduledDeliveryEnabled: true,
             runSqlEnabled: false,
@@ -3627,16 +3624,9 @@ export class McpService extends BaseService {
 
         this.registerSkillToolHandlers();
 
-        // Dark-launched: this tool is only registered — and therefore only
-        // advertised in tools/list and invocable — when the AiWriteback
-        // feature flag is enabled for the caller. Clients without the flag
-        // never see it. The flag is resolved per-request in the MCP router
-        // (mcpRouter.ts) and passed through createServer.
-        if (options.aiWritebackEnabled) {
-            this.registerRunAiWritebackTool();
-            this.registerGetAiWritebackStatusTool();
-            this.registerAiWritebackTaskHandlers();
-        }
+        this.registerRunAiWritebackTool();
+        this.registerGetAiWritebackStatusTool();
+        this.registerAiWritebackTaskHandlers();
 
         this.mcpServer.registerPrompt(
             'lightdash-analyst',
@@ -4066,7 +4056,6 @@ export class McpService extends BaseService {
         this.mcpServer = newServer;
         this.setupHandlers({
             projectPinned: options?.projectPinned ?? false,
-            aiWritebackEnabled: options?.aiWritebackEnabled ?? false,
             mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
             scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
             runSqlEnabled: options?.runSqlEnabled ?? false,

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -182,7 +182,6 @@ const MCP_CLIENT_TEXT_MAX_CHARS = 2048;
 // Required keeps newly added server options from silently escaping the matrix.
 const disabledMcpOptions: Required<McpServerToolOptions> = {
     projectPinned: false,
-    aiWritebackEnabled: false,
     mcpContentWritesEnabled: false,
     scheduledDeliveryEnabled: false,
     runSqlEnabled: false,
@@ -314,7 +313,7 @@ describe('MCP tool contracts', () => {
     });
 
     it.each(mcpOptionCombinations)(
-        'guards MCP text lengths: pinned=$projectPinned writeback=$aiWritebackEnabled content=$mcpContentWritesEnabled scheduled=$scheduledDeliveryEnabled sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
+        'guards MCP text lengths: pinned=$projectPinned content=$mcpContentWritesEnabled scheduled=$scheduledDeliveryEnabled sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
         async (options) => {
             const configuration = JSON.stringify(options);
             const mcpService = makeMcpService();
@@ -396,7 +395,6 @@ describe('MCP tool contracts', () => {
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
         await mcpService.createServer({
-            aiWritebackEnabled: true,
             runSqlEnabled: true,
             runMetricQueryEnabled: true,
         });
@@ -437,7 +435,6 @@ describe('MCP tool contracts', () => {
 
         mockRegisteredMcpTools.length = 0;
         await mcpService.createServer({
-            aiWritebackEnabled: true,
             runSqlEnabled: false,
             runMetricQueryEnabled: false,
         });
@@ -459,7 +456,6 @@ describe('MCP tool contracts', () => {
 
         mockRegisteredMcpTools.length = 0;
         await mcpService.createServer({
-            aiWritebackEnabled: true,
             runSqlEnabled: true,
             runMetricQueryEnabled: false,
         });
@@ -548,7 +544,6 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         await mcpService.createServer({
-            aiWritebackEnabled: true,
             runSqlEnabled: true,
         });
 

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -398,9 +398,6 @@ mcpRouter.all(
                 ]);
                 const toolOptions: McpServerToolOptions = {
                     projectPinned: pinnedProjectUuid !== undefined,
-                    // The run_ai_writeback tool is always registered now that
-                    // AI writeback has graduated from its dark-launch flag.
-                    aiWritebackEnabled: true,
                     mcpContentWritesEnabled,
                     scheduledDeliveryEnabled,
                     runSqlEnabled,


### PR DESCRIPTION
Remove the stale aiWritebackEnabled MCP option: the router has always enabled writeback since #25308. Keep tools registered and preserve execution authorization; update tests to match the shipped behavior.

Risk: high — tool registration changes; human review required. Verified 186 tests, typecheck, lint/format, and snapshot freshness.