### PR TITLE
fix(frontend): keep request paths and codes out of the network failure toast

### DIFF
--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -259,13 +259,64 @@ describe('network error messages', () => {
                 name: 'NetworkError',
                 statusCode: 500,
                 message: expect.stringContaining(
-                    'Lightdash is reachable, but PATCH http://test.lightdash/api/v1/projects/abc was blocked before it arrived',
+                    'Lightdash is reachable, but this request was blocked before it arrived',
                 ),
                 data: {
                     kind: 'blocked',
+                    path: 'http://test.lightdash/api/v1/projects/abc',
                     cause: 'Failed to fetch',
                     probe: { ok: true, status: 200 },
                 },
+            },
+        });
+    });
+
+    it('keeps the request out of the toast text', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(healthOk());
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                message: expect.not.stringContaining('/projects/abc'),
+            },
+        });
+    });
+
+    it('falls back to the generic message with no diagnostics inside an embed', async () => {
+        setToInMemoryStorage(EMBED_KEY, { token: 'jwt' });
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(healthOk());
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message:
+                    'We are currently unable to reach the Lightdash server. Please try again in a few moments.',
+                data: {},
+            },
+        });
+        clearInMemoryStorage();
+    });
+
+    it('treats an error body that is not the API envelope as intercepted', async () => {
+        globalThis.fetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ message: 'Forbidden' }), {
+                status: 403,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+
+        await expect(request()).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                message: expect.stringContaining(
+                    'with HTTP 403 instead of Lightdash',
+                ),
+                data: { kind: 'intercepted', responseStatus: 403 },
             },
         });
     });

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -19,6 +19,7 @@ import { recordServerBuildHash } from './features/buildHashHandshake/buildHashHa
 import { getFromInMemoryStorage } from './utils/inMemoryStorage';
 import {
     diagnoseTransportFailure,
+    GENERIC_NETWORK_FAILURE_MESSAGE,
     networkFailureMessage,
     UnexpectedResponseError,
 } from './utils/networkDiagnostics';
@@ -114,11 +115,22 @@ const parseJsonBody = (r: Response): Promise<AnyType> =>
         throw new UnexpectedResponseError(r.status);
     });
 
+// An error status with a body that is not the API envelope came from
+// something in front of Lightdash, not from Lightdash.
+const parseErrorBody = (r: Response): Promise<ApiError> =>
+    parseJsonBody(r).then((d) => {
+        if (isApiError(d)) return d;
+        throw new UnexpectedResponseError(r.status);
+    });
+
 type FailedRequest = {
     method: string;
     url: string;
     apiPrefix: string;
     traceId: string | null;
+    // Rendered inside a host application (SDK or embed): the viewer gets the
+    // generic message and no diagnostics, which would name the Lightdash host.
+    hosted: boolean;
 };
 
 const handleError = async (
@@ -153,8 +165,10 @@ const handleError = async (
         error: {
             name: 'NetworkError',
             statusCode: 500,
-            message: networkFailureMessage(diagnostics),
-            data: diagnostics,
+            message: request.hosted
+                ? GENERIC_NETWORK_FAILURE_MESSAGE
+                : networkFailureMessage(diagnostics),
+            data: request.hosted ? {} : diagnostics,
         },
     };
 };
@@ -226,7 +240,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
         .then((r) => {
             recordServerBuildHash(r);
             if (!r.ok) {
-                return parseJsonBody(r).then((d) => {
+                return parseErrorBody(r).then((d) => {
                     throw d;
                 });
             }
@@ -271,6 +285,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
                 url,
                 apiPrefix,
                 traceId: sentryTrace?.split('-')[0] ?? null,
+                hosted: baseUrl !== null || !!embed?.token,
             });
             networkHistory.push(
                 sensitive
@@ -339,12 +354,13 @@ export const lightdashApiStream = ({
         signal,
     }).then(async (r) => {
         if (!r.ok) {
-            const error: unknown = await parseJsonBody(r).catch((e) => e);
+            const error: unknown = await parseErrorBody(r).catch((e) => e);
             const apiError = await handleError(error, {
                 method,
                 url,
                 apiPrefix,
                 traceId: sentryTrace?.split('-')[0] ?? null,
+                hosted: baseUrl !== null || !!embed?.token,
             });
             throw new Error(apiError.error.message);
         }

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -158,9 +158,14 @@ const NetworkFailureMessage = ({
     apiError: ApiErrorDetail;
     showSupportButton: boolean;
 }) => {
-    const diagnostics = isNetworkDiagnostics(apiError.data)
-        ? formatNetworkDiagnostics(apiError.data)
-        : apiError.message;
+    if (!isNetworkDiagnostics(apiError.data)) {
+        return (
+            <Text mb={0} fz="xs">
+                {apiError.message}
+            </Text>
+        );
+    }
+    const diagnostics = formatNetworkDiagnostics(apiError.data);
     return (
         <Stack gap="xxs" align="start">
             <Text mb={0} fz="xs">

--- a/packages/frontend/src/utils/networkDiagnostics.test.ts
+++ b/packages/frontend/src/utils/networkDiagnostics.test.ts
@@ -4,6 +4,7 @@ import {
     formatNetworkDiagnostics,
     isNetworkDiagnostics,
     networkFailureMessage,
+    redactRequestPath,
     UnexpectedResponseError,
 } from './networkDiagnostics';
 
@@ -99,16 +100,40 @@ describe('diagnoseTransportFailure', () => {
     });
 });
 
+describe('redactRequestPath', () => {
+    it('drops the query string and keeps a relative prefix relative', () => {
+        expect(redactRequestPath('/api/v1', '/search?q=secret+term')).toBe(
+            '/api/v1/search',
+        );
+        expect(
+            redactRequestPath('http://test.lightdash/api/v1', '/projects/abc'),
+        ).toBe('http://test.lightdash/api/v1/projects/abc');
+    });
+
+    it('masks one-time codes in the path', () => {
+        expect(redactRequestPath('/api/v1', '/password-reset/abc123')).toBe(
+            '/api/v1/password-reset/***',
+        );
+        expect(
+            redactRequestPath('/api/v1', '/invite-links/code42/activate'),
+        ).toBe('/api/v1/invite-links/***/activate');
+        expect(redactRequestPath('/api/v1', '/share/n4n0id')).toBe(
+            '/api/v1/share/***',
+        );
+    });
+});
+
 describe('networkFailureMessage', () => {
-    it('names the request and the likely culprit per kind', async () => {
+    it('names the likely culprit per kind without the request', async () => {
         globalThis.fetch = vi.fn().mockResolvedValue(healthOk());
         const blocked = await diagnoseTransportFailure({
             ...request,
             error: new TypeError('Failed to fetch'),
         });
         expect(networkFailureMessage(blocked)).toContain(
-            'Lightdash is reachable, but PATCH http://test.lightdash/api/v1/projects/abc was blocked',
+            'Lightdash is reachable, but this request was blocked',
         );
+        expect(networkFailureMessage(blocked)).not.toContain('/projects/abc');
 
         const intercepted = await diagnoseTransportFailure({
             ...request,

--- a/packages/frontend/src/utils/networkDiagnostics.ts
+++ b/packages/frontend/src/utils/networkDiagnostics.ts
@@ -41,6 +41,24 @@ export type NetworkDiagnostics = {
 
 const PROBE_TIMEOUT_MS = 4000;
 
+// Path segments that follow these carry a one-time code.
+const CODE_BEARING_SEGMENTS = ['password-reset', 'invite-links', 'share'];
+
+// The request as it may be shown to people: no query string, no one-time
+// codes, and the host only when the request left the page's own origin.
+export const redactRequestPath = (apiPrefix: string, url: string): string => {
+    const raw = `${apiPrefix}${url}`;
+    const absolute = /^https?:\/\//.test(raw);
+    const parsed = new URL(raw, 'http://relative.invalid');
+    const segments = parsed.pathname.split('/');
+    const masked = segments.map((segment, index) =>
+        index > 0 && CODE_BEARING_SEGMENTS.includes(segments[index - 1])
+            ? '***'
+            : segment,
+    );
+    return `${absolute ? parsed.origin : ''}${masked.join('/')}`;
+};
+
 const isAbortError = (err: unknown): boolean =>
     typeof err === 'object' &&
     err !== null &&
@@ -89,7 +107,7 @@ export const diagnoseTransportFailure = async ({
     const base = {
         at: new Date().toISOString(),
         method,
-        path: `${apiPrefix}${url}`,
+        path: redactRequestPath(apiPrefix, url),
         online: isOnline(),
         cause: getErrorMessage(error),
         traceId,
@@ -126,19 +144,22 @@ export const diagnoseTransportFailure = async ({
     };
 };
 
+export const GENERIC_NETWORK_FAILURE_MESSAGE =
+    'We are currently unable to reach the Lightdash server. Please try again in a few moments.';
+
+// Names the cause only; the request itself lives in the copied diagnostics.
 export const networkFailureMessage = (d: NetworkDiagnostics): string => {
-    const request = `${d.method} ${d.path}`;
     switch (d.kind) {
         case 'offline':
             return 'You appear to be offline. Check your internet connection and try again.';
         case 'blocked':
-            return `Lightdash is reachable, but ${request} was blocked before it arrived. A corporate proxy, VPN or security software on your network most likely intercepted it. Try again from another network, or copy the diagnostics for your IT team.`;
+            return 'Lightdash is reachable, but this request was blocked before it arrived. A corporate proxy, VPN or security software on your network most likely intercepted it. Try again from another network, or copy the diagnostics for your IT team.';
         case 'unreachable':
-            return `Lightdash cannot be reached from your network right now (${request}). Check your connection or VPN and try again.`;
+            return 'Lightdash cannot be reached from your network right now. Check your connection or VPN and try again.';
         case 'intercepted':
-            return `Something between you and Lightdash answered ${request} with HTTP ${d.responseStatus} instead of Lightdash. A proxy, firewall or load balancer intercepted it. Try again in a few moments, or copy the diagnostics for your IT team.`;
+            return `Something between you and Lightdash answered this request with HTTP ${d.responseStatus} instead of Lightdash. A proxy, firewall or load balancer intercepted it. Try again in a few moments, or copy the diagnostics for your IT team.`;
         case 'cancelled':
-            return `${request} was cancelled before Lightdash responded.`;
+            return 'The request was cancelled before Lightdash responded.';
         default:
             return assertUnreachable(d.kind, 'Unknown transport failure');
     }


### PR DESCRIPTION
## Problem

#28875 made the "unable to reach the server" toast name the failing request. Reviewing what that puts on screen:

- **SDK and embeds.** The API prefix is the SDK instance URL and embed mode appends `projectUuid`, so an end viewer of a white-labelled dashboard would read the Lightdash host and project id in the toast.
- **One-time codes.** Password reset, invite link and share requests carry the code in the path, so a transport failure on those pages printed it in the toast and in the copied report.
- **Query strings.** Search terms and filter values in GET URLs appeared in the toast.

Separately, an error status whose body is JSON but not the API envelope (a gateway's own `{"message":"Forbidden"}`) skipped the envelope check, passed the health probe, and produced a confident "blocked by a proxy or VPN" message.

Nothing secret was reaching the toast or the report: no headers, cookies, JWT, request or response bodies, and `getErrorMessage` only ever returns an Error message or a string. This PR is about what non-technical viewers should see.

## Fix

- The toast names the cause only ("this request was blocked before it arrived"). The request line lives in the copied diagnostics.
- `redactRequestPath` drops the query string, masks the segment after `password-reset`, `invite-links` and `share`, and keeps the host only when the request left the page's origin.
- A hosted page (SDK instance URL in session storage, or an embed token in memory) gets the original generic message with empty `data`, and the toast renders no Copy diagnostics or Notify support buttons when there are no diagnostics. The Sentry breadcrumb still carries the full diagnosis.
- `parseErrorBody` throws `UnexpectedResponseError(status)` for a non-envelope JSON error body on both `lightdashApi` and `lightdashApiStream`, so it is classified as intercepted.

## Regression analysis

- Real API errors are unchanged: any body with `status: 'error'` passes through as before, and the `NetworkError` name and 500 status the retry policy keys on are untouched.
- Network history entries for the support drawer still carry the diagnostics (now with the redacted path).
- Users of the app itself see the same diagnosis with the same buttons; only the request line moved from the toast text to the copied report.

## Verification

29 tests pass across `api.test.ts` and `networkDiagnostics.test.ts`, including new ones for the path staying out of the toast, the embed fallback, the non-envelope JSON body, query string dropping and code masking. Typecheck, oxlint and oxfmt clean.

No ticket exists for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BnwSAJkNVeQekScvRYfTN5
