### PR TITLE
fix: wait for guided tour targets before showing the next step

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.module.css
@@ -331,3 +331,10 @@
         animation: none;
     }
 }
+
+.waitingControls {
+    position: fixed;
+    bottom: var(--mantine-spacing-md);
+    right: var(--mantine-spacing-md);
+    pointer-events: auto;
+}

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,8 +1,8 @@
 import { Popover } from '@mantine/core';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type FC } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import MantineModal from '../MantineModal';
 import { GuidedTour, type GuidedTourStep } from './GuidedTour';
@@ -12,6 +12,20 @@ const steps: GuidedTourStep[] = [
     { target: null, title: 'Step two', body: 'second body' },
     { target: null, title: 'Step three', body: 'third body' },
 ];
+
+// jsdom has no layout; model visible controls with non-empty boxes.
+beforeEach(() => {
+    document.elementsFromPoint = () => [];
+    Element.prototype.scrollIntoView = () => {};
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+        function (this: Element) {
+            return this.hasAttribute('hidden')
+                ? new DOMRect(0, 0, 0, 0)
+                : new DOMRect(100, 100, 100, 30);
+        },
+    );
+});
+afterEach(() => vi.restoreAllMocks());
 
 describe('GuidedTour', () => {
     it('renders nothing when closed', () => {
@@ -102,13 +116,14 @@ describe('GuidedTour', () => {
         expect(calls).toEqual(['finish', 'close']);
     });
 
-    // A control the instance never shows (a screen behind a config the tour
-    // did not know about) used to leave the page blocked with no card and no
-    // Skip: the only way out was a new tab.
-    it('brings the card back when the next control never appears', async () => {
+    it('keeps the next step hidden but allows skipping when its control never appears', async () => {
         vi.useFakeTimers();
+        const onClose = vi.fn();
+        const recovery = document.createElement('button');
+        recovery.setAttribute('data-recovery', '');
+        document.body.appendChild(recovery);
         try {
-            renderWithProviders(
+            const { unmount } = renderWithProviders(
                 <GuidedTour
                     steps={[
                         { target: null, title: 'Step one', body: '' },
@@ -117,11 +132,12 @@ describe('GuidedTour', () => {
                             title: 'Step two',
                             body: '',
                             interactive: true,
-                            advanceOnTargetClick: true,
+                            via: ['[data-recovery]'],
                         },
+                        { target: null, title: 'Step three', body: '' },
                     ]}
                     opened
-                    onClose={vi.fn()}
+                    onClose={onClose}
                     initialStepIndex={1}
                     initialBeacon={{ x: 10, y: 10 }}
                 />,
@@ -136,20 +152,122 @@ describe('GuidedTour', () => {
             });
             expect(screen.queryByText('Step two')).not.toBeInTheDocument();
 
-            // Well before the 15 s path patience: the learner needs to see
-            // the tour is alive long before that.
+            // Passing the old card-return timeout must not reveal the step.
             await act(async () => {
                 await vi.advanceTimersByTimeAsync(2_000);
             });
-            expect(screen.getByText('Step two')).toBeInTheDocument();
+            expect(screen.queryByText('Step two')).not.toBeInTheDocument();
             expect(
                 screen.getByRole('button', { name: 'Skip' }),
             ).toBeInTheDocument();
-            expect(screen.getByText(/Still waiting/)).toBeInTheDocument();
+            expect(screen.queryByText(/Still waiting/)).not.toBeInTheDocument();
+            await act(() => vi.advanceTimersByTimeAsync(20_000));
+            await act(() => vi.advanceTimersByTimeAsync(1_000));
+            await act(() => vi.advanceTimersByTimeAsync(1_000));
+            fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+            expect(onClose).toHaveBeenCalledTimes(1);
+            unmount();
+            await act(() => vi.advanceTimersByTimeAsync(20_000));
+            expect(document.documentElement).not.toHaveClass(
+                'ld-tour-beacon-cursor',
+            );
         } finally {
+            recovery.remove();
             vi.useRealTimers();
         }
     });
+
+    it.each(['Next', 'click', 'input'] as const)(
+        'waits for a visible destination after %s, then supports a targetless step',
+        async (advance) => {
+            vi.useFakeTimers();
+            const host = document.createElement('div');
+            host.innerHTML = '<input id="source" />';
+            document.body.appendChild(host);
+            const onNavigate = vi.fn();
+            const onFinish = vi.fn();
+            try {
+                renderWithProviders(
+                    <GuidedTour
+                        steps={[
+                            {
+                                target: '#source',
+                                title: 'Source step',
+                                body: '',
+                                interactive: true,
+                                advanceOnTargetClick: advance === 'click',
+                                advanceOnTargetInput: advance === 'input',
+                            },
+                            {
+                                target: '#destination',
+                                via: ['#source'],
+                                title: 'Destination step',
+                                body: 'Destination instructions',
+                                route: '/destination',
+                                interactive: true,
+                                advanceOnTargetClick: true,
+                            },
+                            { target: null, title: 'Finished', body: '' },
+                        ]}
+                        opened
+                        onClose={vi.fn()}
+                        onFinish={onFinish}
+                        onNavigate={onNavigate}
+                    />,
+                );
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                if (advance === 'Next') {
+                    fireEvent.click(
+                        screen.getByRole('button', { name: 'Next' }),
+                    );
+                } else if (advance === 'click') {
+                    fireEvent.click(host.querySelector('#source')!);
+                } else {
+                    fireEvent.input(host.querySelector('#source')!, {
+                        target: { value: 'hello' },
+                    });
+                    await act(() => vi.advanceTimersByTimeAsync(1_000));
+                }
+                expect(onNavigate).toHaveBeenCalledWith('/destination');
+                expect(
+                    screen.queryByText('Destination step'),
+                ).not.toBeInTheDocument();
+                await act(() => vi.advanceTimersByTimeAsync(20_000));
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                expect(
+                    screen.queryByText('Destination instructions'),
+                ).not.toBeInTheDocument();
+                expect(
+                    screen.queryByText(/Still waiting/),
+                ).not.toBeInTheDocument();
+                expect(
+                    screen.getByRole('button', { name: 'Skip' }),
+                ).toBeVisible();
+                expect(onFinish).not.toHaveBeenCalled();
+
+                host.innerHTML =
+                    '<button id="destination" hidden>Destination</button>';
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                expect(
+                    screen.queryByText('Destination step'),
+                ).not.toBeInTheDocument();
+
+                host.querySelector('#destination')!.removeAttribute('hidden');
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                expect(screen.getByText('Destination step')).toBeVisible();
+                fireEvent.click(host.querySelector('#destination')!);
+                await act(() => vi.advanceTimersByTimeAsync(1_000));
+                expect(screen.getByText('Finished')).toBeVisible();
+                fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+                expect(onFinish).toHaveBeenCalledTimes(1);
+            } finally {
+                host.remove();
+                vi.useRealTimers();
+            }
+        },
+    );
 
     // A step's target may sit behind a control only some instances show (a
     // chooser before the export form). While that control is on the page and
@@ -171,11 +289,6 @@ describe('GuidedTour', () => {
                 ],
             },
         ];
-        // jsdom has no layout: the tour's viewport checks need these to exist.
-        beforeEach(() => {
-            document.elementsFromPoint = () => [];
-            Element.prototype.scrollIntoView = () => {};
-        });
         const mount = (html: string) => {
             const host = document.createElement('div');
             host.innerHTML = html;
@@ -228,7 +341,7 @@ describe('GuidedTour', () => {
                         host.querySelector('[data-x="download"]'),
                     ).toHaveAttribute('data-tour-active'),
                 );
-                expect(screen.getByText('Click Download')).toBeVisible();
+                expect(await screen.findByText('Click Download')).toBeVisible();
                 expect(
                     screen.queryByText('Click Download data'),
                 ).not.toBeInTheDocument();
@@ -323,7 +436,7 @@ describe('GuidedTour and the menus a step opens', () => {
         );
 
         expect(screen.getByText('Sales')).toBeInTheDocument();
-        await user.click(screen.getByRole('button', { name: 'Got it' }));
+        await user.click(await screen.findByRole('button', { name: 'Got it' }));
         await waitFor(() =>
             expect(screen.queryByText('Sales')).not.toBeInTheDocument(),
         );

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -122,13 +122,6 @@ const CARD_EXPAND_MS = 280;
 const FALLBACK_GRACE_MS = 1500;
 /** How long a step waits for a control that has not appeared yet. */
 const TARGET_PATIENCE_MS = 15000;
-/**
- * How long the beacon waits alone before the card comes back. Shorter than
- * the patience above on purpose: a card returning early costs nothing (it
- * re-anchors the moment the control appears), while a beacon alone for
- * long reads as a page that has died.
- */
-const CARD_RETURN_MS = 4000;
 /** A typed-input step counts as done after this many characters and a pause. */
 const MIN_INPUT_CHARS = 3;
 const INPUT_SETTLE_MS = 900;
@@ -196,10 +189,17 @@ const sameRect = (a: DOMRect | null, b: DOMRect | null) =>
 const useTargetRect = (
     selector: string | null,
     active: boolean,
+    stepIndex: number,
 ): DOMRect | null => {
-    const [rect, setRect] = useState<DOMRect | null>(null);
+    const [measurement, setMeasurement] = useState<{
+        selector: string | null;
+        stepIndex: number;
+        rect: DOMRect | null;
+    }>({ selector, stepIndex, rect: null });
 
     useEffect(() => {
+        const setRect = (rect: DOMRect | null) =>
+            setMeasurement({ selector, stepIndex, rect });
         // A new step (or a page change) starts with no highlight; the previous
         // element's box must never linger while the next target is looked up.
         setRect(null);
@@ -229,11 +229,22 @@ const useTargetRect = (
             }
             if (el) {
                 const current = el.getBoundingClientRect();
-                if (sameRect(current, last) && !sameRect(current, published)) {
+                const visible =
+                    current.width > 0 &&
+                    current.height > 0 &&
+                    getComputedStyle(el).visibility === 'visible';
+                if (!visible) {
+                    if (published) setRect(null);
+                    last = null;
+                    published = null;
+                } else if (
+                    sameRect(current, last) &&
+                    !sameRect(current, published)
+                ) {
                     published = current;
                     setRect(current);
                 }
-                last = current;
+                if (visible) last = current;
             }
             frame = window.requestAnimationFrame(tick);
         };
@@ -242,9 +253,13 @@ const useTargetRect = (
             window.cancelAnimationFrame(frame);
             el?.removeAttribute(TARGET_ATTRIBUTE);
         };
-    }, [selector, active]);
+    }, [selector, active, stepIndex]);
 
-    return rect;
+    return active &&
+        measurement.selector === selector &&
+        measurement.stepIndex === stepIndex
+        ? measurement.rect
+        : null;
 };
 
 type Resolved = {
@@ -547,9 +562,8 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     const [cardHeight, cardRef] = useCardHeight();
 
     const step = steps[stepIndex];
-    // Each step resolves its own target when reached (rows may load late), so a
-    // step with a not-yet-rendered target just shows a centered card until it
-    // appears, rather than being dropped.
+    // Resolve the destination immediately, but keep its card hidden until
+    // the control has a stable, visible box.
     const { selector: resolvedSelector, detourTitle } = useResolvedSelector(
         step,
         opened,
@@ -558,7 +572,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
     // work rather than on the finished surface.
     const { busy, status } = useBusy(step?.busy, opened);
     const spotlightSelector = busy && step?.busy ? step.busy : resolvedSelector;
-    const rect = useTargetRect(spotlightSelector, opened);
+    const rect = useTargetRect(spotlightSelector, opened, stepIndex);
     // How the last step change happened: Next glides the ring from the old
     // control to the new one; a click on the control shrinks the ring into a
     // beacon at the click (the control usually vanishes: a menu item, a link)
@@ -672,7 +686,25 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             setShownStepIndex(0);
         }
     }, [opened]);
+    const hasTarget = step?.target != null;
+    // Recovery controls can be spotlighted without revealing instructions
+    // for a destination that is still loading.
+    const targetReady =
+        !hasTarget ||
+        (rect !== null &&
+            (spotlightSelector === step?.target ||
+                detourTitle !== null ||
+                busy));
     useEffect(() => {
+        if (!hasTarget) {
+            advanceByClickRef.current = false;
+            setBeacon(false);
+            setCardPhase('shown');
+            setCardRect(null);
+            setShownRect(null);
+            setShownStepIndex(stepIndex);
+            return undefined;
+        }
         if (advanceByClickRef.current) {
             advanceByClickRef.current = false;
             setBeacon(true);
@@ -691,7 +723,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         setShownStepIndex(stepIndex);
         glideFor(GLIDE_MS);
         return undefined;
-    }, [stepIndex, glideFor]);
+    }, [stepIndex, hasTarget, glideFor]);
 
     // While the beacon waits for the next control it becomes the cursor:
     // the native pointer is hidden and the beacon follows the mouse, so the
@@ -716,26 +748,6 @@ export const GuidedTour: FC<GuidedTourProps> = ({
             window.removeEventListener('mousemove', follow, true);
             if (frame !== null) window.cancelAnimationFrame(frame);
         };
-    }, [waiting]);
-
-    // A control that never arrives (a screen this instance does not have)
-    // would otherwise hide the card for good, leaving the page blocked with
-    // no way out but a new tab. After a short wait the card comes back,
-    // centred, saying it is still waiting, so Skip is always within reach;
-    // the beacon keeps waiting and the card still opens at the control if
-    // it turns up.
-    const [cardReturned, setCardReturned] = useState(false);
-    useEffect(() => {
-        if (!waiting) {
-            setCardReturned(false);
-            return undefined;
-        }
-        const timeout = window.setTimeout(() => {
-            setCardRect(null);
-            setCardPhase('shown');
-            setCardReturned(true);
-        }, CARD_RETURN_MS);
-        return () => window.clearTimeout(timeout);
     }, [waiting]);
 
     // When the work finishes the ring travels to the finished surface.
@@ -906,7 +918,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         if (!handsOn) return undefined;
         const guard = (event: MouseEvent) => {
             const target = event.target as Element | null;
-            if (!target || target.closest('[data-tour-card]')) return;
+            if (!target || target.closest('[data-tour-root]')) return;
             if (
                 target.closest(
                     'button, a, [role="button"], [role="menuitem"], input, select, textarea',
@@ -998,12 +1010,6 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                         <Box fz="sm" c="dimmed">
                             {shownStep.body}
                         </Box>
-                    )}
-                    {cardReturned && waiting && (
-                        <Text fz="xs" c="dimmed" data-tour-card-waiting>
-                            Still waiting for the page to show the next control.
-                            You can skip if it does not appear.
-                        </Text>
                     )}
                 </Stack>
                 <Group justify="space-between" align="center">
@@ -1185,7 +1191,13 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                 ) : (
                     <Box className={styles.dim} />
                 )}
-                {cardPhase === 'hidden' ? null : busy ? (
+                {cardPhase === 'hidden' || !targetReady ? (
+                    <Box className={styles.waitingControls}>
+                        <Button variant="default" onClick={handleClose}>
+                            Skip
+                        </Button>
+                    </Box>
+                ) : busy ? (
                     // The ring is following work that moves and reshapes;
                     // the card parks out of its way so it can be read.
                     <Box className={styles.cardDocked}>{cardBody}</Box>


### PR DESCRIPTION
## What changed

## Summary
- Remove the four-second timeout that exposed the next step before its target loaded.
- Require a stable, visible target measurement before showing instructions, without delaying navigation or breaking targetless explainers, explicit detours, or busy states.
- Keep a standalone Skip button available during loading, including hands-on recovery flows.
- Cover delayed click, input, and Next transitions, hidden targets, recovery fallbacks, resumed tours, and skipping.

The attached runtime capture shows the demo home page after the Learn route redirected; it is not proof of a guided-tour transition.

## Verification

- `pnpm -F frontend exec oxfmt src/components/common/GuidedTour/GuidedTour.tsx src/components/common/GuidedTour/GuidedTour.test.tsx src/components/common/GuidedTour/GuidedTour.module.css --check` — passed.
- `pnpm -F frontend typecheck` — passed.
- `pnpm -F frontend lint` — passed with 0 errors; one warning in unchanged LearnPage.test.tsx about sort comparators.
- `pnpm -F frontend exec vitest related src/components/common/GuidedTour/GuidedTour.tsx src/components/common/GuidedTour/GuidedTour.test.tsx src/components/common/GuidedTour/GuidedTour.module.css --run` — 4 files, 29 tests passed. React act warnings appeared in test output.
- Regression tests were observed failing before their fixes, including the timeout-based reveal and blocked standalone Skip.
- `git diff --check` — passed. Commit hooks passed, including unused-exports check. Worktree clean after commit 7f798bffbd.
- Live capture attempted: Learn redirected to Home, so no tour-transition browser verification was obtained. The final attempt to relabel that capture failed before execution.

## Visual evidence

### Guided-tour smoke check: opening the learning library before starting a walkthrough.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/818b0e5be5d28c4ec8da57a48118e6f90fad50e86f0167b5c4b7dcb940737833.png)

### Guided-tour smoke check in the project's learning library.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/818b0e5be5d28c4ec8da57a48118e6f90fad50e86f0167b5c4b7dcb940737833.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-11097-43745a3cb884.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-11097](https://linear.app/lightdash/issue/PROD-11097)

