### PR TITLE
feat(learn): enable Learn per organization through feature flags

### DIFF
--- a/docs/learn/architecture.md
+++ b/docs/learn/architecture.md
@@ -22,7 +22,8 @@ Code is the reference for anything finer-grained. Specs live in Linear (CS-207, 
   `data-tour-*` markers beside the permission checks that gate them; a build-time script reads those markers and
   the docs repository and writes each walkthrough's steps as data. The library, the titles, the explanatory text
   and the checks that enforce the rules all derive from that.
-- **Off by default.** `LIGHTDASH_LEARN_ENABLED` (config `learn.enabled`) turns the whole thing on. When it is off
+- **Off by default.** The `enable-learn` feature flag turns Learn on per organization through the Console.
+  Self-hosted operators add it to `LIGHTDASH_ENABLE_FEATURE_FLAGS`; previews enable it automatically. When it is off
   there is no Learn icon, no page, no endpoints and no permission layer, even if a training project already
   exists.
 
@@ -121,7 +122,7 @@ engineering sense: no branch, nothing to promote.
 | No real data reachable                            | embedded read-only DuckDB file, SELECT-only gate, no filesystem or network functions |
 | No way outside the copy                           | trainee set excludes deliveries, sheets, git, source, external connections; agents in training refuse Slack and MCP; moving an agent checks the destination |
 | One copy per learner, bounded lifetime            | per-user advisory lock, cooldown, 24 h expiry, app files deleted with the copy |
-| Nothing shows when Learn is off                   | `learn.enabled` gates the icon, page, endpoints and the permission layer   |
+| Nothing shows when Learn is off                   | `enable-learn` gates the icon, page, endpoints and the permission layer    |
 
 ## Traps
 
@@ -140,8 +141,8 @@ engineering sense: no branch, nothing to promote.
 - **A fresh checkout serves stale routes.** `routes.ts` is committed only by the release workflow; run
   `pnpm -F backend generate-api` after checking out a branch that adds the Learn endpoints, or every one of them
   answers 404. The Rainbow recipe does this in its build.
-- **`LIGHTDASH_LEARN_ENABLED` off is total.** No icon, no page, no endpoints and no trainee scopes, even with a
-  training project in the database. An instance that looks like "Learn vanished" almost always has the switch off.
+- **`enable-learn` off closes Learn for the organization.** No icon, no page, no endpoints and no trainee scopes,
+  even with a training project in the database. Cached session abilities expire on their existing TTL.
 
 ## Where it is going
 
@@ -154,4 +155,5 @@ module" route (CS-258, CS-259), and progress stored server-side rather than in t
 
 Stack 1 (PRs #28710 to #28716) carries the type, the permission layer and copies, the seeded content, the tour
 kit, the host and generator, the library, and Enable Learn. Walkthrough content follows in further pull requests.
-Merging the stack changes nothing on an instance until `LIGHTDASH_LEARN_ENABLED=true` is set.
+Learn remains off until `enable-learn` is enabled for the organization in the Console, or added to
+`LIGHTDASH_ENABLE_FEATURE_FLAGS` on self-hosted instances. Previews enable the flag automatically.

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -468,9 +468,6 @@ export const lightdashConfigMock: LightdashConfig = {
         bufferMaxSize: 10000,
         s3: null,
     },
-    learn: {
-        enabled: false,
-    },
     appRuntime: {
         enabled: false,
         dataAppCodingAgent: 'claude',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1829,14 +1829,6 @@ export type LightdashConfig = {
     dashboardComments: {
         enabled: boolean;
     };
-    /**
-     * Learn: the training project and its walkthroughs (CS-257). Off by
-     * default; switched on per instance with LIGHTDASH_LEARN_ENABLED=true,
-     * then enabled per org by an admin from the Learn page.
-     */
-    learn: {
-        enabled: boolean;
-    };
     preAggregates: {
         enabled: boolean;
         parquetEnabled: boolean;
@@ -3714,9 +3706,6 @@ export const parseConfig = (): LightdashConfig => {
         },
         dashboardComments: {
             enabled: process.env.DISABLE_DASHBOARD_COMMENTS !== 'true',
-        },
-        learn: {
-            enabled: process.env.LIGHTDASH_LEARN_ENABLED === 'true',
         },
         softDelete: {
             enabled: process.env.SOFT_DELETE_ENABLED === 'true',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -1131,7 +1131,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         provisionTrainingProject({
                             user,
                             projectService,
-                            learnEnabled: context.lightdashConfig.learn.enabled,
+                            featureFlagModel: models.getFeatureFlagModel(),
                             projectModel: models.getProjectModel(),
                             onboardingModel: models.getOnboardingModel(),
                             catalogService: repository.getCatalogService(),

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -147,6 +147,65 @@ const buildFakeWriteDatabase = ({
 };
 
 describe('FeatureFlagModel', () => {
+    describe('Learn', () => {
+        it('is off by default', async () => {
+            const model = buildModel({}, buildFakeDatabase({}));
+            await expect(
+                model.get({
+                    user: dbUser,
+                    featureFlagId: FeatureFlags.EnableLearn,
+                }),
+            ).resolves.toEqual({
+                id: FeatureFlags.EnableLearn,
+                enabled: false,
+            });
+        });
+
+        it.each([true, false])(
+            'honors an organization override of %s',
+            async (enabled) => {
+                const model = buildModel(
+                    {},
+                    buildFakeDatabase({
+                        flag: { default_enabled: false },
+                        orgOverride: { enabled },
+                    }),
+                );
+                await expect(
+                    model.get({
+                        user: dbUser,
+                        featureFlagId: FeatureFlags.EnableLearn,
+                    }),
+                ).resolves.toEqual({ id: FeatureFlags.EnableLearn, enabled });
+            },
+        );
+
+        it('can be enabled through the self-hosted allowlist', async () => {
+            const model = buildModel({
+                enabledFeatureFlags: new Set([FeatureFlags.EnableLearn]),
+            });
+            await expect(
+                model.get({
+                    user: dbUser,
+                    featureFlagId: FeatureFlags.EnableLearn,
+                }),
+            ).resolves.toEqual({ id: FeatureFlags.EnableLearn, enabled: true });
+        });
+
+        it('is enabled automatically in previews', async () => {
+            const model = buildModel(
+                { previewFeatureFlags: { enabled: true } },
+                buildFakeDatabase({}),
+            );
+            await expect(
+                model.get({
+                    user: dbUser,
+                    featureFlagId: FeatureFlags.EnableLearn,
+                }),
+            ).resolves.toEqual({ id: FeatureFlags.EnableLearn, enabled: true });
+        });
+    });
+
     describe('check telemetry', () => {
         beforeEach(() => {
             vi.mocked(record).mockReset();

--- a/packages/backend/src/models/UserModel.test.ts
+++ b/packages/backend/src/models/UserModel.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@casl/ability';
 import {
     CommercialFeatureFlags,
+    FeatureFlags,
     LightdashMode,
     LightdashUser,
     MemberAbility,
@@ -103,7 +104,6 @@ const lightdashConfig = {
     },
     license: {},
     customRoles: { enabled: false },
-    learn: { enabled: true },
     rudder: {},
 } as unknown as LightdashConfig;
 
@@ -448,14 +448,27 @@ describe('UserModel', () => {
             role_uuid: undefined,
         };
 
-        const createHumanModel = () => {
+        const createHumanModel = (learnEnabled = true) => {
             const model = new UserModel({
                 database: vi.fn() as unknown as Knex,
                 lightdashConfig: {
                     ...lightdashConfig,
                     customRoles: { enabled: true },
                 } as LightdashConfig,
-                featureFlagModel,
+                featureFlagModel: {
+                    get: vi.fn(
+                        async ({
+                            featureFlagId,
+                        }: {
+                            featureFlagId: string;
+                        }) => ({
+                            id: featureFlagId,
+                            enabled:
+                                featureFlagId === FeatureFlags.EnableLearn &&
+                                learnEnabled,
+                        }),
+                    ),
+                } as unknown as FeatureFlagModel,
             }) as unknown as TestableUserModel;
             model.hasAuthentication = vi.fn(async () => true);
             model.getTrainingProjects = vi.fn(async () => []);
@@ -480,6 +493,21 @@ describe('UserModel', () => {
             model.applyServiceAccountProjectMemberships = vi.fn(async () => {});
             return model;
         };
+
+        it('does not grant trainee scopes when the org Learn flag is off', async () => {
+            const model = createHumanModel(false);
+            const { abilityBuilder } =
+                await model.generateUserAbilityBuilder(humanDetails);
+            expect(model.getTrainingProjects).not.toHaveBeenCalled();
+            expect(
+                abilityBuilder.build().can(
+                    'manage',
+                    subject('PinnedItems', {
+                        projectUuid: 'training-copy',
+                    }),
+                ),
+            ).toBe(false);
+        });
 
         it('grants the trainee layer on the org training project only', async () => {
             const model = createHumanModel();

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -8,6 +8,7 @@ import {
     CommercialFeatureFlags,
     CreateUserArgs,
     CreateUserWithRole,
+    FeatureFlags,
     ForbiddenError,
     getAllScopesForRole,
     getTrainingProjectScopes,
@@ -1159,25 +1160,35 @@ export class UserModel {
         ].filter((roleUuid): roleUuid is string => Boolean(roleUuid));
         const isEnterprise =
             this.lightdashConfig.license.licenseKey !== undefined;
-        const [customRoleScopes, customRolesFlag, patScopeAuthoritativeFlag] =
-            await Promise.all([
-                this.customRoleScopes(customRoleUuids, trx),
-                this.featureFlagModel.get(
-                    {
-                        user: lightdashUser,
-                        featureFlagId: CommercialFeatureFlags.CustomRoles,
-                    },
-                    { trx },
-                ),
-                this.featureFlagModel.get(
-                    {
-                        user: lightdashUser,
-                        featureFlagId:
-                            CommercialFeatureFlags.PatScopeAuthoritative,
-                    },
-                    { trx },
-                ),
-            ]);
+        const [
+            customRoleScopes,
+            customRolesFlag,
+            patScopeAuthoritativeFlag,
+            learnFlag,
+        ] = await Promise.all([
+            this.customRoleScopes(customRoleUuids, trx),
+            this.featureFlagModel.get(
+                {
+                    user: lightdashUser,
+                    featureFlagId: CommercialFeatureFlags.CustomRoles,
+                },
+                { trx },
+            ),
+            this.featureFlagModel.get(
+                {
+                    user: lightdashUser,
+                    featureFlagId: CommercialFeatureFlags.PatScopeAuthoritative,
+                },
+                { trx },
+            ),
+            this.featureFlagModel.get(
+                {
+                    user: lightdashUser,
+                    featureFlagId: FeatureFlags.EnableLearn,
+                },
+                { trx },
+            ),
+        ]);
 
         // Narrow empty-role resolution: only the flagged enterprise human's
         // primary org role uuid is checked for existence when it has no
@@ -1228,6 +1239,7 @@ export class UserModel {
             user.user_uuid,
             isEnterprise,
             abilityBuilder,
+            learnFlag.enabled,
             trx,
         );
 
@@ -1304,11 +1316,12 @@ export class UserModel {
         userUuid: string,
         isEnterprise: boolean,
         builder: AbilityBuilder<MemberAbility>,
+        learnEnabled: boolean,
         trx: Knex = this.database,
     ): Promise<void> {
-        // Learn off for the instance: no trainee scopes, even if a training
+        // Learn off for the org: no trainee scopes, even if a training
         // project is left over, so switching off also closes the sandbox.
-        if (!this.lightdashConfig.learn.enabled) return;
+        if (!learnEnabled) return;
         const trainingProjects = await this.getTrainingProjects(
             organizationId,
             userUuid,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -157,9 +157,6 @@ export const BaseResponse: HealthState = {
     preAggregates: {
         enabled: false,
     },
-    learn: {
-        enabled: false,
-    },
     dataApps: {
         previewOrigin: null,
         sampleDataEnabled: true,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -306,9 +306,6 @@ export class HealthService extends BaseService {
             preAggregates: {
                 enabled: this.lightdashConfig.preAggregates.enabled,
             },
-            learn: {
-                enabled: this.lightdashConfig.learn.enabled,
-            },
             dataApps: {
                 previewOrigin: this.lightdashConfig.appRuntime.previewOrigin,
                 sampleDataEnabled:

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -411,6 +411,7 @@ const getMockedProjectService = (
             ConstructorParameters<typeof ProjectService>[0],
             | 'spacePermissionService'
             | 'provisionPlaygroundProject'
+            | 'provisionTrainingProject'
             | 'downloadFileModel'
             | 'getAiAgentService'
             | 'organizationWarehouseCredentialsModel'
@@ -459,7 +460,9 @@ const getMockedProjectService = (
         encryptionUtil: {
             encrypt: vi.fn(() => Buffer.from('encrypted-project-data')),
         } as unknown as EncryptionUtil,
-        userModel: {} as UserModel,
+        userModel: {
+            invalidateSessionUserCache: vi.fn(),
+        } as unknown as UserModel,
         userOAuthGrantsModel: {} as UserOAuthGrantsModel,
         featureFlagModel:
             overrides.featureFlagModel ??
@@ -508,6 +511,7 @@ const getMockedProjectService = (
             }),
         } as never,
         provisionPlaygroundProject: overrides.provisionPlaygroundProject,
+        provisionTrainingProject: overrides.provisionTrainingProject,
         getAiAgentService: overrides.getAiAgentService,
         getDataAppCustomSqlProvenance:
             overrides.getDataAppCustomSqlProvenance ??
@@ -566,6 +570,105 @@ type RefreshForTest = <T>(
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
     const service = getMockedProjectService(lightdashConfigMock);
+
+    describe('Learn flag guards', () => {
+        const learnUser: SessionUser = {
+            ...user,
+            organizationUuid: 'organization-uuid',
+            organizationName: 'Organization',
+            organizationCreatedAt: new Date('2026-09-01'),
+        };
+
+        test('provisions training for an org admin when Learn is enabled', async () => {
+            const provisionTrainingProject = vi.fn(async () => ({
+                projectUuid: 'training-project',
+                created: true,
+            }));
+            const learnService = getMockedProjectService(lightdashConfigMock, {
+                featureFlagModel: {
+                    get: vi.fn(async () => ({
+                        id: FeatureFlags.EnableLearn,
+                        enabled: true,
+                    })),
+                } as unknown as FeatureFlagModel,
+                provisionTrainingProject,
+            });
+            const adminUser = {
+                ...learnUser,
+                ability: new Ability<PossibleAbilities>([
+                    { action: 'manage', subject: 'Organization' },
+                ]),
+            };
+            await expect(learnService.enableLearn(adminUser)).resolves.toEqual({
+                projectUuid: 'training-project',
+                created: true,
+            });
+            expect(provisionTrainingProject).toHaveBeenCalledExactlyOnceWith({
+                user: adminUser,
+                projectService: learnService,
+            });
+        });
+        test.each(['enable', 'copy', 'delete'] as const)(
+            'blocks %s when the requesting org has Learn disabled',
+            async (operation) => {
+                const get = vi.fn(async () => ({
+                    id: FeatureFlags.EnableLearn,
+                    enabled: false,
+                }));
+                const provisionTrainingProject = vi.fn();
+                const learnService = getMockedProjectService(
+                    lightdashConfigMock,
+                    {
+                        featureFlagModel: {
+                            get,
+                        } as unknown as FeatureFlagModel,
+                        provisionTrainingProject,
+                    },
+                );
+                const operations = {
+                    enable: () => learnService.enableLearn(learnUser),
+                    copy: () =>
+                        learnService.createTrainingPreview(
+                            learnUser,
+                            'training-project',
+                        ),
+                    delete: () =>
+                        learnService.deleteTrainingPreviews(
+                            learnUser,
+                            'training-project',
+                        ),
+                };
+                await expect(operations[operation]()).rejects.toThrow(
+                    'Learn is not enabled for this organization',
+                );
+                expect(get).toHaveBeenCalledExactlyOnceWith({
+                    user: learnUser,
+                    featureFlagId: FeatureFlags.EnableLearn,
+                });
+                expect(provisionTrainingProject).not.toHaveBeenCalled();
+            },
+        );
+
+        test('still requires org admin permissions when Learn is enabled', async () => {
+            const provisionTrainingProject = vi.fn();
+            const learnService = getMockedProjectService(lightdashConfigMock, {
+                featureFlagModel: {
+                    get: vi.fn(async () => ({
+                        id: FeatureFlags.EnableLearn,
+                        enabled: true,
+                    })),
+                } as unknown as FeatureFlagModel,
+                provisionTrainingProject,
+            });
+            await expect(
+                learnService.enableLearn({
+                    ...learnUser,
+                    ability: new Ability<PossibleAbilities>([]),
+                }),
+            ).rejects.toThrow('Only an organization admin can enable Learn');
+            expect(provisionTrainingProject).not.toHaveBeenCalled();
+        });
+    });
 
     describe('MotherDuck instance cache enablement', () => {
         test.each([

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -768,12 +768,10 @@ export class ProjectService extends BaseService {
     /**
      * Enable Learn for the user's organization (CS-257): create the training
      * project, seeded, with the caller as its assigned admin. Idempotent.
-     * Org admins only; 404 when the instance has Learn switched off.
+     * Org admins only; 404 when the org has Learn switched off.
      */
     async enableLearn(user: SessionUser): Promise<EnableLearnResults> {
-        if (!this.lightdashConfig.learn.enabled) {
-            throw new NotFoundError('Learn is not enabled on this instance');
-        }
+        await this.assertLearnEnabled(user);
         if (!this.provisionTrainingProject) {
             throw new NotFoundError('Learn is not available');
         }
@@ -11264,10 +11262,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         trainingProjectUuid: string,
     ): Promise<CreateTrainingPreviewResults> {
-        // Learn off for the instance closes the sandbox: no copies either.
-        if (!this.lightdashConfig.learn.enabled) {
-            throw new NotFoundError('Learn is not enabled on this instance');
-        }
+        await this.assertLearnEnabled(user);
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
@@ -11417,6 +11412,21 @@ export class ProjectService extends BaseService {
 
     private static readonly TRAINING_PREVIEW_EXPIRES_IN_HOURS = 24;
 
+    private async assertLearnEnabled(user: SessionUser): Promise<void> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        const { enabled } = await this.featureFlagModel.get({
+            user,
+            featureFlagId: FeatureFlags.EnableLearn,
+        });
+        if (!enabled) {
+            throw new NotFoundError(
+                'Learn is not enabled for this organization',
+            );
+        }
+    }
+
     /**
      * Remove the caller's own copies of the training project (a finished or
      * abandoned walkthrough). Other learners' copies are untouched.
@@ -11425,9 +11435,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         trainingProjectUuid: string,
     ): Promise<{ deleted: number }> {
-        if (!this.lightdashConfig.learn.enabled) {
-            throw new NotFoundError('Learn is not enabled on this instance');
-        }
+        await this.assertLearnEnabled(user);
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.test.ts
@@ -1,5 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
+    FeatureFlags,
     OrganizationMemberRole,
     ProjectMemberRole,
     ProjectType,
@@ -84,10 +85,14 @@ const buildArguments = (
     const seedTrainingContent = vi.fn(async () => undefined);
     const validateTrainingDatabase = vi.fn(async () => undefined);
     const track = vi.fn();
+    const getFeatureFlag = vi.fn(async () => ({
+        id: FeatureFlags.EnableLearn,
+        enabled: true,
+    }));
     return {
         args: {
             user,
-            learnEnabled: true,
+            featureFlagModel: { get: getFeatureFlag },
             projectModel: {
                 getAllByOrganizationUuid,
                 delete: deleteProject,
@@ -115,16 +120,26 @@ const buildArguments = (
         indexCatalog,
         seedTrainingContent,
         track,
+        getFeatureFlag,
     };
 };
 
 describe('provisionTrainingProject', () => {
-    it('refuses when Learn is switched off for the instance', async () => {
-        const mocks = buildArguments({ learnEnabled: false });
+    it('refuses when Learn is switched off for the organization', async () => {
+        const mocks = buildArguments();
+        mocks.getFeatureFlag.mockResolvedValueOnce({
+            id: FeatureFlags.EnableLearn,
+            enabled: false,
+        });
         await expect(provisionTrainingProject(mocks.args)).rejects.toThrow(
-            'Learn is not enabled on this instance',
+            'Learn is not enabled for this organization',
         );
         expect(mocks.createWithoutCompile).not.toHaveBeenCalled();
+        expect(mocks.runInTrainingProvisioningLock).not.toHaveBeenCalled();
+        expect(mocks.getFeatureFlag).toHaveBeenCalledExactlyOnceWith({
+            user,
+            featureFlagId: FeatureFlags.EnableLearn,
+        });
         expect(mocks.track).toHaveBeenCalledExactlyOnceWith(
             expect.objectContaining({
                 event: 'training_project.skipped',

--- a/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
+++ b/packages/backend/src/services/ProjectService/provisionTrainingProject.ts
@@ -2,6 +2,7 @@ import {
     DbtProjectType,
     DefaultSupportedDbtVersion,
     DuckdbConnectionType,
+    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     ProjectMemberRole,
@@ -23,6 +24,7 @@ import {
     validatePlaygroundDatabaseBundle,
 } from '../../ee/services/ProjectService/provisionPlaygroundProject';
 import Logger from '../../logging/logger';
+import { type FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { type OnboardingModel } from '../../models/OnboardingModel/OnboardingModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { type CatalogService } from '../CatalogService/CatalogService';
@@ -40,7 +42,7 @@ export type SeedTrainingContentArguments = {
 
 export type ProvisionTrainingProjectArguments = {
     user: SessionUser;
-    learnEnabled: boolean;
+    featureFlagModel: Pick<FeatureFlagModel, 'get'>;
     projectModel: Pick<
         ProjectModel,
         | 'getAllByOrganizationUuid'
@@ -82,7 +84,7 @@ const describe = (error: unknown): string =>
  */
 export const provisionTrainingProject = async ({
     user,
-    learnEnabled,
+    featureFlagModel,
     projectModel,
     onboardingModel,
     projectService,
@@ -108,9 +110,13 @@ export const provisionTrainingProject = async ({
             properties: { organizationId: organizationUuid, projectId, reason },
         });
     };
+    const { enabled: learnEnabled } = await featureFlagModel.get({
+        user,
+        featureFlagId: FeatureFlags.EnableLearn,
+    });
     if (!learnEnabled) {
         trackSkipped('learn_disabled', null);
-        throw new NotFoundError('Learn is not enabled on this instance');
+        throw new NotFoundError('Learn is not enabled for this organization');
     }
     if (!user.email) {
         throw new ForbiddenError(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -971,8 +971,7 @@ export class ServiceRepository
                         provisionTrainingProject({
                             user,
                             projectService,
-                            learnEnabled:
-                                this.context.lightdashConfig.learn.enabled,
+                            featureFlagModel: this.models.getFeatureFlagModel(),
                             projectModel: this.models.getProjectModel(),
                             onboardingModel: this.models.getOnboardingModel(),
                             catalogService: this.getCatalogService(),

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -769,14 +769,6 @@ export type HealthState = {
     preAggregates: {
         enabled: boolean;
     };
-    learn: {
-        /**
-         * Whether Learn (the training project and its walkthroughs) is
-         * switched on for this instance (`LIGHTDASH_LEARN_ENABLED`). Off by
-         * default; an org admin still has to enable it for their org.
-         */
-        enabled: boolean;
-    };
     dataApps: {
         /**
          * Origin where data-app preview iframes are served (e.g.,

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -87,6 +87,8 @@ export enum FeatureFlags {
      * is true. Disabled by default.
      */
     EnableDataApps = 'enable-data-apps',
+    // Enable the Learn library, walkthroughs and training project per org.
+    EnableLearn = 'enable-learn',
 
     /**
      * Per-organization gate for declaring custom npm dependencies in data

--- a/packages/frontend/src/features/learn/LearnLink.test.tsx
+++ b/packages/frontend/src/features/learn/LearnLink.test.tsx
@@ -1,0 +1,55 @@
+import { FeatureFlags, ProjectType } from '@lightdash/common';
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LearnLink } from './LearnLink';
+
+const mocks = vi.hoisted(() => ({
+    useServerFeatureFlag: vi.fn(),
+    useProjects: vi.fn(),
+}));
+
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: mocks.useServerFeatureFlag,
+}));
+vi.mock('../../hooks/useProjects', () => ({
+    useProjects: mocks.useProjects,
+}));
+
+describe('LearnLink', () => {
+    afterEach(cleanup);
+
+    it.each([
+        { enabled: undefined, type: ProjectType.DEFAULT, visible: false },
+        { enabled: false, type: ProjectType.DEFAULT, visible: false },
+        { enabled: true, type: ProjectType.DEFAULT, visible: true },
+        { enabled: true, type: ProjectType.PREVIEW, visible: false },
+    ])(
+        'renders with flag $enabled on $type: $visible',
+        ({ enabled, type, visible }) => {
+            mocks.useServerFeatureFlag.mockReturnValue({
+                data:
+                    enabled === undefined
+                        ? undefined
+                        : { id: FeatureFlags.EnableLearn, enabled },
+            });
+            mocks.useProjects.mockReturnValue({
+                data: [{ projectUuid: 'project', type }],
+            });
+            render(
+                <MantineProvider>
+                    <MemoryRouter>
+                        <LearnLink projectUuid="project" />
+                    </MemoryRouter>
+                </MantineProvider>,
+            );
+            expect(
+                screen.queryByRole('button', { name: 'Learn' }) !== null,
+            ).toBe(visible);
+            expect(mocks.useServerFeatureFlag).toHaveBeenCalledWith(
+                FeatureFlags.EnableLearn,
+            );
+        },
+    );
+});

--- a/packages/frontend/src/features/learn/LearnLink.tsx
+++ b/packages/frontend/src/features/learn/LearnLink.tsx
@@ -1,27 +1,27 @@
-import { ProjectType } from '@lightdash/common';
+import { FeatureFlags, ProjectType } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine/core';
 import { IconSchool } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useNavigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
-import useHealth from '../../hooks/health/useHealth';
 import { useProjects } from '../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 
 /**
  * Navbar entry to the library, an icon beside notifications and help;
- * present for everyone on an instance with Learn switched on, whether or
- * not the org has enabled it yet (the page says how), and never on a
+ * present for everyone in an org with the Learn flag on, whether or
+ * not the training project exists yet (the page says how), and never on a
  * preview (a learner's training copy included): a library opened inside a
  * copy would start walkthroughs from the wrong place.
  */
 export const LearnLink: FC<{ projectUuid: string }> = ({ projectUuid }) => {
     const navigate = useNavigate();
-    const { data: health } = useHealth();
+    const { data: learnFlag } = useServerFeatureFlag(FeatureFlags.EnableLearn);
     const { data: projects } = useProjects();
     const current = projects?.find(
         (project) => project.projectUuid === projectUuid,
     );
-    if (!health?.learn.enabled || current?.type === ProjectType.PREVIEW)
+    if (!learnFlag?.enabled || current?.type === ProjectType.PREVIEW)
         return null;
     return (
         <Tooltip label="Learn" position="bottom" withinPortal>

--- a/packages/frontend/src/features/learn/LearnPage.test.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.test.tsx
@@ -8,11 +8,11 @@ import { EventName } from '../../types/Events';
 import { buildLearnCatalogue } from './catalogue';
 import LearnPage from './LearnPage';
 
-const { track, projectState, healthState, availabilityState, accessState } =
+const { track, projectState, learnFlagState, availabilityState, accessState } =
     vi.hoisted(() => ({
         track: vi.fn(),
         projectState: { current: [] as unknown[] },
-        healthState: { current: { learn: { enabled: true } } },
+        learnFlagState: { current: { enabled: true }, isLoading: false },
         availabilityState: { current: { isSettled: true } },
         // Everything the learner can do, anywhere.
         accessState: { current: [] as string[] },
@@ -52,8 +52,11 @@ vi.mock('./useLearnAccess', async () => {
     };
 });
 
-vi.mock('../../hooks/health/useHealth', () => ({
-    default: () => ({ data: healthState.current }),
+vi.mock('../../hooks/useServerOrClientFeatureFlag', () => ({
+    useServerFeatureFlag: () => ({
+        data: learnFlagState.current,
+        isLoading: learnFlagState.isLoading,
+    }),
 }));
 
 vi.mock('../../hooks/useProjects', () => ({
@@ -105,7 +108,8 @@ describe('LearnPage analytics', () => {
     beforeEach(() => {
         localStorage.clear();
         track.mockClear();
-        healthState.current = { learn: { enabled: true } };
+        learnFlagState.current = { enabled: true };
+        learnFlagState.isLoading = false;
         availabilityState.current = { isSettled: true };
         accessState.current = scopes;
         projectState.current = [
@@ -187,7 +191,7 @@ describe('LearnPage analytics', () => {
     });
 
     it('records nothing when Learn is switched off for the instance', () => {
-        healthState.current = { learn: { enabled: false } };
+        learnFlagState.current = { enabled: false };
 
         renderPage();
 
@@ -201,7 +205,7 @@ describe('LearnPage access', () => {
     beforeEach(() => {
         localStorage.clear();
         track.mockClear();
-        healthState.current = { learn: { enabled: true } };
+        learnFlagState.current = { enabled: true };
         availabilityState.current = { isSettled: true };
         accessState.current = ['view:Dashboard', 'manage:Validation'];
         projectState.current = [

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { ProjectType } from '@lightdash/common';
+import { FeatureFlags, ProjectType } from '@lightdash/common';
 import {
     Box,
     Button,
@@ -27,9 +27,9 @@ import {
 import { Navigate } from 'react-router';
 import MantineIcon from '../../components/common/MantineIcon';
 import { getGreeting } from '../../ee/features/homepageBuilder/greeting';
-import useHealth from '../../hooks/health/useHealth';
 import { useOptionalProjectRoute } from '../../hooks/useProjectRoute';
 import { useProjects } from '../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
@@ -147,7 +147,8 @@ const ModuleCard: FC<{
  */
 const LearnPage: FC = () => {
     const { user } = useApp();
-    const { data: health } = useHealth();
+    const { data: learnFlag, isLoading: isLearnFlagLoading } =
+        useServerFeatureFlag(FeatureFlags.EnableLearn);
     const { data: projects } = useProjects();
     const trainingProject = projects?.find(
         (project) => project.type === ProjectType.TRAINING,
@@ -276,8 +277,8 @@ const LearnPage: FC = () => {
     const trackedViewRef = useRef(false);
     useEffect(() => {
         if (trackedViewRef.current) return;
-        if (!projects || !health || !isSettled) return;
-        if (previewRedirect || !health.learn.enabled) return;
+        if (!projects || !learnFlag || !isSettled) return;
+        if (previewRedirect || !learnFlag.enabled) return;
         trackedViewRef.current = true;
         track({
             name: EventName.LEARN_LIBRARY_VIEWED,
@@ -299,7 +300,7 @@ const LearnPage: FC = () => {
         });
     }, [
         projects,
-        health,
+        learnFlag,
         isSettled,
         previewRedirect,
         organizationUuid,
@@ -310,10 +311,10 @@ const LearnPage: FC = () => {
         track,
     ]);
 
-    if (previewRedirect) return <Navigate to={previewRedirect} replace />;
-    // Learn switched off for the instance: the route falls through to the
+    if (isLearnFlagLoading) return null;
+    // Learn switched off for the org: the route falls through to the
     // project's home.
-    if (health && !health.learn.enabled) {
+    if (!learnFlag?.enabled) {
         return (
             <Navigate
                 to={
@@ -325,6 +326,7 @@ const LearnPage: FC = () => {
             />
         );
     }
+    if (previewRedirect) return <Navigate to={previewRedirect} replace />;
     if (projects && !trainingProject) {
         return (
             <EnableLearnPanel

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -151,9 +151,6 @@ export default function mockHealthResponse(
         preAggregates: {
             enabled: false,
         },
-        learn: {
-            enabled: false,
-        },
         dataApps: {
             previewOrigin: null,
             sampleDataEnabled: true,

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -77,10 +77,6 @@ EMAIL_SMTP_SENDER_EMAIL = "noreply@lightdash.local"
 # PR mode implies this (docs/preview-feature-flags.md); kept explicit so a
 # later mode change cannot silently drop the flag-management API.
 LIGHTDASH_PREVIEW_FEATURE_FLAGS_ENABLED = "true"
-# Learn is off by default everywhere (docs/learn/architecture.md); previews
-# exist to try unreleased work, so switch it on here and let an admin press
-# Enable Learn in the environment.
-LIGHTDASH_LEARN_ENABLED = "true"
 # No product analytics from previews. The backend's config bakes in a default
 # RudderStack write key and data plane, so without this every environment
 # tracks into production analytics — and the migrate rung's node process


### PR DESCRIPTION
### Description

Learn currently requires an instance environment variable, so operators cannot enable it for individual organizations from the Console. Replace that gate with `FeatureFlags.EnableLearn` (`enable-learn`) throughout the UI, training provisioning, preview-copy endpoints, and trainee permissions.

The flag is off by default, configurable per organization through the existing flag system, and automatically enabled in previews. Self-hosted operators can add `enable-learn` to `LIGHTDASH_ENABLE_FEATURE_FLAGS`. Remove `LIGHTDASH_LEARN_ENABLED` and the obsolete health-response field with no legacy fallback; the old variable was used only on the internal instance.

Preserves org-admin checks for provisioning and gates library-view analytics with the same flag. Cached session abilities retain the existing 30-second TTL.

### Validation

- On the rebased commit: 306 backend tests passed across flag resolution, provisioning, endpoint guards, health, and trainee permissions; 13 frontend tests passed covering Learn navigation visibility and library analytics/access behavior.
- Frontend tests use the repository-pinned Node 24.18 (`fnm exec --using 24.18.0 pnpm -F frontend test src/features/learn/LearnLink.test.tsx src/features/learn/LearnPage.test.tsx --maxWorkers=1 --testTimeout=30000`).
- Full backend/frontend typechecks and common/warehouses builds passed on the rebased commit. Changed-file lint, formatting, and API generation passed before rebasing; the updated Learn page lint has no errors and one existing array-sort warning.
- Live Docker and Rainbow flows have not been exercised. Generated API artifacts are excluded from the commit per repository policy.

### Risk assessment

- [ ] This is a high-risk change

Existing authorization checks remain in place; this changes their feature gate to the standard organization-aware flag resolver. The internal instance must enable `enable-learn` when adopting this change.
