### PR TITLE
fix(embed): enforce scopes-only dashboard roles mode

### DIFF
--- a/.context/PERMISSIONS.md
+++ b/.context/PERMISSIONS.md
@@ -353,12 +353,12 @@ ability.can(
 
 | Content | Omitted / `'default'` | `'roles'` |
 | --- | --- | --- |
-| Dashboard | JWT flags and their defaults only | JWT flags OR actor embed scopes |
+| Dashboard | JWT flags and their defaults only | Actor embed scopes only |
 | AI agent | Existing AI prerequisites | Existing AI prerequisites AND `view:EmbedAiAgent` |
 
 The mode is signed into the JWT. `'jwt'` and `'legacy'` are not accepted aliases.
-AI default does not mean unconditional access. Dashboard role mode is additive:
-to control a capability solely through its scope, set its JWT flag to false.
+AI default does not mean unconditional access. Dashboard role mode ignores
+capability flags and their defaults, including PDF export's enabled default.
 
 Dashboard scopes are considered only when `writeActions.permissionsMode` is
 `'roles'` and the embed JWT has a `writeActions` actor that
@@ -370,30 +370,28 @@ If there is no resolved write actor, use only the JWT values in the default
 mode; dashboard `'roles'` mode rejects the request. Do not use the embed
 creator, organization admin, or a default role as an implicit actor.
 
-In dashboard `'roles'` mode, legacy flags and scopes are combined with OR semantics.
+In dashboard `'roles'` mode, only the actor's embed scopes grant capabilities.
 Omitted/`'default'` uses only JWT flags and their existing defaults:
 
 ```typescript
-const isAllowed =
-    jwtCapability === true ||
-    writeActorAbility.can(
-        'view',
-        subject('EmbedExplore', {
-            organizationUuid,
-            projectUuid,
-        }),
-    );
+const isAllowed = writeActorAbility.can(
+    'view',
+    subject('EmbedExplore', {
+        organizationUuid,
+        projectUuid,
+    }),
+);
 ```
 
-A JWT value of `false` must not override a granted scope. Conversely, adding a
-`writeActions` actor must not remove a capability that the JWT explicitly set
-to `true`.
+In `'roles'` mode, JWT values of `true`, `false`, and omitted all have the same
+effect: the scope decides. Adding a `writeActions` actor without selecting
+`'roles'` must not change JWT-based capability access.
 
 For structured legacy options, resolve the effective value centrally rather
 than scattering boolean checks through the UI. For example, the dashboard
 filter scope grants interactivity for all dashboard filters, while preserving
-hidden-filter presentation. Without that scope, retain the JWT's `enabled`
-and `allowedFilters` behavior.
+hidden-filter presentation. Without that scope, disable filter interactivity
+in role mode. Default mode retains the JWT's `enabled` and `allowedFilters` behavior.
 
 #### AI access: opt-in role-based authorization
 
@@ -433,8 +431,8 @@ service accounts and grant/revoke/re-grant using identical JWTs.
 Dashboard JWTs reuse `writeActions.permissionsMode`:
 
 - Omitted/`'default'`: JWT flags only, including PDF's enabled default.
-- `'roles'`: JWT flags OR the corresponding embed scopes.
-  True JWT flags still grant access when the scope is absent.
+- `'roles'`: only the corresponding embed scopes grant capabilities.
+  JWT flags and their defaults are ignored, including for PDF export.
   A write actor must resolve successfully; no implicit fallback actor is used.
 
 This applies to backend abilities, dashboard response capabilities, and
@@ -445,14 +443,14 @@ The mode does not change standalone chart, data app, or metrics catalog embeds.
 
 To opt in, issue dashboard tokens with `permissionsMode: 'roles'` under the
 existing `writeActions` user/service-account configuration. Change the actor's
-scopes and reload the same token to verify revocation/re-grant with flags false.
-Changing a role never revokes a true JWT flag. Tokens that omit the mode ignore
+scopes and reload the same token to verify revocation/re-grant with flags true,
+false, and omitted. Removing the last effective scope grant revokes the capability.
+Tokens that omit the mode ignore
 dashboard scopes; integrations must explicitly opt in. No data migration is required.
 
 For future dashboard capabilities, add independent scopes under
 `ScopeGroup.EMBED`, not new JWT capability booleans or per-feature enforcement
-switches. Keep existing flags for backward compatibility. External documentation
-are follow-up work after implementation and live validation.
+switches. Keep existing flags for backward compatibility in default mode.
 
 #### Implementation checklist for embed capabilities
 
@@ -484,27 +482,27 @@ are follow-up work after implementation and live validation.
    and the existing ability context on the frontend, using the embed target's
    identifiers. The account already serializes these ability rules. Do not add
    JWT flags, separate permission response objects, or frontend token overlays.
-6. For existing dashboard capabilities, retain JWT flags OR embed scopes.
+6. For existing dashboard capabilities, choose JWT flags or embed scopes by mode.
    The scope projection handles the mode centrally: default imports no
-   dashboard scopes, roles imports the actor's embed scopes. Do not gate or
-   disable existing JWT flags. New scope-only dashboard capabilities require
+   dashboard scopes, roles imports the actor's embed scopes. Ignore existing
+   JWT capability flags in roles mode. New scope-only dashboard capabilities require
    `'roles'` mode and the scope; do not add another JWT flag.
    Keep the JWT payload unchanged. Backend dashboard
-   responses retain their existing fields; combine scopes with flags there for
+   responses retain their existing fields; resolve the selected source there for
    existing UI consumers. Structured filters and parameters remain in the
-   existing account access fields. Preserve omitted-field defaults in both modes.
-7. Verify three cases: no write actor uses only the JWT; JWT `true` remains
-   allowed with an actor; JWT `false` plus a granted actor scope is allowed only
+   existing account access fields. Preserve omitted-field defaults in default mode only.
+7. Verify three cases: no write actor uses only the JWT in default mode; JWT `true`
+   without a scope is denied in roles mode; JWT `false` plus a granted actor scope is allowed only
    in `'roles'` mode and remains denied in omitted/`'default'` mode.
    Also verify at least one system role and one custom role through the embed
    UI. In dashboard role mode, also test true/false/omitted flags with scopes
    on/off, unresolved actors, structured controls, and UI/backend agreement.
 
 During the compatibility period, existing JWT fields are an API contract:
-keep accepting them, avoid changing their meaning, and document any eventual
+keep accepting them in default mode, and document any eventual
 removal through the normal deprecation and release-note process.
-In both modes, preserve omitted-field defaults too, including PDF export being enabled when
-`canExportPagePdf` is absent.
+In default mode, preserve omitted-field defaults, including PDF export being enabled when
+`canExportPagePdf` is absent. In roles mode, PDF export requires its scope.
 
 Organization and project role grants remain additive. To restrict an embed
 through a project custom role, avoid also granting the capability through the

--- a/packages/backend/src/auth/account/account.test.ts
+++ b/packages/backend/src/auth/account/account.test.ts
@@ -221,26 +221,29 @@ describe('account', () => {
                                         ability: actor.build(),
                                     },
                                 });
+                                const roleFilterInteractivity =
+                                    scope === 'EmbedDashboardFilters'
+                                        ? FilterInteractivityValues.all
+                                        : false;
                                 expect(result.access.filtering).toEqual({
                                     enabled:
-                                        permissionsMode === 'roles' &&
-                                        scope === 'EmbedDashboardFilters'
-                                            ? FilterInteractivityValues.all
+                                        permissionsMode === 'roles'
+                                            ? roleFilterInteractivity
                                             : enabled,
                                     allowedFilters: ['department'],
                                     hidden: true,
                                     canAddFilters:
-                                        enabled === true ||
-                                        (permissionsMode === 'roles' &&
-                                            scope ===
-                                                'EmbedDashboardFilterAddition'),
+                                        permissionsMode === 'roles'
+                                            ? scope ===
+                                              'EmbedDashboardFilterAddition'
+                                            : enabled === true,
                                 });
                                 expect(result.access.parameters).toEqual({
                                     enabled:
-                                        enabled === true ||
-                                        (permissionsMode === 'roles' &&
-                                            scope ===
-                                                'EmbedDashboardParameters'),
+                                        permissionsMode === 'roles'
+                                            ? scope ===
+                                              'EmbedDashboardParameters'
+                                            : enabled === true,
                                 });
                                 expect(result.access.controls).toEqual(
                                     mockUserAttributes,

--- a/packages/backend/src/auth/account/account.ts
+++ b/packages/backend/src/auth/account/account.ts
@@ -122,42 +122,33 @@ export const fromJwt = ({
     let parameters = isDashboardContent(decodedToken.content)
         ? decodedToken.content.parameterInteractivity
         : undefined;
-    if (isDashboardContent(decodedToken.content)) {
+    if (
+        isDashboardContent(decodedToken.content) &&
+        decodedToken.writeActions?.permissionsMode === 'roles'
+    ) {
         const target = {
             organizationUuid: embed.organization.organizationUuid,
             projectUuid: embed.projectUuid,
         };
-        if (
-            abilities.can(
+        filtering = {
+            ...filtering,
+            enabled: abilities.can(
                 'view',
                 subject('EmbedDashboardFilters', { ...target }),
             )
-        ) {
-            filtering = {
-                ...filtering,
-                enabled: FilterInteractivityValues.all,
-            };
-        }
-        if (
-            abilities.can(
+                ? FilterInteractivityValues.all
+                : false,
+            canAddFilters: abilities.can(
                 'view',
                 subject('EmbedDashboardFilterAddition', { ...target }),
-            )
-        ) {
-            filtering = {
-                ...filtering,
-                enabled: filtering?.enabled ?? false,
-                canAddFilters: true,
-            };
-        }
-        if (
-            abilities.can(
+            ),
+        };
+        parameters = {
+            enabled: abilities.can(
                 'view',
                 subject('EmbedDashboardParameters', { ...target }),
-            )
-        ) {
-            parameters = { enabled: true };
-        }
+            ),
+        };
     }
 
     return createAccount({

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.test.ts
@@ -141,8 +141,9 @@ describe('EmbedService', () => {
                                     ? (flag ?? true)
                                     : flag;
                             const expected =
-                                (permissionsMode === 'roles' && granted) ||
-                                jwtPermission;
+                                permissionsMode === 'roles'
+                                    ? granted
+                                    : jwtPermission;
                             expect(result[field]).toBe(expected);
                         }
                     }),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -621,6 +621,8 @@ export class EmbedService extends BaseService {
             throw new ParameterError('JWT content is not of type dashboard');
         }
         const { isPreview, stickyHeader } = decodedToken.content;
+        const useJwtPermissions =
+            decodedToken.writeActions?.permissionsMode !== 'roles';
         const ability = this.createAuditedAbility(account);
         const embedTarget = {
             organizationUuid: dashboard.organizationUuid,
@@ -630,36 +632,41 @@ export class EmbedService extends BaseService {
             ability.can(
                 'view',
                 subject('EmbedCsvExport', { ...embedTarget }),
-            ) || decodedToken.content.canExportCsv;
+            ) ||
+            (useJwtPermissions && decodedToken.content.canExportCsv);
         const canExportDashboardCsv =
             ability.can(
                 'view',
                 subject('EmbedDashboardCsvExport', { ...embedTarget }),
-            ) || decodedToken.content.canExportDashboardCsv;
+            ) ||
+            (useJwtPermissions && decodedToken.content.canExportDashboardCsv);
         const canExportImages =
             ability.can(
                 'view',
                 subject('EmbedImageExport', { ...embedTarget }),
-            ) || decodedToken.content.canExportImages;
+            ) ||
+            (useJwtPermissions && decodedToken.content.canExportImages);
         const canExportPagePdf =
             ability.can(
                 'view',
                 subject('EmbedPagePdfExport', { ...embedTarget }),
-            ) || decodedToken.content.canExportPagePdf;
+            ) ||
+            (useJwtPermissions && decodedToken.content.canExportPagePdf);
         const canDateZoom =
             ability.can('view', subject('EmbedDateZoom', { ...embedTarget })) ||
-            decodedToken.content.canDateZoom;
+            (useJwtPermissions && decodedToken.content.canDateZoom);
         const canExplore =
             ability.can('view', subject('EmbedExplore', { ...embedTarget })) ||
-            decodedToken.content.canExplore;
+            (useJwtPermissions && decodedToken.content.canExplore);
         const canViewUnderlyingData =
             ability.can(
                 'view',
                 subject('EmbedUnderlyingData', { ...embedTarget }),
-            ) || decodedToken.content.canViewUnderlyingData;
+            ) ||
+            (useJwtPermissions && decodedToken.content.canViewUnderlyingData);
         const canViewDataApps =
             ability.can('view', subject('EmbedDataApps', { ...embedTarget })) ||
-            decodedToken.content.canViewDataApps;
+            (useJwtPermissions && decodedToken.content.canViewDataApps);
         // Embed paletteUuid query param overrides everything; otherwise fall back
         // through chart → dashboard → space → project → org via the resolver.
         let selectedPalette: {

--- a/packages/common/src/authorization/embedPermissions.test.ts
+++ b/packages/common/src/authorization/embedPermissions.test.ts
@@ -296,10 +296,9 @@ describe.each([undefined, 'default', 'roles'] as const)(
                                     }),
                                 ),
                             ).toBe(
-                                legacy === true ||
-                                    (permissionsMode === 'roles' &&
-                                        hasActor &&
-                                        granted),
+                                permissionsMode === 'roles'
+                                    ? hasActor && granted
+                                    : legacy === true,
                             );
                             expect(token).toEqual(original);
                         }

--- a/packages/common/src/authorization/jwtAbility.ts
+++ b/packages/common/src/authorization/jwtAbility.ts
@@ -39,6 +39,8 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
 }) => {
     const { organization } = embed;
     const { can } = builder;
+    const useJwtPermissions =
+        embedUser.writeActions?.permissionsMode !== 'roles';
 
     can('view', 'Dashboard', {
         dashboardUuid: content.dashboardUuid,
@@ -47,7 +49,7 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
 
     if (
         embedUser.content.type === 'dashboard' &&
-        (embedUser.content.canDateZoom ||
+        ((useJwtPermissions && embedUser.content.canDateZoom) ||
             canViewEmbedScope('EmbedDateZoom', builder, embed))
     ) {
         can('view', 'Dashboard', {
@@ -66,15 +68,11 @@ const dashboardAbilities: EmbeddedAbilityBuilder = ({
         projectUuid: embed.projectUuid,
     });
 
-    // Data app tiles require an explicit opt-in on the JWT — same trust
-    // model as canExplore. Off by default, the data app tile renders as a
-    // "not authorized" placeholder. With the flag set, the customer is
-    // accepting that the embed user can run the app's metric queries and use
-    // its admin-linked external connections. Metric queries remain filtered
-    // by the JWT's user attributes via getFilteredExplore.
+    // Data app access permits metric queries and admin-linked external connections.
+    // Queries remain filtered by the JWT's user attributes via getFilteredExplore.
     if (
         embedUser.content.type === 'dashboard' &&
-        (embedUser.content.canViewDataApps ||
+        ((useJwtPermissions && embedUser.content.canViewDataApps) ||
             canViewEmbedScope('EmbedDataApps', builder, embed))
     ) {
         can('view', 'Explore', {
@@ -239,12 +237,18 @@ const exploreAbilities: EmbeddedAbilityBuilder = ({
     const { content: permissions } = embedUser;
     const { organization } = embed;
     const { can } = builder;
+    const useJwtPermissions =
+        !isDashboardContent(permissions) ||
+        embedUser.writeActions?.permissionsMode !== 'roles';
 
     const canExplore =
-        ('canExplore' in permissions && permissions.canExplore) ||
+        (useJwtPermissions &&
+            'canExplore' in permissions &&
+            permissions.canExplore) ||
         canViewEmbedScope('EmbedExplore', builder, embed);
     const canViewUnderlyingData =
-        ('canViewUnderlyingData' in permissions &&
+        (useJwtPermissions &&
+            'canViewUnderlyingData' in permissions &&
             permissions.canViewUnderlyingData) ||
         canViewEmbedScope('EmbedUnderlyingData', builder, embed);
 
@@ -275,6 +279,9 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
     const { content: permissions } = embedUser;
     const { organization } = embed;
     const { can } = builder;
+    const useJwtPermissions =
+        !isDashboardContent(permissions) ||
+        embedUser.writeActions?.permissionsMode !== 'roles';
 
     if (!isDashboardContent(permissions) && !isChartContent(permissions)) {
         return { embedUser, content, embed, externalId, builder };
@@ -285,7 +292,7 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
 
     // Common abilities for both dashboard and chart
     if (
-        permissions.canExportImages ||
+        (useJwtPermissions && permissions.canExportImages) ||
         canViewEmbedScope('EmbedImageExport', builder, embed)
     ) {
         can('export', subjectType, {
@@ -295,7 +302,7 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
     }
 
     if (
-        permissions.canExportCsv ||
+        (useJwtPermissions && permissions.canExportCsv) ||
         canViewEmbedScope('EmbedCsvExport', builder, embed)
     ) {
         can('export', subjectType, {
@@ -311,7 +318,7 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
     // Dashboard specific abilities
     if (isDashboardContent(embedUser.content)) {
         if (
-            embedUser.content.canExportPagePdf ||
+            (useJwtPermissions && embedUser.content.canExportPagePdf) ||
             canViewEmbedScope('EmbedPagePdfExport', builder, embed)
         ) {
             can('export', 'Dashboard', {
@@ -323,7 +330,7 @@ const exportAbilities: EmbeddedAbilityBuilder = ({
         // Dashboard-level "Export all", scoped to the token's dashboard; the
         // JobStatus grant lets the embed poll the async export job it created.
         if (
-            embedUser.content.canExportDashboardCsv ||
+            (useJwtPermissions && embedUser.content.canExportDashboardCsv) ||
             canViewEmbedScope('EmbedDashboardCsvExport', builder, embed)
         ) {
             can('manage', 'ExportCsv', {

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -121,7 +121,7 @@ export type EmbedWriteActions = {
     serviceAccountUserUuid?: string;
     userUuid?: string;
     spaceUuid: string;
-    /** Opt into role checks: dashboard flags OR scopes; AI additionally requires EmbedAiAgent. */
+    /** Use scopes instead of dashboard flags; AI additionally requires EmbedAiAgent. */
     permissionsMode?: 'default' | 'roles';
 };
 


### PR DESCRIPTION
Relates: SPK-1970
Relates: SPK-1967

### Description

Make dashboard `writeActions.permissionsMode: 'roles'` use only the actor's embed scopes, consistent with role-controlled AI entry access. JWT capability flags no longer bypass a missing scope in dashboard roles mode.

- Gate existing dashboard JWT grants by mode in CASL abilities and dashboard response capabilities.
- Resolve filter interactivity, adding filters, and parameter editing from their independent scopes in roles mode, preserving hidden-filter presentation and data restrictions.
- Keep omitted/`default` dashboard behavior unchanged, including PDF's enabled default. In roles mode, PDF requires its scope.
- Keep AI authorization, other embed types, payload/response types, and scope definitions unchanged. No migration or new abstraction.
- Update internal permissions documentation and the existing permission-mode regression matrices.

External documentation: https://github.com/lightdash/mintlify-docs/pull/1225 (merge after this implementation).

### Validation

- 197 focused common/backend tests passed, covering ability grants, response capabilities, structured controls, token validation, and unchanged AI behavior.
- Common/backend typechecks and lint passed; formatting and `git diff --check` passed.
- Isolated worktree and local database: 18 dashboard configurations (user/service account × omitted/default/roles × omitted/false/true flags), each checking 11 capabilities through scope-off/on/off transitions with identical JWTs.
- Six AI access configurations per transition: default access remains subject to existing prerequisites; roles requires `EmbedAiAgent`.
- Real dashboard CSV export endpoint rejects a roles token with true flags but no scope (403); available filter fields are empty without the scope; no-actor default JWT flags still work.
- Browser: signed in and ran a seeded chart; embedded charts render with scopes absent; default true flags retain export controls; role grants expose export/filter controls with flags omitted; revocation removes controls on reload with the same token.
- Existing regression coverage checks target scope isolation, structured controls, and unresolved actors. No broader security audit or full local E2E suite; no AI model generation or actual PDF/image download exercised.

### Compatibility and rollout

Intentional behavior tightening for dashboard tokens that explicitly select `roles`: integrations relying on true JWT flags or PDF's omitted default must grant the corresponding embed scopes. Default/omitted tokens and AI access are unchanged. No claim is made here about current production adoption; review rollout before merging.

### Risk assessment

- [ ] This is a high-risk change

Scoped, tested, reversible authorization tightening; it does not grant broader access or change data restrictions. The compatibility impact is limited to opted-in dashboard roles-mode tokens as described above. Requires review before merging.
