### PR TITLE
feat: add internal analytics Parquet connector and feature flag

### DIFF
--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -332,7 +332,10 @@ const credentialsTarget = (
                     },
                 };
             }
-            if (credentials.connectionType === DuckdbConnectionType.EMBEDDED) {
+            if (
+                credentials.connectionType === DuckdbConnectionType.EMBEDDED ||
+                credentials.connectionType === DuckdbConnectionType.ANALYTICS
+            ) {
                 throw new ParameterError(
                     'Embedded DuckDB credentials cannot be used for dbt compilation',
                 );

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1770,6 +1770,138 @@ describe('ProjectService', () => {
         );
     });
 
+    describe('public analytics connection configuration', () => {
+        const warehouseConnection = {
+            type: WarehouseTypes.DUCKDB as const,
+            connectionType: DuckdbConnectionType.ANALYTICS as const,
+            database: 'memory' as const,
+            schema: 'main' as const,
+        };
+        const creationUser: SessionUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                { subject: 'Project', action: ['view', 'create'] },
+            ]),
+            organizationUuid: projectWithSensitiveFields.organizationUuid,
+            organizationName: 'Organization',
+            organizationCreatedAt: new Date(),
+        };
+        const createProjectData = {
+            name: 'Internal analytics',
+            type: ProjectType.DEFAULT,
+            dbtConnection: { type: DbtProjectType.NONE as const },
+            dbtVersion: projectWithSensitiveFields.dbtVersion,
+            warehouseConnection,
+        };
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        test.each([ProjectType.DEFAULT, ProjectType.PREVIEW])(
+            'rejects public analytics provisioning on %s projects',
+            async (type) => {
+                await expect(
+                    service.createWithoutCompile(
+                        creationUser,
+                        { ...createProjectData, type },
+                        RequestMethod.WEB_APP,
+                    ),
+                ).rejects.toThrow(
+                    'Analytics connections can only be provisioned internally',
+                );
+                expect(
+                    projectModel.createWithOptionalCredentials,
+                ).not.toHaveBeenCalled();
+            },
+        );
+
+        test('rejects scheduled creation before creating a job', async () => {
+            await expect(
+                service.scheduleCreate(
+                    creationUser,
+                    createProjectData,
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrow(
+                'Analytics connections can only be provisioned internally',
+            );
+            expect(jobModel.create).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.createProjectWithCompile,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects analytics credentials inherited from an upstream preview', async () => {
+            projectModel.getWarehouseCredentialsForProject.mockResolvedValueOnce(
+                warehouseConnection,
+            );
+            await expect(
+                service.createWithoutCompile(
+                    creationUser,
+                    {
+                        ...createProjectData,
+                        type: ProjectType.PREVIEW,
+                        warehouseConnection: undefined,
+                        upstreamProjectUuid: projectUuid,
+                        copyWarehouseConnectionFromUpstreamProject: true,
+                    },
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrow(
+                'Analytics connections can only be provisioned internally',
+            );
+            expect(
+                projectModel.createWithOptionalCredentials,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('rejects warehouse credential updates before persistence', async () => {
+            await expect(
+                service.updateWarehouseCredentials(
+                    projectUuid,
+                    developerAccount,
+                    {
+                        warehouseConnection,
+                    },
+                ),
+            ).rejects.toThrow(
+                'Analytics connections can only be provisioned internally',
+            );
+            expect(projectModel.update).not.toHaveBeenCalled();
+        });
+
+        test('rejects update-and-compile before persistence or scheduling', async () => {
+            await expect(
+                service.updateAndScheduleAsyncWork(
+                    projectUuid,
+                    developerAccount,
+                    { ...createProjectData, warehouseConnection },
+                    RequestMethod.WEB_APP,
+                ),
+            ).rejects.toThrow(
+                'Analytics connections can only be provisioned internally',
+            );
+            expect(projectModel.update).not.toHaveBeenCalled();
+            expect(jobModel.create).not.toHaveBeenCalled();
+        });
+
+        test('rejects warehouse connection tests before accessing the warehouse', async () => {
+            await expect(
+                service.testWarehouseConnection(
+                    developerAccount as RegisteredAccount,
+                    projectUuid,
+                    warehouseConnection,
+                ),
+            ).rejects.toThrow(
+                'Analytics connections can only be provisioned internally',
+            );
+            expect(
+                projectModel.getWarehouseClientFromCredentials,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
     describe('default AI agent provisioning', () => {
         test('provisions a default AI agent for a playground when the organization already has another project', async () => {
             const createdProjectUuid = 'created-playground-project-uuid';

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3647,6 +3647,14 @@ export class ProjectService extends BaseService {
     ): void {
         if (
             credentials?.type === WarehouseTypes.DUCKDB &&
+            credentials.connectionType === DuckdbConnectionType.ANALYTICS
+        ) {
+            throw new ParameterError(
+                'Analytics connections can only be provisioned internally',
+            );
+        }
+        if (
+            credentials?.type === WarehouseTypes.DUCKDB &&
             credentials.connectionType === DuckdbConnectionType.EMBEDDED &&
             internalProvisioning === undefined
         ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1944,6 +1944,12 @@ export class ProjectService extends BaseService {
             case WarehouseTypes.DUCKDB: {
                 if (
                     credentials.connectionType ===
+                    DuckdbConnectionType.ANALYTICS
+                ) {
+                    return credentials;
+                }
+                if (
+                    credentials.connectionType ===
                     DuckdbConnectionType.MOTHERDUCK
                 ) {
                     return {

--- a/packages/backend/src/services/ProjectService/analyticsProject/GcsAnalyticsSource.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/GcsAnalyticsSource.test.ts
@@ -1,0 +1,107 @@
+import { resolveGcsAnalyticsSource } from './GcsAnalyticsSource';
+
+describe('GCS analytics manifests', () => {
+    const organizationUuid = '00000000-0000-0000-0000-000000000001';
+    const prefix = `events/compacted/org_id=${organizationUuid}/`;
+    const config = {
+        bucket: 'example-bucket',
+        organizationUuid,
+        startDate: '2026-09-07',
+        endDate: '2026-09-07',
+        getAccessToken: async () => 'token',
+    };
+    const object = (date: string, stream = 'query_events') => ({
+        name: `${prefix}stream=${stream}/dt=${date}/part.parquet`,
+    });
+    afterEach(() => vi.unstubAllGlobals());
+
+    it('lists only the org prefix, handles pagination and bounds dates and streams', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    items: [object('2026-09-06'), object('2026-09-07')],
+                    nextPageToken: 'page2',
+                }),
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    items: [
+                        object('2026-09-07', 'ai_usage'),
+                        object('2026-09-08'),
+                        object('2026-09-07', 'unknown'),
+                    ],
+                }),
+            });
+        vi.stubGlobal('fetch', fetchMock);
+        const result = await resolveGcsAnalyticsSource(config);
+        expect(fetchMock.mock.calls[0][0].searchParams.get('prefix')).toBe(
+            prefix,
+        );
+        expect(fetchMock.mock.calls[1][0].searchParams.get('pageToken')).toBe(
+            'page2',
+        );
+        expect(result.tables.map(({ name }) => name)).toEqual([
+            'query_events',
+            'ai_usage',
+        ]);
+        expect(result.tables.flatMap(({ urls }) => urls)).toHaveLength(2);
+    });
+
+    it('rejects cross-org list responses', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => ({
+                    items: [
+                        {
+                            name: 'events/compacted/org_id=other/part.parquet',
+                        },
+                    ],
+                }),
+            }),
+        );
+        await expect(resolveGcsAnalyticsSource(config)).rejects.toThrow(
+            /cross-org/,
+        );
+    });
+
+    it('reports empty data without creating a misleading empty project', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+        );
+        await expect(resolveGcsAnalyticsSource(config)).rejects.toThrow(
+            /No compacted/,
+        );
+    });
+
+    it('does not disclose credential-bearing HTTP error bodies', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+                ok: false,
+                status: 403,
+                text: async () => 'token',
+            }),
+        );
+        await expect(resolveGcsAnalyticsSource(config)).rejects.toThrow(
+            'Analytics object listing failed (HTTP 403)',
+        );
+    });
+
+    it('rejects org path injection before authenticating', async () => {
+        const getAccessToken = vi.fn();
+        await expect(
+            resolveGcsAnalyticsSource({
+                ...config,
+                organizationUuid: '../other',
+                getAccessToken,
+            }),
+        ).rejects.toThrow(/Invalid analytics/);
+        expect(getAccessToken).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/ProjectService/analyticsProject/GcsAnalyticsSource.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/GcsAnalyticsSource.ts
@@ -1,0 +1,93 @@
+import { ParameterError } from '@lightdash/common';
+import { type DuckdbParquetSource } from '@lightdash/warehouses';
+
+export type GcsAnalyticsSourceConfig = {
+    bucket: string;
+    organizationUuid: string;
+    startDate: string;
+    endDate: string;
+    getAccessToken: () => Promise<string>;
+};
+
+/** Read-only discovery of a bounded, single-org file manifest. */
+export const resolveGcsAnalyticsSource = async ({
+    bucket,
+    organizationUuid,
+    startDate,
+    endDate,
+    getAccessToken,
+}: GcsAnalyticsSourceConfig): Promise<DuckdbParquetSource> => {
+    if (
+        !/^[a-z0-9][a-z0-9.-]{1,220}[a-z0-9]$/.test(bucket) ||
+        !/^[a-f0-9-]{36}$/.test(organizationUuid) ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(startDate) ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(endDate) ||
+        startDate > endDate
+    ) {
+        throw new ParameterError(
+            'Invalid analytics bucket, organization, or date range',
+        );
+    }
+    const prefix = `events/compacted/org_id=${organizationUuid}/`;
+    const scope = `https://storage.googleapis.com/${bucket}/${prefix}`;
+    const token = await getAccessToken();
+    const tables = new Map<string, string[]>();
+    let pageToken: string | undefined;
+    let pages = 0;
+    do {
+        const url = new URL(
+            `https://storage.googleapis.com/storage/v1/b/${bucket}/o`,
+        );
+        url.searchParams.set('prefix', prefix);
+        url.searchParams.set('maxResults', '1000');
+        url.searchParams.set('fields', 'items(name),nextPageToken');
+        if (pageToken) url.searchParams.set('pageToken', pageToken);
+        // eslint-disable-next-line no-await-in-loop
+        const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal: AbortSignal.timeout(30_000),
+        });
+        if (!response.ok) {
+            // Do not include request headers or credential-bearing SDK errors.
+            throw new Error(
+                `Analytics object listing failed (HTTP ${response.status})`,
+            );
+        }
+        // eslint-disable-next-line no-await-in-loop
+        const page = (await response.json()) as {
+            items?: { name: string }[];
+            nextPageToken?: string;
+        };
+        for (const { name } of page.items ?? []) {
+            if (!name.startsWith(prefix))
+                throw new Error('Unexpected cross-org analytics object');
+            const match =
+                /^stream=(query_events|ai_usage)\/dt=(\d{4}-\d{2}-\d{2})\/[^/]+\.parquet$/.exec(
+                    name.slice(prefix.length),
+                );
+            if (match && match[2] >= startDate && match[2] <= endDate) {
+                const urls = tables.get(match[1]) ?? [];
+                urls.push(`https://storage.googleapis.com/${bucket}/${name}`);
+                tables.set(match[1], urls);
+            }
+        }
+        pageToken = page.nextPageToken;
+        pages += 1;
+        if (pageToken && pages >= 100)
+            throw new Error(
+                'Analytics manifest exceeds the local triage limit',
+            );
+    } while (pageToken);
+    if (tables.size === 0)
+        throw new Error(
+            'No compacted analytics Parquet files found in the requested date range',
+        );
+    return {
+        scope,
+        httpAuth: { bearerToken: token },
+        tables: [...tables].map(([name, urls]) => ({
+            name,
+            urls: urls.sort(),
+        })),
+    };
+};

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -5,6 +5,8 @@
  * If the feature flag is no longer in use, remove it from this enum.
  */
 export enum FeatureFlags {
+    /** Backend-provisioned usage analytics projects. */
+    AnalyticsProject = 'analytics-project',
     /* Show user groups */
     UserGroupsEnabled = 'user-groups-enabled',
 

--- a/packages/common/src/types/projects.test.ts
+++ b/packages/common/src/types/projects.test.ts
@@ -2,6 +2,7 @@ import {
     BigqueryAuthenticationType,
     buildSafeDbtEnvironmentVariables,
     DbtVersionOptionLatest,
+    DuckdbConnectionType,
     fillOmittedSecrets,
     getDbtEnvironmentVariableKeyError,
     getDbtVersionSupportedWarehouses,
@@ -27,6 +28,7 @@ import {
     type CreateRedshiftCredentials,
     type CreateSnowflakeCredentials,
     type CreateWarehouseCredentials,
+    type DuckdbAnalyticsCredentials,
 } from './projects';
 
 describe('project dbt source name validation', () => {
@@ -418,6 +420,20 @@ describe('omitted secrets on connection test', () => {
             ...postgres,
             sshTunnelPrivateKey: undefined,
         });
+    });
+
+    it('preserves internal analytics identifiers without adding secrets', () => {
+        const analytics: DuckdbAnalyticsCredentials = {
+            type: WarehouseTypes.DUCKDB,
+            connectionType: DuckdbConnectionType.ANALYTICS,
+            database: 'memory',
+            schema: 'main',
+        };
+
+        expect(fillOmittedSecrets(omitEmptySecrets(analytics))).toEqual(
+            analytics,
+        );
+        expect(fillOmittedSecrets(analytics)).toEqual(analytics);
     });
 
     it('flags a private key BigQuery connection without a key file', () => {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -626,7 +626,8 @@ export type CreateWarehouseCredentialsWithOptionalSecrets =
     | WithOptionalSecrets<CreateAthenaCredentials>
     | WithOptionalSecrets<CreateDuckdbMotherduckCredentials>
     | WithOptionalSecrets<CreateDuckdbDucklakeCredentials>
-    | WithOptionalSecrets<CreateDuckdbEmbeddedCredentials>;
+    | WithOptionalSecrets<CreateDuckdbEmbeddedCredentials>
+    | WithOptionalSecrets<DuckdbAnalyticsCredentials>;
 
 const isSensitiveCredentialsFieldName = (
     key: string,
@@ -687,6 +688,7 @@ export const fillOmittedSecrets = (
                     return { ...credentials, token: credentials.token ?? '' };
                 case DuckdbConnectionType.DUCKLAKE:
                 case DuckdbConnectionType.EMBEDDED:
+                case DuckdbConnectionType.ANALYTICS:
                     return credentials;
                 default:
                     return assertUnreachable(

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -13,6 +13,7 @@ export enum ProjectType {
      * taught controls they do not hold on real projects.
      */
     TRAINING = 'TRAINING',
+    /** Backend-provisioned usage metadata project, never user-configurable. */
 }
 
 export enum DbtProjectType {
@@ -56,6 +57,7 @@ export enum DuckdbConnectionType {
     MOTHERDUCK = 'motherduck',
     DUCKLAKE = 'ducklake',
     EMBEDDED = 'embedded',
+    ANALYTICS = 'analytics',
 }
 
 export type SshTunnelConfiguration = {
@@ -276,6 +278,17 @@ export type CreateDuckdbEmbeddedCredentials = {
 };
 export type DuckdbEmbeddedCredentials = CreateDuckdbEmbeddedCredentials;
 
+/** An identifier only: storage locations and credentials belong to the backend. */
+export type DuckdbAnalyticsCredentials = {
+    type: WarehouseTypes.DUCKDB;
+    connectionType: DuckdbConnectionType.ANALYTICS;
+    database: 'memory';
+    schema: 'main';
+    requireUserCredentials?: false;
+    dataTimezone?: string;
+    startOfWeek?: number;
+};
+
 export enum DucklakeCatalogType {
     POSTGRES = 'postgres',
     SQLITE = 'sqlite',
@@ -404,12 +417,14 @@ export type DuckdbDucklakeCredentials = Omit<
 export type CreateDuckdbCredentials =
     | CreateDuckdbMotherduckCredentials
     | CreateDuckdbDucklakeCredentials
-    | CreateDuckdbEmbeddedCredentials;
+    | CreateDuckdbEmbeddedCredentials
+    | DuckdbAnalyticsCredentials;
 
 export type DuckdbCredentials =
     | DuckdbMotherduckCredentials
     | DuckdbDucklakeCredentials
-    | DuckdbEmbeddedCredentials;
+    | DuckdbEmbeddedCredentials
+    | DuckdbAnalyticsCredentials;
 
 /**
  * Normalize legacy credential values at decrypt time so callers receive a

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -56,7 +56,10 @@ export const getConnectionDefaults = (
                     schema: nonEmpty(credentials.schema),
                 };
             }
-            if (credentials.connectionType === DuckdbConnectionType.EMBEDDED) {
+            if (
+                credentials.connectionType === DuckdbConnectionType.EMBEDDED ||
+                credentials.connectionType === DuckdbConnectionType.ANALYTICS
+            ) {
                 return {
                     database: undefined,
                     schema: nonEmpty(credentials.schema),

--- a/packages/common/src/utils/warehouseLocation.ts
+++ b/packages/common/src/utils/warehouseLocation.ts
@@ -101,6 +101,7 @@ export const getWarehouseLocation = (
                         schema: credentials.schema,
                     };
                 case DuckdbConnectionType.EMBEDDED:
+                case DuckdbConnectionType.ANALYTICS:
                     return {
                         database: null,
                         schema: credentials.schema ?? null,
@@ -190,8 +191,9 @@ export const applyWarehouseLocation = (
                         schema: schema ?? credentials.schema,
                     };
                 case DuckdbConnectionType.EMBEDDED:
+                case DuckdbConnectionType.ANALYTICS:
                     throw new ParameterError(
-                        'Embedded DuckDB credentials cannot be used for dbt compilation',
+                        'Internal DuckDB credentials cannot be used for dbt compilation',
                     );
                 default:
                     return assertUnreachable(

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -14,6 +14,7 @@ import type { Mock } from 'vitest';
 import {
     DuckdbWarehouseClient,
     mapFieldTypeFromTypeId,
+    type DuckdbParquetSource,
     type DuckdbS3Credentials,
 } from './DuckdbWarehouseClient';
 import * as MotherduckInstanceCache from './MotherduckInstanceCache';
@@ -141,6 +142,119 @@ const createMockConnection = (
         disconnectSync: vi.fn(),
     }),
     closeSync: vi.fn(),
+});
+
+describe('internal Parquet projects', () => {
+    const scope =
+        'https://storage.googleapis.com/example/events/compacted/org_id=org-a/';
+    const url = `${scope}stream=query_events/dt=2026-09-07/part.parquet`;
+    const source = (): DuckdbParquetSource => ({
+        scope,
+        httpAuth: { bearerToken: 'test-token' },
+        tables: [{ name: 'query_events', urls: [url] }],
+    });
+    let run: Mock;
+    beforeEach(() => {
+        vi.clearAllMocks();
+        run = vi.fn();
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(
+                vi.fn(async () => getMockStreamResult([[{ count: 2 }]], [5])),
+                run,
+            ),
+        );
+    });
+
+    it('binds trusted views, restricts external access and refreshes the manifest each session', async () => {
+        const resolveSource = vi.fn(async () => source());
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource,
+        });
+        await client.runQuery('SELECT count(*) FROM query_events');
+        await client.runQuery('SELECT count(*) FROM query_events');
+        expect(resolveSource).toHaveBeenCalledTimes(2);
+        expect(createInstanceMock).toHaveBeenCalledTimes(2);
+        expect(run).toHaveBeenCalledWith(`SET allowed_paths = ['${url}'];`);
+        expect(run).toHaveBeenCalledWith('SET enable_external_access = false;');
+        expect(run).toHaveBeenCalledWith("SET temp_directory = '';");
+        expect(run).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'CREATE VIEW "query_events" AS SELECT * FROM read_parquet',
+            ),
+        );
+        expect(client.credentials).not.toHaveProperty('httpAuth');
+    });
+
+    it.each([
+        'https://storage.googleapis.com/example/events/compacted/org_id=org-b/file.parquet',
+        `${scope}../org-b/file.parquet`,
+        `${scope}%2e%2e/org-b/file.parquet`,
+        `${scope}*.parquet`,
+        '/tmp/private.parquet',
+    ])('rejects files outside the exact manifest scope: %s', async (file) => {
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: async () => ({
+                ...source(),
+                tables: [{ name: 'query_events', urls: [file] }],
+            }),
+        });
+        await expect(
+            client.runQuery('SELECT * FROM query_events'),
+        ).rejects.toThrow();
+        expect(run).not.toHaveBeenCalledWith(
+            expect.stringContaining('CREATE SECRET'),
+        );
+    });
+
+    it.each([
+        { name: 'x"; SELECT 1; --', urls: [url] },
+        { name: 'query_events', urls: [] },
+    ])(
+        'rejects arbitrary table SQL and empty manifests: $name',
+        async (table) => {
+            const client = new DuckdbWarehouseClient({
+                type: 'duckdb_parquet',
+                resolveSource: async () => ({ ...source(), tables: [table] }),
+            });
+            await expect(client.runQuery('SELECT 1')).rejects.toThrow(
+                /unique names/,
+            );
+        },
+    );
+
+    it('keeps user-supplied read_parquet forbidden', async () => {
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: async () => source(),
+        });
+        await expect(
+            client.runQuery(`SELECT * FROM read_parquet('${url}')`),
+        ).rejects.toThrow(/not allowed/);
+    });
+
+    it('cannot create privileged readers from public project credentials or shared instances', () => {
+        expect(
+            () =>
+                new DuckdbWarehouseClient({
+                    type: WarehouseTypes.DUCKDB,
+                    connectionType: DuckdbConnectionType.ANALYTICS,
+                    database: 'memory',
+                    schema: 'main',
+                }),
+        ).toThrow(/internal project service/);
+        expect(
+            () =>
+                new DuckdbWarehouseClient(
+                    {
+                        type: 'duckdb_parquet',
+                        resolveSource: async () => source(),
+                    },
+                    { instanceCacheKey: 'shared' },
+                ),
+        ).toThrow(/cannot share/);
+    });
 });
 
 describe('mapFieldTypeFromTypeId', () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -138,7 +138,23 @@ export type DuckdbS3Credentials = {
     s3Config: DuckdbS3SessionConfig;
 };
 
-export type DuckdbConnectionCredentials = DuckdbS3Credentials;
+/** Server-owned manifest. Never accept this configuration from project APIs. */
+export type DuckdbParquetSource = {
+    scope: string;
+    tables: { name: string; urls: string[] }[];
+    httpAuth?: { bearerToken: string };
+    s3Config?: DuckdbS3SessionConfig;
+};
+
+export type DuckdbParquetCredentials = {
+    type: 'duckdb_parquet';
+    /** Resolve again for every session so new files and refreshed credentials are visible. */
+    resolveSource: () => Promise<DuckdbParquetSource>;
+};
+
+export type DuckdbConnectionCredentials =
+    | DuckdbS3Credentials
+    | DuckdbParquetCredentials;
 
 export type DuckdbWarehouseClientOptions = {
     /** Resource-constrained isolated sessions, used for materialization/parquet conversion and embedded databases. */
@@ -548,6 +564,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
 
     private readonly s3Config?: DuckdbS3SessionConfig;
 
+    private readonly parquetConfig?: DuckdbParquetCredentials;
+
     private readonly ducklakeConfig?: CreateDuckdbDucklakeCredentials;
 
     private readonly embeddedConfig?: CreateDuckdbEmbeddedCredentials;
@@ -586,6 +604,15 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             credentials &&
             'type' in credentials &&
             credentials.type === 'duckdb_s3';
+        const isParquet = credentials?.type === 'duckdb_parquet';
+        if (
+            credentials?.type === WarehouseTypes.DUCKDB &&
+            credentials.connectionType === DuckdbConnectionType.ANALYTICS
+        ) {
+            throw new ParameterError(
+                'Analytics connections must be resolved by the internal project service',
+            );
+        }
         const isDucklake =
             !isS3Only &&
             credentials &&
@@ -600,7 +627,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             credentials.connectionType === DuckdbConnectionType.EMBEDDED;
 
         let effectiveCredentials: CreateDuckdbMotherduckCredentials;
-        if (isS3Only) {
+        if (isS3Only || isParquet) {
             effectiveCredentials = DUCKDB_INTERNAL_CREDENTIALS;
         } else if (isDucklake) {
             const ducklake = credentials as CreateDuckdbDucklakeCredentials;
@@ -633,6 +660,15 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
 
         if (isS3Only) {
             this.s3Config = (credentials as DuckdbS3Credentials).s3Config;
+        }
+
+        if (isParquet) {
+            this.parquetConfig = credentials as DuckdbParquetCredentials;
+            if (options?.instanceCacheKey || options?.enableInstanceCache) {
+                throw new ParameterError(
+                    'Parquet project sessions cannot share a DuckDB instance',
+                );
+            }
         }
 
         if (isDucklake) {
@@ -675,7 +711,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                   ...options?.resourceLimits,
               }
             : options?.resourceLimits;
-        this.sharedResourceLimits = options?.sharedResourceLimits;
+        this.sharedResourceLimits = isParquet
+            ? {
+                  memoryLimit: '256MB',
+                  threads: 2,
+                  ...options?.sharedResourceLimits,
+              }
+            : options?.sharedResourceLimits;
         // DuckLake attaches a postgres catalog secret on every fresh DuckDB
         // instance, and the postgres extension only pools 8 connections per
         // instance — so parallel getFields() calls during project compile
@@ -687,7 +729,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         this.instanceCacheKey =
             options?.instanceCacheKey ?? ducklakeAutoCacheKey;
         this.logger = options?.logger;
-        this.enableQueryProfiling = options?.enableQueryProfiling ?? false;
+        this.enableQueryProfiling =
+            !isParquet && (options?.enableQueryProfiling ?? false);
         this.onQueryProfile = options?.onQueryProfile;
         this.embeddedQueryTimeoutMs =
             options?.embeddedQueryTimeoutMs ?? EMBEDDED_QUERY_TIMEOUT_MS;
@@ -961,6 +1004,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             );
         }
 
+        if (client.parquetConfig) {
+            await client.bootstrapParquetViews(db);
+        }
+
         if (client.ducklakeConfig) {
             const stmts = DuckdbWarehouseClient.buildDucklakeAttachSql(
                 client.ducklakeConfig,
@@ -994,6 +1041,88 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             bootstrapMs,
             httpfsMs,
         };
+    }
+
+    private async bootstrapParquetViews(db: DuckdbConnection): Promise<void> {
+        const source = await this.parquetConfig!.resolveSource();
+        const escape = DuckdbWarehouseClient.escapeDuckdbString;
+        const literal = (value: string) => `'${escape(value)}'`;
+        const scope = new URL(source.scope);
+        if (
+            !['https:', 's3:'].includes(scope.protocol) ||
+            scope.username ||
+            scope.password ||
+            scope.search ||
+            scope.hash ||
+            !source.scope.endsWith('/') ||
+            scope.pathname === '/'
+        ) {
+            throw new ParameterError(
+                'Parquet source requires a scoped remote prefix',
+            );
+        }
+        const names = new Set<string>();
+        source.tables.forEach(({ name, urls }) => {
+            if (
+                !/^[a-z][a-z0-9_]*$/.test(name) ||
+                names.has(name) ||
+                urls.length === 0
+            ) {
+                throw new ParameterError(
+                    'Parquet tables require unique names and a non-empty file manifest',
+                );
+            }
+            names.add(name);
+            urls.forEach((url) => {
+                const parsed = new URL(url);
+                if (
+                    parsed.href !== url ||
+                    !url.startsWith(source.scope) ||
+                    !url.endsWith('.parquet') ||
+                    parsed.search ||
+                    parsed.hash ||
+                    /[%*?[\]{}]/.test(parsed.pathname)
+                ) {
+                    throw new ParameterError(
+                        'Parquet file is outside the trusted source prefix',
+                    );
+                }
+            });
+        });
+        if (source.httpAuth) {
+            if (scope.protocol !== 'https:') {
+                throw new ParameterError(
+                    'HTTP credentials require an HTTPS source',
+                );
+            }
+            await db.run(
+                `CREATE SECRET analytics_http (TYPE http, BEARER_TOKEN ${literal(source.httpAuth.bearerToken)}, SCOPE ${literal(source.scope)});`,
+            );
+        }
+        if (source.s3Config) {
+            if (DuckdbWarehouseClient.usesS3CredentialChain(source.s3Config)) {
+                await this.loadExtension(db, 'aws');
+            }
+            await db.run(
+                DuckdbWarehouseClient.buildS3SecretSql({
+                    ...source.s3Config,
+                    scope: [source.scope],
+                }),
+            );
+        }
+        // Restrict the engine, not just SQL validation. No globbing, arbitrary
+        // network reads, local files, or shared spill/cache directories.
+        await db.run("SET temp_directory = '';");
+        const files = source.tables.flatMap(({ urls }) => urls);
+        await db.run(`SET allowed_paths = [${files.map(literal).join(',')}];`);
+        await db.run('SET enable_external_access = false;');
+        // eslint-disable-next-line no-restricted-syntax
+        for (const { name, urls } of source.tables) {
+            // eslint-disable-next-line no-await-in-loop
+            await db.run(
+                `CREATE VIEW "${name}" AS SELECT * FROM read_parquet([${urls.map(literal).join(',')}], hive_partitioning = true, union_by_name = true);`,
+            );
+        }
     }
 
     private static async bootstrapSharedInstance(
@@ -1703,6 +1832,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
             );
         }
         try {
+            if (this.parquetConfig) {
+                return await this.withEphemeralQuerySession(callback);
+            }
             if (this.embeddedConfig) {
                 return await this.withDirectSession(
                     callback,


### PR DESCRIPTION
## Summary

First independently mergeable slice of the internal usage analytics stack. Introduce the shared `analytics-project` feature flag and the internal DuckDB Parquet reader; no provisioning endpoint, visible connector, or production authentication is enabled here.

- Injectable source/credential resolver, isolated in-memory DuckDB sessions, bounded memory/threads, no disk spilling or shared-instance cache.
- Bind backend-provided exact file URLs to named views. Retain SELECT-only/file-function validation and restrict external access to the manifest.
- Read-only GCS manifest discovery limited to an org prefix, supported streams, and a date range. Authentication is supplied by the caller, not acquired or persisted here.
- Internal persisted connection identifiers cannot directly instantiate a public warehouse client or compile a dbt project.
- Reject analytics credentials at the shared project-service boundary: ordinary create (including scheduled creation and inherited preview credentials), update, and connection-test paths cannot persist or use them. This rejection is unconditional in PR1, independent of feature-flag state; the trusted internal provisioning exception is added only in PR3.
- Existing connection handling remains unchanged apart from handling the new union member. There is no feature activation in this PR; enabling the flag alone does not expose a read path.

## Validation

- Review hardening: all 210 ProjectService tests passed on this branch independently, including seven regression cases for public analytics configuration and side-effect prevention. Backend typecheck, scoped lint, formatting, and diff checks passed.
- Checked this branch independently: common build; backend, frontend, and warehouse typechecks passed.
- 115 DuckDB client tests passed after rebasing onto current main; five resolver tests passed during the split.
- Scoped pre-commit lint, formatting, unused exports, and secrets checks passed.
- Production storage auth and real cloud-enforced cross-org credential denial are not implemented or validated in this slice. Cloud checks are tracked on the latest revision.

## Stack / rollout

1. This PR: connector foundation and shared feature flag.
2. #28916: bucket credentials and exact-file signed GET URLs; existing writer credentials stay in the trusted backend for local testing.
3. #28849: admin create-or-get endpoint and both Query Events and AI Usage models, initially development-only.
4. #28924: internal architecture, credentials, and testing documentation.

Dedicated read-only source credentials remain deferred to PROD-11103 before customer enablement.

No cloud IAM, bucket contents, event writers, compaction, or database migrations are changed.

Relates: [PROD-11059](https://linear.app/lightdash/issue/PROD-11059)
Relates: [PROD-8603](https://linear.app/lightdash/issue/PROD-8603)
