### PR TITLE
fix(embed): restore standalone chart project access

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,4 +1,4 @@
-import { Ability } from '@casl/ability';
+import { Ability, subject } from '@casl/ability';
 import {
     ConflictError,
     convertExplores,
@@ -43,6 +43,7 @@ import {
     type CreateWarehouseCredentials,
     type DbtManifest,
     type DownloadFile,
+    type EmbedContent,
     type Explore,
     type ExploreError,
     type Job,
@@ -61,6 +62,7 @@ import { warehouseClientFromCredentials } from '@lightdash/warehouses';
 import { Readable } from 'stream';
 import { gunzipSync } from 'zlib';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromJwt } from '../../auth/account/account';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
@@ -694,6 +696,50 @@ describe('ProjectService', () => {
     });
 
     describe('getProject', () => {
+        const embedAccountFor = (content: EmbedContent) =>
+            fromJwt({
+                decodedToken: {
+                    content:
+                        content.type === 'chart'
+                            ? {
+                                  type: 'chart',
+                                  contentId: content.chartUuids[0],
+                              }
+                            : { type: 'dashboard', dashboardUuid: 'dashboard' },
+                },
+                content,
+                embed: {
+                    organization: {
+                        organizationUuid:
+                            projectWithSensitiveFields.organizationUuid,
+                        name: 'Test organization',
+                    },
+                    projectUuid,
+                    encodedSecret: 'test-secret',
+                    dashboardUuids: ['dashboard'],
+                    allowAllDashboards: false,
+                    chartUuids: ['chart'],
+                    allowAllCharts: false,
+                    appUuids: [],
+                    allowAllApps: false,
+                    createdAt: '2026-01-01',
+                    user: {
+                        userUuid: 'user',
+                        firstName: 'Test',
+                        lastName: 'User',
+                    },
+                },
+                source: 'test-token',
+                userAttributes: {
+                    userAttributes: {},
+                    intrinsicUserAttributes: {},
+                },
+            });
+        const chartAccount = embedAccountFor({
+            type: 'chart',
+            chartUuids: ['chart'],
+            explores: ['orders'],
+        });
         const projectWithEnvironment: Project = {
             ...projectWithSensitiveFields,
             dbtConnection: {
@@ -725,40 +771,104 @@ describe('ProjectService', () => {
             ]);
         });
 
-        test('returns only render settings to embed tokens', async () => {
-            projectModel.get.mockResolvedValueOnce({
-                ...projectWithEnvironment,
-                warehouseConnection: {
+        test.each([
+            ['chart', chartAccount],
+            [
+                'dashboard',
+                embedAccountFor({
+                    type: 'dashboard',
+                    dashboardUuid: 'dashboard',
+                    chartUuids: [],
+                    explores: [],
+                }),
+            ],
+        ])(
+            'returns only render settings to %s embed tokens',
+            async (_type, embedAccount) => {
+                projectModel.get.mockResolvedValueOnce({
+                    ...projectWithEnvironment,
+                    warehouseConnection: {
+                        type: WarehouseTypes.SNOWFLAKE,
+                        account: 'acme-prod.eu-west-1',
+                        role: 'ANALYTICS_READER',
+                        database: 'PROD',
+                        warehouse: 'WH_SMALL',
+                        schema: 'REPORTING',
+                        startOfWeek: WeekDay.SUNDAY,
+                    },
+                });
+                const result = await service.getProject(
+                    projectUuid,
+                    embedAccount,
+                );
+
+                expect(result.warehouseConnection).toEqual({
                     type: WarehouseTypes.SNOWFLAKE,
-                    account: 'acme-prod.eu-west-1',
-                    role: 'ANALYTICS_READER',
-                    database: 'PROD',
-                    warehouse: 'WH_SMALL',
-                    schema: 'REPORTING',
                     startOfWeek: WeekDay.SUNDAY,
-                },
-            });
-            const jwtAccount = buildAccount({ accountType: 'jwt' });
-            const embedAccount = {
-                ...jwtAccount,
-                user: {
-                    ...jwtAccount.user,
-                    ability: new Ability<PossibleAbilities>([
-                        { subject: 'Project', action: ['update', 'view'] },
-                    ]),
-                },
-            } as typeof jwtAccount;
+                });
+                expect(result.dbtConnection).toEqual({
+                    type: DbtProjectType.NONE,
+                });
+                expect(result.createdByUserUuid).toBeNull();
+            },
+        );
 
-            const result = await service.getProject(projectUuid, embedAccount);
+        test.each([
+            { projectUuid: 'another-project' },
+            { organizationUuid: 'another-organization' },
+        ])(
+            'rejects chart embeds outside their target: %j',
+            async (overrides) => {
+                const project = { ...projectWithEnvironment, ...overrides };
+                projectModel.get.mockResolvedValueOnce(project);
+                await expect(
+                    service.getProject(project.projectUuid, chartAccount),
+                ).rejects.toThrow(ForbiddenError);
+            },
+        );
 
-            expect(result.warehouseConnection).toEqual({
-                type: WarehouseTypes.SNOWFLAKE,
-                startOfWeek: WeekDay.SUNDAY,
-            });
-            expect(result.dbtConnection).toEqual({
-                type: DbtProjectType.NONE,
-            });
-            expect(result.createdByUserUuid).toBeNull();
+        test('keeps chart token query permissions restricted to its explore', () => {
+            const { ability } = chartAccount.user;
+            for (const type of ['Project', 'Explore'] as const) {
+                for (const [exploreName, allowed] of [
+                    ['orders', true],
+                    ['customers', false],
+                ] as const) {
+                    expect(
+                        ability.can(
+                            'view',
+                            subject(type, {
+                                organizationUuid:
+                                    projectWithSensitiveFields.organizationUuid,
+                                projectUuid,
+                                exploreNames: [exploreName],
+                            }),
+                        ),
+                    ).toBe(allowed);
+                }
+            }
+        });
+
+        test('does not grant chart embeds project-wide explore or table listing', async () => {
+            await expect(
+                service.getAllExploresSummary(chartAccount, projectUuid, false),
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                service.getTablesConfiguration(chartAccount, projectUuid),
+            ).rejects.toThrow(ForbiddenError);
+        });
+
+        test('does not bypass a missing Project grant', async () => {
+            projectModel.get.mockResolvedValueOnce(projectWithEnvironment);
+            await expect(
+                service.getProject(projectUuid, {
+                    ...chartAccount,
+                    user: {
+                        ...chartAccount.user,
+                        ability: new Ability<PossibleAbilities>([]),
+                    },
+                }),
+            ).rejects.toThrow(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2703,6 +2703,10 @@ export class ProjectService extends BaseService {
         const projectSubject = subject('Project', {
             organizationUuid: project.organizationUuid,
             projectUuid,
+            exploreNames:
+                isJwtUser(account) && account.access.content.type === 'chart'
+                    ? account.access.content.explores
+                    : undefined,
         });
         if (auditedAbility.cannot('view', projectSubject)) {
             throw new ForbiddenError();


### PR DESCRIPTION
Closes: [PROD-11073](https://linear.app/lightdash/issue/PROD-11073)
Closes: #28860

### Description:

Restore standalone chart embeds that display “You don't have access to this resource or action”.

Chart JWTs constrain project access to the chart's resolved explores, but `getProject` checked a subject without explore names. The required project fetch introduced in #28037 exposed this older mismatch from #18022; the recent embed permission modes did not introduce it.

- Include the server-resolved chart explore context in `getProject`'s permission check, only for chart JWTs (four production lines).
- Keep target project/organization checks and sanitized embed project responses unchanged.
- Preserve chart/explore restrictions; do not add an unrestricted project grant.
- Replace the unrestricted embed test mock with real JWT abilities and cover authorization boundaries.

### Testing:

- Reproduced on main: project endpoint returned 403 while the same chart JWT returned 200 for saved chart and account endpoints; browser displayed permission denied.
- Regression test failed before the fix and passed afterward.
- All 209 ProjectService tests passed, including chart/dashboard render settings, cross-project/cross-organization denial, missing grants, and restricted explore/table access.
- Backend typecheck and lint passed; diff sanity check passed.
- Live browser: the original chart JWT now renders the saved chart.
- Live API: allowed explore succeeds; unrelated chart/explore and project-wide explore listing remain forbidden. Dashboard and AI project access succeeds in both default and roles modes.
- Applied an existing pending migration to the isolated local database to enable chart execution; no migration or generated API changes are included in this PR.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: a narrow, tested restoration of intended chart-embed project access. The existing query ability conditions, target project/organization boundaries, and response sanitization remain intact. No API contract, permission-mode, or database schema changes.
