### PR TITLE
fix(learn): clear GuidedTour glide timers on unmount

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -562,10 +562,15 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     // The position transition is on only for a moment after a move starts,
     // so scroll and resize still track instantly afterwards.
     const [gliding, setGliding] = useState(false);
+    // Held so the timer is cleared on unmount: its callback sets state, and
+    // firing after teardown throws on a window that no longer exists.
+    const glideTimer = useRef<number | undefined>(undefined);
     const glideFor = useCallback((ms: number) => {
         setGliding(true);
-        window.setTimeout(() => setGliding(false), ms);
+        window.clearTimeout(glideTimer.current);
+        glideTimer.current = window.setTimeout(() => setGliding(false), ms);
     }, []);
+    useEffect(() => () => window.clearTimeout(glideTimer.current), []);
     // The ring effect below answers to the target rect alone: the beacon,
     // card phase and step it reads are mirrored into refs so a change in
     // any of them does not re-run it (a click's beacon must wait for the
@@ -609,10 +614,14 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             glidedForStepRef.current = stepIndexRef.current;
             glideFor(GLIDE_MS);
             expandTimeoutRef.current = window.setTimeout(() => {
-                expandTimeoutRef.current = null;
                 setCardRect(latestRectRef.current);
                 setCardPhase('expanding');
-                window.setTimeout(() => setCardPhase('shown'), CARD_EXPAND_MS);
+                // Chained onto the same ref, which the outer timer has just
+                // released, so unmount clears whichever is still pending.
+                expandTimeoutRef.current = window.setTimeout(() => {
+                    expandTimeoutRef.current = null;
+                    setCardPhase('shown');
+                }, CARD_EXPAND_MS);
             }, GLIDE_MS);
             return;
         }


### PR DESCRIPTION
Relates: #28793

### Description:

`GuidedTour`'s `glideFor` schedules a timer whose callback sets state, with no cleanup:

```ts
const glideFor = useCallback((ms: number) => {
    setGliding(true);
    window.setTimeout(() => setGliding(false), ms);   // never cleared
}, []);
```

It runs on step change, so walking a tour queues timers that can outlive the component. When one fires after a test file's jsdom teardown, the callback reaches a `window` that no longer exists:

```
ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom-client.development.js:1308
 ❯ dispatchSetState       react-dom-client.development.js:9126
 ❯ Timeout._onTimeout     GuidedTour.tsx:528
   originated in src/components/common/GuidedTour/GuidedTour.test.tsx
```

Whether the timer outlives teardown is a race, so it surfaces as an **intermittent failure on unrelated pull requests** — every test passes and the run still fails on the unhandled error. It hit lightdash/lightdash#28872 (a backend-only PR) earlier today. In the browser the same leak sets state on an unmounted component.

This holds the handle in a ref, clears it before re-scheduling and on unmount.

**A second instance of the same fault** is fixed alongside it: the nested timer after the card expansion called `setCardPhase` and was never tracked. It's now chained onto the existing `expandTimeoutRef` — which the outer timer has released by that point — so the existing unmount cleanup covers whichever is still pending.

### On verification — please read

**I could not reproduce the race locally, and I don't want to imply I did.** Stashing the fix and running `GuidedTour.test.tsx` 8× on unfixed code came back clean every time; the race needs whole-suite teardown timing that a single file doesn't recreate. The evidence for the fix is the stack trace above (which lands exactly on the `glideFor` line) plus the code itself, not a local red-to-green.

What I did verify:

- `pnpm -F frontend test src/components/common/GuidedTour/GuidedTour.test.tsx` — 8/8 pass
- full `pnpm -F frontend test` — **485/486 files, and no `window is not defined` anywhere in the output**
- format, lint, typecheck — clean

The one non-passing file in that full run is `CustomVisConfig.test.tsx`, which dies at worker level during import (`tests 0ms`, V8 heap allocation trace). It fails identically on **unmodified `main`** with this fix reverted, so it is a pre-existing issue in my sandbox and unrelated to this change.

### Risk assessment:

- [ ] This is a high-risk change

Six lines in one component, adding cleanup where there was none. No behaviour change while mounted: the timer is cleared before re-scheduling, which was already the effective behaviour since the callback only sets a flag false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTrjgVZidS2EnD49Xox8yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTrjgVZidS2EnD49Xox8yj)_