### PR TITLE
fix(ai): separate Agent and MCP query guidance

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -6161,34 +6161,7 @@ Input modes:
 
 If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
 
-This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
-
-Response shape (MCP CallToolResult):
-- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
-- If the query finishes before the MCP wait window, structuredContent: {
-    result: {
-      status: "done",
-      queryUuid: string,
-      rows: Array<Record<string, unknown>>,
-      fields: Record<string, unknown>,
-      exploreUrl: string | null
-    }
-  }
-- If the query is still running, structuredContent: {
-    result: {
-      status: "running",
-      queryUuid: string,
-      nextPollAfterMs: number,
-      heartbeatAt: string
-    }
-  }
-  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
-
-Notes:
-- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
-- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
-- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
-",
+The tool handles execution and chart artifacts. It returns a result summary and CSV data when data access is enabled. For empty results, follow the returned guidance. Correct validation or execution errors before retrying.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -7926,48 +7899,13 @@ custom metrics are applied automatically.
     },
   },
   {
-    "description": "Execute an arbitrary SQL query against the project's data warehouse and return the results. The platform already gives the user a way to continue this exact query in SQL Runner — do not add your own SQL Runner link in the final answer text; a link you write in prose cannot be scoped to a specific query and will point at the wrong one if this tool is called more than once in a turn.
+    "description": "Execute a read-only SQL query against the project's data warehouse. Prefer the semantic layer when it can answer the question; use SQL for ad-hoc analysis or queries the semantic layer cannot express.
 
-Use this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.
-This is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.
-If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, prefer run_metric_query and then render_chart when the request fits the semantic layer. render_chart does not support run_sql results.
+Use a valid SELECT statement in the connected warehouse's SQL dialect.
+The tool handles execution and returns a row/column summary, plus a CSV preview when data access is enabled. Empty results report zero rows. Correct validation or execution errors before retrying.
 
-The query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).
-
-Parameters:
-- sql: The SQL query to execute. Must be a valid SELECT statement.
-- limit: Maximum number of rows to return (default 500, max 500).
-
-Response shape (MCP CallToolResult):
-- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return CSV with a header row plus data rows. Empty results return prose text like "Query returned 0 rows."; running queries return polling status text; errors return an error message.
-- If the query finishes before the MCP wait window, structuredContent: {
-    result: {
-      status: "done",
-      rows:     Array<Record<string, unknown>>,  // each row keyed by column name
-      columns:  string[],                        // column names in order
-      rowCount: number,                          // total rows returned
-      sqlRunnerUrl: string | null                // shareable URL to inspect/edit the SQL in SQL Runner
-    }
-  }
-- If the query is still running, structuredContent: {
-    result: {
-      status: "running",
-      queryUuid: string,
-      nextPollAfterMs: number,
-      heartbeatAt: string
-    }
-  }
-  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
-
-Notes:
-- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
-- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
-- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
-- Values in rows are JSON-serializable primitives: numbers, strings, booleans, ISO date strings, or null. They are NOT pre-stringified — there's no need for parseFloat / parseInt on numeric columns.
-- Empty results still return structuredContent.result with { status: "done", rows: [], columns, rowCount: 0, sqlRunnerUrl } — distinct from a parse failure.
-- Lightdash applies the requested row limit to the SQL query. Ensure the SELECT statement is complete; malformed trailing SQL can surface errors near the generated LIMIT.
-- On startup/validation/application/warehouse error, the response has isError: true and content[0].text contains the error message; structuredContent is omitted.
-",
+The row limit defaults to 500, max 500.
+Do not invent SQL Runner links.",
     "inputSchema": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "additionalProperties": false,
@@ -9403,34 +9341,7 @@ exports[`AI agent tool contracts > matches the filter-expression visualization c
 
 If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
 
-This tool returns metric query data only. If the user asked for a visual, or if a chart would make the answer easier to understand than raw rows alone, call render_chart after run_metric_query returns done.
-
-Response shape (MCP CallToolResult):
-- content: [{ type: "text", text: string }] — human-readable fallback. Completed queries return bare CSV text. CSV headers are display labels, not stable field IDs; running queries return polling status text; errors return an error message.
-- If the query finishes before the MCP wait window, structuredContent: {
-    result: {
-      status: "done",
-      queryUuid: string,
-      rows: Array<Record<string, unknown>>,
-      fields: Record<string, unknown>,
-      exploreUrl: string | null
-    }
-  }
-- If the query is still running, structuredContent: {
-    result: {
-      status: "running",
-      queryUuid: string,
-      nextPollAfterMs: number,
-      heartbeatAt: string
-    }
-  }
-  Use get_query_result with this queryUuid to poll until the query is done. heartbeatAt is an ISO timestamp for the latest Lightdash check that confirmed the query is still running.
-
-Notes:
-- Some clients expose structuredContent; others only expose content text plus isError. Prefer structuredContent.result when present. Otherwise parse content text and use isError as the success/failure signal.
-- This tool waits up to ~50s server-side. If unfinished, call get_query_result again with queryUuid after nextPollAfterMs. Warehouse execution timeout comes from the Lightdash warehouse connection, not MCP. Client/transport timeouts are retryable with the same queryUuid.
-- Validation errors fail before a query starts and should be fixed, not retried. Application errors and warehouse execution errors are terminal until the request is corrected.
-
+The tool handles execution and chart artifacts. It returns a result summary and CSV data when data access is enabled. For empty results, follow the returned guidance. Correct validation or execution errors before retrying.
 Filter expressions use \`<fieldId> <operator>[=<value>...]\`. The input schema defines category placement and nullability; for supported operators, quoting, arity, connectors, and examples, follow the Lightdash Agent system prompt.",
   "inputSchema": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/ai/tools/agentToolContracts.snapshot.test.ts
@@ -72,7 +72,10 @@ const sharedAgentToolDefinitionNames = agentToolDefinitions.map(
     (toolDefinition) => toolDefinition.for('agent').name,
 );
 
-const makeAgentTools = (enableFilterExpressions = false) => {
+const makeAgentTools = (
+    enableFilterExpressions = false,
+    enableMergeQueries = true,
+) => {
     const noop = vi.fn();
     const noopAsync = vi.fn().mockResolvedValue(undefined);
 
@@ -173,7 +176,7 @@ const makeAgentTools = (enableFilterExpressions = false) => {
         generateVisualization: getGenerateVisualization({
             createOrUpdateArtifact: noop,
             enableDataAccess: true,
-            enableMergeQueries: true,
+            enableMergeQueries,
             enableFilterExpressions,
             getPrompt: noop,
             maxLimit: 500,
@@ -230,6 +233,38 @@ const makeAgentTools = (enableFilterExpressions = false) => {
 };
 
 describe('AI agent tool contracts', () => {
+    it.each(
+        [false, true].flatMap((enableFilterExpressions) =>
+            [false, true].map((enableMergeQueries) => ({
+                enableFilterExpressions,
+                enableMergeQueries,
+            })),
+        ),
+    )(
+        'keeps MCP polling out of Agent query guidance: expressions=$enableFilterExpressions merge=$enableMergeQueries',
+        ({ enableFilterExpressions, enableMergeQueries }) => {
+            const { generateVisualization, runSql } = makeAgentTools(
+                enableFilterExpressions,
+                enableMergeQueries,
+            );
+            for (const description of [
+                generateVisualization.description,
+                runSql.description,
+                agentToolDefinitionsByName.runQuery.for('agent').description,
+                agentToolDefinitionsByName.runSql.for('agent').description,
+            ]) {
+                expect(description).toContain('execution');
+                expect(description).not.toMatch(
+                    /get_query_result|render_chart|structuredContent|nextPollAfterMs|heartbeatAt|~50s/,
+                );
+            }
+            expect(generateVisualization.description).toContain(
+                'queryConfig.parameters',
+            );
+            expect(runSql.description).toContain('max 500');
+        },
+    );
+
     it('matches the shared agent tool definition names snapshot', () => {
         expect(sharedAgentToolDefinitionNames).toMatchSnapshot();
     });

--- a/packages/backend/src/ee/services/ai/tools/runSql.ts
+++ b/packages/backend/src/ee/services/ai/tools/runSql.ts
@@ -1,5 +1,5 @@
 import {
-    buildRunSqlDescription,
+    buildAgentRunSqlDescription,
     createToolRunSqlArgsSchema,
     isSlackPrompt,
     runSqlToolDefinition,
@@ -130,7 +130,7 @@ export const getRunSql = ({
     };
 
     return tool({
-        description: buildRunSqlDescription(500, maxQueryLimit),
+        description: buildAgentRunSqlDescription(500, maxQueryLimit),
         inputSchema,
         outputSchema: toolDefinition.outputSchema,
         toModelOutput: toolDefinition.toModelOutput,

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolDefinitions.ts
@@ -292,6 +292,7 @@ import {
     toolRunSavedChartOutputSchema,
 } from './toolRunSavedChartArgs';
 import {
+    buildAgentRunSqlDescription,
     buildRunSqlDescription,
     DEFAULT_RUN_SQL_LIMIT,
     DEFAULT_RUN_SQL_MAX_LIMIT,
@@ -664,10 +665,16 @@ export const runSqlToolDefinition: ToolDefinitionWithMcpOutput<
 > = defineTool({
     name: 'runSql',
     title: 'Run SQL',
-    description: buildRunSqlDescription(
-        DEFAULT_RUN_SQL_LIMIT,
-        DEFAULT_RUN_SQL_MAX_LIMIT,
-    ),
+    description: ({ runtime }) =>
+        (
+            ({
+                agent: buildAgentRunSqlDescription,
+                mcp: buildRunSqlDescription,
+            }) satisfies Record<
+                ToolDescriptionContext['runtime'],
+                typeof buildRunSqlDescription
+            >
+        )[runtime](DEFAULT_RUN_SQL_LIMIT, DEFAULT_RUN_SQL_MAX_LIMIT),
     availability: ['agent', 'mcp'],
     inputSchema: toolRunSqlArgsSchema,
     agent: { outputSchema: toolRunSqlOutputSchema },

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { MergeJoinType } from '../../../../types/mergeQuery';
+import assertUnreachable from '../../../../utils/assertUnreachable';
 import {
     customMetricsSchema,
     customMetricsSchemaTransformed,
@@ -278,17 +279,26 @@ export const isCustomChartTypeSlugChartConfig = (
 // the agent runtime has its own prompt and different sibling tool names.
 const MCP_RUN_QUERY_LEAD = `Run a governed metric query through the Lightdash semantic layer. Choose an explore and its metrics and dimensions (from grep_fields / get_metadata), add filters, sorts and a limit, and get consistent, centrally defined results. This is the preferred way to answer data questions and to reproduce a saved chart's query — prefer it over raw SQL whenever the fields exist in a modeled explore.`;
 
+const RUN_QUERY_PARAMETER_GUIDANCE = `If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.`;
+
 export const TOOL_RUN_QUERY_DESCRIPTION = ({
     runtime,
-}: ToolDescriptionContext): string => `${
-    runtime === 'mcp' ? MCP_RUN_QUERY_LEAD : 'Execute a metric query.'
-}
+}: ToolDescriptionContext): string => {
+    switch (runtime) {
+        case 'agent':
+            return `Execute a metric query.
 
-If any selected field is marked "requires parameters" in field discovery or metadata, set the right values in queryConfig.parameters — an unset parameter silently resolves to its default, which can make the query return data that does not match the question.
+${RUN_QUERY_PARAMETER_GUIDANCE}
+
+The tool handles execution and chart artifacts. It returns a result summary and CSV data when data access is enabled. For empty results, follow the returned guidance. Correct validation or execution errors before retrying.`;
+        case 'mcp':
+            return `${MCP_RUN_QUERY_LEAD}
+
+${RUN_QUERY_PARAMETER_GUIDANCE}
 
 This tool returns metric query data only. ${buildMcpVisualizationFollowUpInstruction(
-    'run_metric_query',
-)}
+                'run_metric_query',
+            )}
 
 ${buildMcpQueryRunResponseDescription({
     contentDescription:
@@ -305,6 +315,10 @@ ${buildMcpQueryRunResponseDescription({
 Notes:
 ${MCP_QUERY_COMMON_NOTES}
 `;
+        default:
+            return assertUnreachable(runtime, 'Unknown query tool runtime');
+    }
+};
 
 // Kept only for parsing historical persisted tool args.
 export const toolRunQueryArgsSchemaV1 = createToolSchema()

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
@@ -9,6 +9,17 @@ import {
 export const DEFAULT_RUN_SQL_LIMIT = 500;
 export const DEFAULT_RUN_SQL_MAX_LIMIT = 5000;
 
+export const buildAgentRunSqlDescription = (
+    defaultLimit: number,
+    maxLimit: number,
+) => `Execute a read-only SQL query against the project's data warehouse. Prefer the semantic layer when it can answer the question; use SQL for ad-hoc analysis or queries the semantic layer cannot express.
+
+Use a valid SELECT statement in the connected warehouse's SQL dialect.
+The tool handles execution and returns a row/column summary, plus a CSV preview when data access is enabled. Empty results report zero rows. Correct validation or execution errors before retrying.
+
+The row limit defaults to ${defaultLimit}, max ${maxLimit}.
+Do not invent SQL Runner links.`;
+
 export const buildRunSqlDescription = (
     defaultLimit: number,
     maxLimit: number,


### PR DESCRIPTION
Separate Agent query guidance from MCP transport guidance. Agent queries await results internally, so they must not be told to call unavailable polling or rendering tools. MCP descriptions, schemas, and execution remain unchanged.

Risk: high — model-facing query instructions change; human review required. Verified 139 tests, typecheck, package lint/format, and MCP snapshot freshness.