### PR TITLE
fix(mcp): separate server context and features

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.aiWritebackTasks.test.ts
@@ -1,6 +1,7 @@
 import { ForbiddenError, NotFoundError } from '@lightdash/common';
 import { McpError } from '@modelcontextprotocol/sdk/types.js'; // eslint-disable-line import/extensions
 import { McpService, McpToolName } from './McpService';
+import { makeMcpServerOptions } from './McpService.mock';
 
 type RegisteredToolCallback = (
     args: Record<string, unknown>,
@@ -172,7 +173,7 @@ const createServerWithWriteback = async (
     mockRegisteredMcpTools.clear();
     mockRegisteredRequestHandlers.clear();
     mockRegisterCapabilities.mockClear();
-    await mcpService.createServer();
+    await mcpService.createServer(makeMcpServerOptions());
 };
 
 describe('McpService AI writeback MCP tasks', () => {
@@ -197,13 +198,15 @@ describe('McpService AI writeback MCP tasks', () => {
             const mcpService = makeMcpService({ aiWritebackService: {} });
             mockRegisteredMcpTools.clear();
             mockRegisteredRequestHandlers.clear();
-            await mcpService.createServer({
-                projectPinned: true,
-                runSqlEnabled: false,
-                runMetricQueryEnabled: false,
-                mcpContentWritesEnabled: false,
-                scheduledDeliveryEnabled: false,
-            });
+            await mcpService.createServer(
+                makeMcpServerOptions(
+                    {
+                        mcpContentWritesEnabled: false,
+                        scheduledDeliveryEnabled: false,
+                    },
+                    projectUuid,
+                ),
+            );
 
             expect(
                 mockRegisteredMcpTools.has(McpToolName.RUN_AI_WRITEBACK),

--- a/packages/backend/src/ee/services/McpService/McpService.mock.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.mock.ts
@@ -1,0 +1,18 @@
+import type { McpServerToolOptions } from './McpService';
+
+export const makeMcpServerOptions = (
+    featureAvailability: Partial<
+        McpServerToolOptions['featureAvailability']
+    > = {},
+    pinnedProjectUuid?: string,
+): McpServerToolOptions => ({
+    req: { pinnedProjectUuid },
+    featureAvailability: {
+        mcpContentWritesEnabled: true,
+        scheduledDeliveryEnabled: true,
+        runSqlEnabled: false,
+        runMetricQueryEnabled: false,
+        filterExpressionsEnabled: false,
+        ...featureAvailability,
+    },
+});

--- a/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.queryPolling.test.ts
@@ -12,6 +12,7 @@ import * as Sentry from '@sentry/node';
 import { z, type ZodRawShape } from 'zod';
 import * as runQueryTool from '../ai/tools/runQuery';
 import { McpService, McpToolName } from './McpService';
+import { makeMcpServerOptions } from './McpService.mock';
 
 type RegisteredToolCallback = (
     args: Record<string, unknown>,
@@ -604,14 +605,13 @@ const makeMcpService = ({
     // re-register here with run_sql enabled — these tests exercise the tool.
     mockRegisteredMcpTools.clear();
     mockRegisteredMcpToolInputSchemas.clear();
-    service.setupHandlers({
-        projectPinned: false,
-        mcpContentWritesEnabled: true,
-        scheduledDeliveryEnabled: true,
-        runSqlEnabled: true,
-        runMetricQueryEnabled: true,
-        filterExpressionsEnabled,
-    });
+    service.setupHandlers(
+        makeMcpServerOptions({
+            runSqlEnabled: true,
+            runMetricQueryEnabled: true,
+            filterExpressionsEnabled,
+        }),
+    );
 
     return {
         aiAgentService,
@@ -671,6 +671,48 @@ const getTextResult = (result: unknown) => {
 
 const parseTextResult = (result: unknown) =>
     JSON.parse(getTextResult(result) || '{}') as Record<string, unknown>;
+
+describe('MCP catalogue audit', () => {
+    it.each([undefined, projectUuid])(
+        'preserves flat catalogue metadata for pinnedProjectUuid=%s',
+        async (pinnedProjectUuid) => {
+            const { service, mcpToolCallModel } = makeMcpService();
+            service.recordToolList({
+                catalogue: makeMcpServerOptions(
+                    { runSqlEnabled: true, filterExpressionsEnabled: true },
+                    pinnedProjectUuid,
+                ),
+                authInfo: {
+                    token: 'test-token',
+                    clientId: 'test-client',
+                    scopes: [],
+                    extra: {
+                        ...extra.authInfo.extra,
+                        headerProjectUuid: pinnedProjectUuid,
+                    },
+                },
+                durationMs: 1,
+            });
+            await vi.waitFor(() => {
+                expect(mcpToolCallModel.createToolCall).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        tool_name: 'tools/list',
+                        result_metadata: {
+                            catalogue: {
+                                projectPinned: pinnedProjectUuid !== undefined,
+                                mcpContentWritesEnabled: true,
+                                scheduledDeliveryEnabled: true,
+                                runSqlEnabled: true,
+                                runMetricQueryEnabled: false,
+                                filterExpressionsEnabled: true,
+                            },
+                        },
+                    }),
+                );
+            });
+        },
+    );
+});
 
 describe('MCP async query polling', () => {
     beforeEach(() => {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -458,12 +458,14 @@ const getMcpContext = (
 ): McpProtocolContext => mcpProtocolContextSchema.parse(extra);
 
 export type McpServerToolOptions = {
-    projectPinned?: boolean;
-    mcpContentWritesEnabled?: boolean;
-    scheduledDeliveryEnabled?: boolean;
-    runSqlEnabled?: boolean;
-    runMetricQueryEnabled?: boolean;
-    filterExpressionsEnabled?: boolean;
+    req: { pinnedProjectUuid: string | undefined };
+    featureAvailability: {
+        mcpContentWritesEnabled: boolean;
+        scheduledDeliveryEnabled: boolean;
+        runSqlEnabled: boolean;
+        runMetricQueryEnabled: boolean;
+        filterExpressionsEnabled: boolean;
+    };
 };
 
 export class McpService extends BaseService {
@@ -1924,20 +1926,15 @@ export class McpService extends BaseService {
     }
 
     setupHandlers(
-        options: {
-            projectPinned: boolean;
-            mcpContentWritesEnabled: boolean;
-            scheduledDeliveryEnabled: boolean;
-            runSqlEnabled: boolean;
-            runMetricQueryEnabled: boolean;
-            filterExpressionsEnabled: boolean;
-        } = {
-            projectPinned: false,
-            mcpContentWritesEnabled: true,
-            scheduledDeliveryEnabled: true,
-            runSqlEnabled: false,
-            runMetricQueryEnabled: true,
-            filterExpressionsEnabled: false,
+        { req, featureAvailability: options }: McpServerToolOptions = {
+            req: { pinnedProjectUuid: undefined },
+            featureAvailability: {
+                mcpContentWritesEnabled: true,
+                scheduledDeliveryEnabled: true,
+                runSqlEnabled: false,
+                runMetricQueryEnabled: true,
+                filterExpressionsEnabled: false,
+            },
         },
     ): void {
         this.registerTrackedTool(
@@ -2416,7 +2413,7 @@ export class McpService extends BaseService {
 
         // When the project is pinned via header, hide the legacy
         // project-selection tools so clients cannot change the pin.
-        if (!options.projectPinned) {
+        if (req.pinnedProjectUuid === undefined) {
             this.registerTrackedTool(
                 mcpListProjectsTool.name,
                 {
@@ -4040,29 +4037,16 @@ export class McpService extends BaseService {
      * See: https://github.com/advisories/GHSA-345p-7cg4-v4c7
      */
     public async createServer(
-        options?: McpServerToolOptions,
+        options: McpServerToolOptions,
     ): Promise<McpServer> {
-        const newServer = this.buildMcpServer({
-            runSqlEnabled: options?.runSqlEnabled ?? false,
-            runMetricQueryEnabled: options?.runMetricQueryEnabled ?? false,
-            filterExpressionsEnabled:
-                options?.filterExpressionsEnabled ?? false,
-        });
+        const newServer = this.buildMcpServer(options.featureAvailability);
 
         // Temporarily swap the server to register handlers on the new instance.
         // Kept synchronous so concurrent createServer calls can't observe each
         // other's swapped this.mcpServer across an await.
         const originalServer = this.mcpServer;
         this.mcpServer = newServer;
-        this.setupHandlers({
-            projectPinned: options?.projectPinned ?? false,
-            mcpContentWritesEnabled: options?.mcpContentWritesEnabled ?? true,
-            scheduledDeliveryEnabled: options?.scheduledDeliveryEnabled ?? true,
-            runSqlEnabled: options?.runSqlEnabled ?? false,
-            runMetricQueryEnabled: options?.runMetricQueryEnabled ?? false,
-            filterExpressionsEnabled:
-                options?.filterExpressionsEnabled ?? false,
-        });
+        this.setupHandlers(options);
         this.mcpServer = originalServer;
 
         // Skill resources load asynchronously; register them directly on the
@@ -4429,7 +4413,14 @@ export class McpService extends BaseService {
                     durationMs: params.durationMs,
                     status: 'success',
                     errorMessage: null,
-                    resultMetadata: { catalogue: params.catalogue },
+                    resultMetadata: {
+                        catalogue: {
+                            projectPinned:
+                                params.catalogue.req.pinnedProjectUuid !==
+                                undefined,
+                            ...params.catalogue.featureAvailability,
+                        },
+                    },
                     trackAnalytics: false,
                 }),
             )

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -22,6 +22,7 @@ import {
     McpToolName,
     type McpServerToolOptions,
 } from './McpService';
+import { makeMcpServerOptions } from './McpService.mock';
 
 type RegisteredMcpTool = {
     name: string;
@@ -179,21 +180,22 @@ const defaultMcpAnalystPromptOptions = {
 // Observed in Claude Code 2.1.263; this is not an MCP protocol limit.
 const MCP_CLIENT_TEXT_MAX_CHARS = 2048;
 
-// Required keeps newly added server options from silently escaping the matrix.
-const disabledMcpOptions: Required<McpServerToolOptions> = {
-    projectPinned: false,
-    mcpContentWritesEnabled: false,
-    scheduledDeliveryEnabled: false,
-    runSqlEnabled: false,
-    runMetricQueryEnabled: false,
-    filterExpressionsEnabled: false,
-};
-const mcpOptionCombinations = Object.keys(disabledMcpOptions).reduce(
+// Classify new features explicitly: registration-only or text-changing.
+const registrationOnlyFeatures = {
+    mcpContentWritesEnabled: true,
+    scheduledDeliveryEnabled: true,
+} satisfies Omit<
+    McpServerToolOptions['featureAvailability'],
+    keyof typeof defaultMcpAnalystPromptOptions
+>;
+const mcpOptionCombinations = Object.keys(
+    defaultMcpAnalystPromptOptions,
+).reduce(
     (combinations, key) =>
         combinations.flatMap((options) =>
             [false, true].map((enabled) => ({ ...options, [key]: enabled })),
         ),
-    [disabledMcpOptions],
+    [defaultMcpAnalystPromptOptions],
 );
 
 const warnedTextLengths = new Set<string>();
@@ -261,18 +263,22 @@ describe('MCP tool contracts', () => {
     it('matches initialization guidance to the filter contract', async () => {
         const mcpService = makeMcpService();
 
-        await mcpService.createServer({
-            runMetricQueryEnabled: true,
-            filterExpressionsEnabled: false,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runMetricQueryEnabled: true,
+                filterExpressionsEnabled: false,
+            }),
+        );
         expect(getLatestMcpServerInstructions()).not.toContain(
             MCP_FILTER_EXPRESSION_GUIDANCE_SECTION,
         );
 
-        await mcpService.createServer({
-            runMetricQueryEnabled: true,
-            filterExpressionsEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runMetricQueryEnabled: true,
+                filterExpressionsEnabled: true,
+            }),
+        );
         expect(getLatestMcpServerInstructions()).toContain(
             MCP_FILTER_EXPRESSION_GUIDANCE_SECTION,
         );
@@ -292,18 +298,21 @@ describe('MCP tool contracts', () => {
         async ({ filterExpressionsEnabled }) => {
             const mcpService = makeMcpService();
 
-            await mcpService.createServer({
-                runSqlEnabled: true,
-                runMetricQueryEnabled: true,
-                filterExpressionsEnabled,
-            });
+            await mcpService.createServer(
+                makeMcpServerOptions({
+                    runSqlEnabled: true,
+                    runMetricQueryEnabled: true,
+                    filterExpressionsEnabled,
+                }),
+            );
 
             expect(getLatestMcpServerInstructions()).toMatchSnapshot();
         },
     );
 
-    it('covers every boolean server configuration exactly once', () => {
-        const expectedCount = 2 ** Object.keys(disabledMcpOptions).length;
+    it('covers every instruction/filter configuration exactly once', () => {
+        const expectedCount =
+            2 ** Object.keys(defaultMcpAnalystPromptOptions).length;
         expect(mcpOptionCombinations).toHaveLength(expectedCount);
         expect(
             new Set(
@@ -312,13 +321,18 @@ describe('MCP tool contracts', () => {
         ).toBe(expectedCount);
     });
 
-    it.each(mcpOptionCombinations)(
-        'guards MCP text lengths: pinned=$projectPinned content=$mcpContentWritesEnabled scheduled=$scheduledDeliveryEnabled sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
+    it.each(
+        mcpOptionCombinations.map((options) => ({
+            ...registrationOnlyFeatures,
+            ...options,
+        })),
+    )(
+        'guards MCP text lengths: sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
         async (options) => {
             const configuration = JSON.stringify(options);
             const mcpService = makeMcpService();
             mockRegisteredMcpTools.length = 0;
-            await mcpService.createServer(options);
+            await mcpService.createServer(makeMcpServerOptions(options));
             const instructionCeilings = options.runSqlEnabled
                 ? { structured: 5483, expression: 9192 }
                 : { structured: 4659, expression: 8368 };
@@ -394,10 +408,12 @@ describe('MCP tool contracts', () => {
 
         mockRegisteredMcpTools.length = 0;
         mockRegisteredMcpPrompts.length = 0;
-        await mcpService.createServer({
-            runSqlEnabled: true,
-            runMetricQueryEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runSqlEnabled: true,
+                runMetricQueryEnabled: true,
+            }),
+        );
 
         const prompts = mockRegisteredMcpPrompts.map(({ name, config }) => ({
             name,
@@ -434,10 +450,12 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            runSqlEnabled: false,
-            runMetricQueryEnabled: false,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runSqlEnabled: false,
+                runMetricQueryEnabled: false,
+            }),
+        );
 
         const registeredNames = mockRegisteredMcpTools.map(({ name }) => name);
         expect(registeredNames).not.toContain(McpToolName.LIST_EXPLORES);
@@ -455,10 +473,12 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            runSqlEnabled: true,
-            runMetricQueryEnabled: false,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runSqlEnabled: true,
+                runMetricQueryEnabled: false,
+            }),
+        );
 
         const registeredNames = mockRegisteredMcpTools.map(({ name }) => name);
         expect(registeredNames).toContain(McpToolName.RUN_SQL);
@@ -471,10 +491,12 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            runMetricQueryEnabled: true,
-            filterExpressionsEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runMetricQueryEnabled: true,
+                filterExpressionsEnabled: true,
+            }),
+        );
 
         const registered = mockRegisteredMcpTools.find(
             ({ name }) => name === McpToolName.RUN_METRIC_QUERY,
@@ -497,10 +519,12 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            runMetricQueryEnabled: true,
-            filterExpressionsEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runMetricQueryEnabled: true,
+                filterExpressionsEnabled: true,
+            }),
+        );
 
         const registered = mockRegisteredMcpTools.find(
             ({ name }) => name === McpToolName.SEARCH_FIELD_VALUES,
@@ -529,10 +553,28 @@ describe('MCP tool contracts', () => {
         }).toMatchSnapshot();
     });
 
+    it.each([undefined, '00000000-0000-4000-8000-000000000001'])(
+        'derives project-switching availability from pinnedProjectUuid=%s',
+        async (pinnedProjectUuid) => {
+            const mcpService = makeMcpService();
+            mockRegisteredMcpTools.length = 0;
+            await mcpService.createServer(
+                makeMcpServerOptions({}, pinnedProjectUuid),
+            );
+            const names = mockRegisteredMcpTools.map(({ name }) => name);
+            expect(names.includes(McpToolName.LIST_PROJECTS)).toBe(
+                pinnedProjectUuid === undefined,
+            );
+            expect(names.includes(McpToolName.SET_PROJECT)).toBe(
+                pinnedProjectUuid === undefined,
+            );
+        },
+    );
+
     it('registers generate_hashes without project scope', async () => {
         const mcpService = makeMcpService();
 
-        await mcpService.createServer();
+        await mcpService.createServer(makeMcpServerOptions());
 
         expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
             McpToolName.GENERATE_HASHES,
@@ -543,9 +585,11 @@ describe('MCP tool contracts', () => {
     it('requires projectUuid on every project-scoped tool', async () => {
         const mcpService = makeMcpService();
 
-        await mcpService.createServer({
-            runSqlEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                runSqlEnabled: true,
+            }),
+        );
 
         const toolsByName = new Map(
             mockRegisteredMcpTools.map((tool) => [tool.name, tool]),
@@ -570,13 +614,17 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({ runSqlEnabled: true });
+        await mcpService.createServer(
+            makeMcpServerOptions({ runSqlEnabled: true }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
             McpToolName.RUN_SQL,
         );
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({ runSqlEnabled: false });
+        await mcpService.createServer(
+            makeMcpServerOptions({ runSqlEnabled: false }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
             McpToolName.RUN_SQL,
         );
@@ -586,13 +634,17 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({ runMetricQueryEnabled: true });
+        await mcpService.createServer(
+            makeMcpServerOptions({ runMetricQueryEnabled: true }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
             McpToolName.RUN_METRIC_QUERY,
         );
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({ runMetricQueryEnabled: false });
+        await mcpService.createServer(
+            makeMcpServerOptions({ runMetricQueryEnabled: false }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
             McpToolName.RUN_METRIC_QUERY,
         );
@@ -757,10 +809,12 @@ describe('MCP tool contracts', () => {
         const mcpService = makeMcpService();
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            mcpContentWritesEnabled: false,
-            scheduledDeliveryEnabled: true,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                mcpContentWritesEnabled: false,
+                scheduledDeliveryEnabled: true,
+            }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).not.toContain(
             McpToolName.CREATE_CONTENT,
         );
@@ -772,10 +826,12 @@ describe('MCP tool contracts', () => {
         );
 
         mockRegisteredMcpTools.length = 0;
-        await mcpService.createServer({
-            mcpContentWritesEnabled: true,
-            scheduledDeliveryEnabled: false,
-        });
+        await mcpService.createServer(
+            makeMcpServerOptions({
+                mcpContentWritesEnabled: true,
+                scheduledDeliveryEnabled: false,
+            }),
+        );
         expect(mockRegisteredMcpTools.map(({ name }) => name)).toContain(
             McpToolName.CREATE_CONTENT,
         );

--- a/packages/backend/src/routers/mcpRouter.authorization.test.ts
+++ b/packages/backend/src/routers/mcpRouter.authorization.test.ts
@@ -227,12 +227,14 @@ describe('MCP tool catalogue activity', () => {
 
         expect(response.status).toBe(200);
         expect(mcpService.recordToolList).toHaveBeenCalledWith({
-            catalogue: expect.objectContaining({
-                projectPinned: false,
-                runSqlEnabled: false,
-                runMetricQueryEnabled: false,
-                filterExpressionsEnabled: true,
-            }),
+            catalogue: {
+                req: { pinnedProjectUuid: undefined },
+                featureAvailability: expect.objectContaining({
+                    runSqlEnabled: false,
+                    runMetricQueryEnabled: false,
+                    filterExpressionsEnabled: true,
+                }),
+            },
             authInfo: expect.objectContaining({ clientId: 'API key' }),
             durationMs: expect.any(Number),
         });
@@ -351,12 +353,12 @@ describe('project-scoped MCP route', () => {
         expect(mcpService.isFilterExpressionsEnabled).toHaveBeenCalledWith(
             expect.objectContaining({ userUuid: 'user-uuid' }),
         );
-        expect(mcpService.createServer).toHaveBeenCalledWith(
-            expect.objectContaining({
-                projectPinned: true,
+        expect(mcpService.createServer).toHaveBeenCalledWith({
+            req: { pinnedProjectUuid: PROJECT_UUID },
+            featureAvailability: expect.objectContaining({
                 filterExpressionsEnabled: true,
             }),
-        );
+        });
         expect(transport.handleRequest).toHaveBeenCalledOnce();
     });
 });

--- a/packages/backend/src/routers/mcpRouter.ts
+++ b/packages/backend/src/routers/mcpRouter.ts
@@ -397,12 +397,14 @@ mcpRouter.all(
                     mcpService.isFilterExpressionsEnabled(req.user!),
                 ]);
                 const toolOptions: McpServerToolOptions = {
-                    projectPinned: pinnedProjectUuid !== undefined,
-                    mcpContentWritesEnabled,
-                    scheduledDeliveryEnabled,
-                    runSqlEnabled,
-                    runMetricQueryEnabled,
-                    filterExpressionsEnabled,
+                    req: { pinnedProjectUuid },
+                    featureAvailability: {
+                        mcpContentWritesEnabled,
+                        scheduledDeliveryEnabled,
+                        runSqlEnabled,
+                        runMetricQueryEnabled,
+                        filterExpressionsEnabled,
+                    },
                 };
                 const mcpServer = await mcpService.createServer(toolOptions);
                 const transport = new StreamableHTTPServerTransport({


### PR DESCRIPTION
Separate request scope (req.pinnedProjectUuid) from required featureAvailability booleans. Check only the eight SQL/metric/filter combinations that change text, with optional tools enabled. Preserve authorization and the existing audit-record format.

Risk: high — request-scope wiring changes; human review required. Verified 134 tests, typecheck, lint/format, and snapshot freshness.