### PR TITLE
feat: resolve org-scoped analytics files using signed storage URLs

### DIFF
--- a/docs/development/analytics-storage-credentials.md
+++ b/docs/development/analytics-storage-credentials.md
@@ -9,12 +9,13 @@ check the shared flag before constructing the resolver.
 ## Reuse existing writer configuration
 
 `createS3AnalyticsSourceResolver` accepts server-owned storage configuration from
-the existing usage-events writer and a validated org/date range. It reuses the
+the existing usage-events writer and a validated org. It reuses the
 backend's S3 SDK authentication. There is no CLI authentication, OAuth exchange,
 new service account, or Terraform requirement for this temporary read path.
 
 The resolver lists only `events/compacted/org_id=<org>/` and selects the existing
-`query_events` and `ai_usage` Parquet files in the date range. It signs exact GET
+`query_events` and `ai_usage` Parquet files across all retained dates. Date filters
+belong to Explore queries; there is no fixed source date window. It signs exact GET
 URLs with 15-minute lifetimes. The file manifest and signatures are refreshed for
 each DuckDB session. Listing is bounded and fails closed on malformed pagination,
 cross-org objects, missing data, or credential failures.
@@ -54,8 +55,8 @@ The opt-in cloud test is read-only. Set `ANALYTICS_S3_LIVE_ENV_FILE` to a secure
 environment file containing the existing `USAGE_EVENTS_S3_BUCKET`,
 `USAGE_EVENTS_S3_ACCESS_KEY`, `USAGE_EVENTS_S3_SECRET_KEY`, and
 `USAGE_EVENTS_S3_REGION` settings. Only those settings are read; no database or
-other instance configuration is loaded. Set `ANALYTICS_S3_LIVE_ORG_UUID`,
-`ANALYTICS_S3_LIVE_START_DATE`, and `ANALYTICS_S3_LIVE_END_DATE`. The endpoint
+other instance configuration is loaded. Set `ANALYTICS_S3_LIVE_ORG_UUID`. The test
+queries all retained partitions for that org. The endpoint
 defaults to GCS; override `ANALYTICS_S3_LIVE_ENDPOINT` for another S3 service.
 
 ```sh

--- a/docs/development/analytics-storage-credentials.md
+++ b/docs/development/analytics-storage-credentials.md
@@ -1,0 +1,68 @@
+# Analytics storage credentials
+
+The stack is connector + `analytics-project` flag → bucket access (this change)
+→ project provisioning with both system explores. Dedicated read-only credentials
+are deferred to PROD-11103. This change does not enable a public connector or add
+any HTTP endpoint. Provisioning must authorize the persisted project's org and
+check the shared flag before constructing the resolver.
+
+## Reuse existing writer configuration
+
+`createS3AnalyticsSourceResolver` accepts server-owned storage configuration from
+the existing usage-events writer and a validated org/date range. It reuses the
+backend's S3 SDK authentication. There is no CLI authentication, OAuth exchange,
+new service account, or Terraform requirement for this temporary read path.
+
+The resolver lists only `events/compacted/org_id=<org>/` and selects the existing
+`query_events` and `ai_usage` Parquet files in the date range. It signs exact GET
+URLs with 15-minute lifetimes. The file manifest and signatures are refreshed for
+each DuckDB session. Listing is bounded and fails closed on malformed pagination,
+cross-org objects, missing data, or credential failures.
+
+DuckDB receives the signed URLs, not the access key/secret or bucket-wide secret.
+Signed URLs are capabilities: never expose them through API responses, model SQL,
+logs, or project configuration. The connector restricts access to the exact signed
+file list, blocks catalog queries that disclose view SQL, sanitizes native errors,
+disables profiling, disables file/metadata caches and spill, and uses a separate
+in-memory instance for each query. HTTP is allowed only for loopback test storage;
+remote endpoints require HTTPS.
+
+The native HTTP reader can retry a rejected HEAD request with a ranged GET; both
+the live GCS test and local MinIO test exercise this with GET-signed URLs. Expired
+URLs fail closed; retry the query to obtain a fresh manifest and signatures.
+
+The trusted backend still holds write-capable credentials. A compromised backend
+or authorization bug in the signer remains a risk. Read-only identity migration
+reduces writer privilege exposure; it does not replace org authorization. Until
+that migration, credentials may also cover other storage used by the deployment.
+
+## Validation
+
+Unit coverage tests prefix filtering, pagination, exact GET signing, invalid scope,
+credential-free manifests, native-error redaction, and blocked catalog/file reads.
+
+The opt-in local test creates a uniquely named bucket on loopback MinIO, uploads
+synthetic Parquet, runs actual DuckDB queries, verifies tampered cross-org URLs,
+PUT attempts, and expired URLs fail, and deletes only its own fixtures/bucket.
+Supply local MinIO credentials as `S3_ACCESS_KEY` / `S3_SECRET_KEY` and run:
+
+```sh
+ANALYTICS_S3_SMOKE_ENDPOINT=http://localhost:9000 pnpm -F backend test src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
+```
+
+The opt-in cloud test is read-only. Set `ANALYTICS_S3_LIVE_ENV_FILE` to a secure
+environment file containing the existing `USAGE_EVENTS_S3_BUCKET`,
+`USAGE_EVENTS_S3_ACCESS_KEY`, `USAGE_EVENTS_S3_SECRET_KEY`, and
+`USAGE_EVENTS_S3_REGION` settings. Only those settings are read; no database or
+other instance configuration is loaded. Set `ANALYTICS_S3_LIVE_ORG_UUID`,
+`ANALYTICS_S3_LIVE_START_DATE`, and `ANALYTICS_S3_LIVE_END_DATE`. The endpoint
+defaults to GCS; override `ANALYTICS_S3_LIVE_ENDPOINT` for another S3 service.
+
+```sh
+pnpm -F backend test src/services/ProjectService/analyticsProject/S3AnalyticsSource.live.test.ts
+```
+
+Both external suites are skipped unless explicitly configured. Never commit an
+environment file, signed URL, credential, or customer-specific test fixture.
+Read-only production credential rollout is tracked separately in PROD-11103;
+ingestion credentials and cloud infrastructure are unchanged here.

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.live.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.live.test.ts
@@ -24,8 +24,6 @@ describe.skipIf(!process.env.ANALYTICS_S3_LIVE_ENV_FILE)(
                     region: settings.USAGE_EVENTS_S3_REGION,
                 },
                 organizationUuid: process.env.ANALYTICS_S3_LIVE_ORG_UUID ?? '',
-                startDate: process.env.ANALYTICS_S3_LIVE_START_DATE ?? '',
-                endDate: process.env.ANALYTICS_S3_LIVE_END_DATE ?? '',
             });
             const source = await resolveSource();
             expect(source).not.toHaveProperty('s3Config');

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.live.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.live.test.ts
@@ -1,0 +1,60 @@
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { parse } from 'dotenv';
+import { readFile } from 'fs/promises';
+import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
+
+// Reads only the named storage settings. Never loads another instance's DB config.
+describe.skipIf(!process.env.ANALYTICS_S3_LIVE_ENV_FILE)(
+    'signed analytics URLs against existing cloud Parquet (read-only)',
+    () => {
+        beforeAll(() => vi.unstubAllGlobals());
+
+        it('queries both streams without CLI authentication or bucket credentials in DuckDB', async () => {
+            const settings = parse(
+                await readFile(process.env.ANALYTICS_S3_LIVE_ENV_FILE!, 'utf8'),
+            );
+            const resolveSource = createS3AnalyticsSourceResolver({
+                storage: {
+                    endpoint:
+                        process.env.ANALYTICS_S3_LIVE_ENDPOINT ??
+                        'https://storage.googleapis.com',
+                    bucket: settings.USAGE_EVENTS_S3_BUCKET,
+                    accessKey: settings.USAGE_EVENTS_S3_ACCESS_KEY,
+                    secretKey: settings.USAGE_EVENTS_S3_SECRET_KEY,
+                    region: settings.USAGE_EVENTS_S3_REGION,
+                },
+                organizationUuid: process.env.ANALYTICS_S3_LIVE_ORG_UUID ?? '',
+                startDate: process.env.ANALYTICS_S3_LIVE_START_DATE ?? '',
+                endDate: process.env.ANALYTICS_S3_LIVE_END_DATE ?? '',
+            });
+            const source = await resolveSource();
+            expect(source).not.toHaveProperty('s3Config');
+            expect(source).not.toHaveProperty('httpAuth');
+            expect(source.tables.map(({ name }) => name).sort()).toEqual([
+                'ai_usage',
+                'query_events',
+            ]);
+            const reader = new DuckdbWarehouseClient({
+                type: 'duckdb_parquet',
+                resolveSource,
+            });
+            const queries = await reader.runQuery(
+                'SELECT count(*) AS events FROM query_events',
+            );
+            const ai = await reader.runQuery(
+                'SELECT count(*) AS events, sum(total_tokens) AS total_tokens FROM ai_usage',
+            );
+            expect(Number(queries.rows[0].events)).toBeGreaterThan(0);
+            expect(Number(ai.rows[0].events)).toBeGreaterThan(0);
+            expect(Number(ai.rows[0].total_tokens)).toBeGreaterThan(0);
+            // Counts only: do not print URLs, tokens, object names or user records.
+            console.info('Verified live analytics counts', {
+                queryEvents: queries.rows[0].events,
+                aiUsage: ai.rows[0].events,
+            });
+            await expect(
+                reader.runQuery('SELECT sql FROM duckdb_views()'),
+            ).rejects.toThrow(/catalog access/);
+        }, 120_000);
+    },
+);

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
@@ -44,19 +44,27 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 `events/compacted/org_id=${org}/stream=query_events/dt=2026-09-07/part.parquet`,
                 `events/compacted/org_id=${org}/stream=ai_usage/dt=2026-09-07/part.parquet`,
                 `events/compacted/org_id=${otherOrg}/stream=query_events/dt=2026-09-07/part.parquet`,
+                `events/compacted/org_id=${org}/stream=query_events/dt=2025-09-07/part.parquet`,
             ];
             const client = createS3ClientFromConfig(storage);
             const directory = await mkdtemp(
                 path.join(tmpdir(), 'ld-analytics-auth-'),
             );
             const fixture = path.join(directory, 'fixture.parquet');
+            const historicalFixture = path.join(
+                directory,
+                'historical.parquet',
+            );
             let created = false;
             try {
                 const instance = await DuckDBInstance.create(':memory:');
                 const db = await instance.connect();
                 try {
                     await db.run(
-                        `COPY (SELECT 42::INTEGER AS tokens) TO '${fixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
+                        `COPY (SELECT 42::INTEGER AS tokens, TIMESTAMP '2026-09-07' AS event_ts) TO '${fixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
+                    );
+                    await db.run(
+                        `COPY (SELECT 42::INTEGER AS tokens, TIMESTAMP '2025-09-07' AS event_ts) TO '${historicalFixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
                     );
                 } finally {
                     db.closeSync();
@@ -67,13 +75,16 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 );
                 created = true;
                 const body = await readFile(fixture);
+                const historicalBody = await readFile(historicalFixture);
                 await Promise.all(
                     keys.map((Key) =>
                         client.send(
                             new PutObjectCommand({
                                 Bucket: storage.bucket,
                                 Key,
-                                Body: body,
+                                Body: Key.includes('/dt=2025-09-07/')
+                                    ? historicalBody
+                                    : body,
                             }),
                         ),
                     ),
@@ -81,8 +92,6 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 const resolveSource = createS3AnalyticsSourceResolver({
                     storage,
                     organizationUuid: org,
-                    startDate: '2026-09-07',
-                    endDate: '2026-09-07',
                 });
                 const reader = new DuckdbWarehouseClient({
                     type: 'duckdb_parquet',
@@ -92,6 +101,13 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                     (
                         await reader.runQuery(
                             'SELECT sum(tokens) AS total FROM query_events',
+                        )
+                    ).rows,
+                ).toEqual([{ total: '84' }]);
+                expect(
+                    (
+                        await reader.runQuery(
+                            "SELECT sum(tokens) AS total FROM query_events WHERE event_ts >= TIMESTAMP '2025-09-07' AND event_ts < TIMESTAMP '2025-09-08'",
                         )
                     ).rows,
                 ).toEqual([{ total: '42' }]);
@@ -149,7 +165,7 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                             'SELECT sum(tokens) AS total FROM query_events',
                         )
                     ).rows,
-                ).toEqual([{ total: '42' }]);
+                ).toEqual([{ total: '84' }]);
             } finally {
                 if (created) {
                     await Promise.all(
@@ -168,6 +184,7 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 }
                 client.destroy();
                 await rm(fixture, { force: true });
+                await rm(historicalFixture, { force: true });
                 await rmdir(directory);
             }
         }, 120_000);

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
@@ -1,0 +1,175 @@
+import {
+    CreateBucketCommand,
+    DeleteBucketCommand,
+    DeleteObjectCommand,
+    GetObjectCommand,
+    PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { randomUUID } from 'crypto';
+import { mkdtemp, readFile, rm, rmdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
+import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
+
+// Opt-in, disposable local MinIO bucket; never writes to a cloud bucket.
+describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
+    'signed analytics URLs with real DuckDB and local S3',
+    () => {
+        beforeAll(() => vi.unstubAllGlobals());
+
+        it('queries both streams and rejects changed org paths, PUTs and metadata access', async () => {
+            const endpoint = process.env.ANALYTICS_S3_SMOKE_ENDPOINT ?? '';
+            if (
+                !['localhost', '127.0.0.1'].includes(new URL(endpoint).hostname)
+            ) {
+                throw new Error(
+                    'Smoke fixture writes require a loopback S3 endpoint',
+                );
+            }
+            const storage = {
+                endpoint,
+                bucket: `ld-analytics-auth-${randomUUID()}`,
+                region: process.env.S3_REGION ?? 'us-east-1',
+                accessKey: process.env.S3_ACCESS_KEY,
+                secretKey: process.env.S3_SECRET_KEY,
+                forcePathStyle: true,
+            };
+            const org = '00000000-0000-0000-0000-000000000001';
+            const otherOrg = '00000000-0000-0000-0000-000000000002';
+            const keys = [
+                `events/compacted/org_id=${org}/stream=query_events/dt=2026-09-07/part.parquet`,
+                `events/compacted/org_id=${org}/stream=ai_usage/dt=2026-09-07/part.parquet`,
+                `events/compacted/org_id=${otherOrg}/stream=query_events/dt=2026-09-07/part.parquet`,
+            ];
+            const client = createS3ClientFromConfig(storage);
+            const directory = await mkdtemp(
+                path.join(tmpdir(), 'ld-analytics-auth-'),
+            );
+            const fixture = path.join(directory, 'fixture.parquet');
+            let created = false;
+            try {
+                const instance = await DuckDBInstance.create(':memory:');
+                const db = await instance.connect();
+                try {
+                    await db.run(
+                        `COPY (SELECT 42::INTEGER AS tokens) TO '${fixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
+                    );
+                } finally {
+                    db.closeSync();
+                    instance.closeSync();
+                }
+                await client.send(
+                    new CreateBucketCommand({ Bucket: storage.bucket }),
+                );
+                created = true;
+                const body = await readFile(fixture);
+                await Promise.all(
+                    keys.map((Key) =>
+                        client.send(
+                            new PutObjectCommand({
+                                Bucket: storage.bucket,
+                                Key,
+                                Body: body,
+                            }),
+                        ),
+                    ),
+                );
+                const resolveSource = createS3AnalyticsSourceResolver({
+                    storage,
+                    organizationUuid: org,
+                    startDate: '2026-09-07',
+                    endDate: '2026-09-07',
+                });
+                const reader = new DuckdbWarehouseClient({
+                    type: 'duckdb_parquet',
+                    resolveSource,
+                });
+                expect(
+                    (
+                        await reader.runQuery(
+                            'SELECT sum(tokens) AS total FROM query_events',
+                        )
+                    ).rows,
+                ).toEqual([{ total: '42' }]);
+                expect(
+                    (
+                        await reader.runQuery(
+                            'SELECT sum(tokens) AS total FROM ai_usage',
+                        )
+                    ).rows,
+                ).toEqual([{ total: '42' }]);
+                await expect(
+                    reader.runQuery('SELECT sql FROM duckdb_views()'),
+                ).rejects.toThrow(/catalog access/);
+                const source = await resolveSource();
+                expect(source).not.toHaveProperty('s3Config');
+                const url = source.tables[0].urls[0];
+                const otherPath = url.replace(org, otherOrg);
+                const denied = await fetch(otherPath);
+                expect(denied.status).toBe(403);
+                await denied.body?.cancel();
+                // A signed GET must not authorize a write, even with writer-origin credentials.
+                const write = await fetch(url, {
+                    method: 'PUT',
+                    body: 'not-parquet',
+                });
+                expect(write.status).toBe(403);
+                await write.body?.cancel();
+                const expired = await getSignedUrl(
+                    client,
+                    new GetObjectCommand({
+                        Bucket: storage.bucket,
+                        Key: keys[0],
+                    }),
+                    {
+                        expiresIn: 1,
+                        signingDate: new Date(Date.now() - 60_000),
+                    },
+                );
+                const failedReader = new DuckdbWarehouseClient({
+                    type: 'duckdb_parquet',
+                    resolveSource: async () => ({
+                        ...source,
+                        tables: [{ name: 'query_events', urls: [expired] }],
+                    }),
+                });
+                await expect(
+                    failedReader.runQuery('SELECT count(*) FROM query_events'),
+                ).rejects.toThrow(
+                    /^Internal analytics query failed\. Check storage access and query permissions\.$/,
+                );
+                // Neither denied attempt modified the original object.
+                expect(
+                    (
+                        await reader.runQuery(
+                            'SELECT sum(tokens) AS total FROM query_events',
+                        )
+                    ).rows,
+                ).toEqual([{ total: '42' }]);
+            } finally {
+                if (created) {
+                    await Promise.all(
+                        keys.map((Key) =>
+                            client.send(
+                                new DeleteObjectCommand({
+                                    Bucket: storage.bucket,
+                                    Key,
+                                }),
+                            ),
+                        ),
+                    );
+                    await client.send(
+                        new DeleteBucketCommand({ Bucket: storage.bucket }),
+                    );
+                }
+                client.destroy();
+                await rm(fixture, { force: true });
+                await rmdir(directory);
+            }
+        }, 120_000);
+    },
+);

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
@@ -1,0 +1,140 @@
+import { GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
+import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
+
+vi.mock('../../../clients/Aws/S3BaseClient', () => ({
+    createS3ClientFromConfig: vi.fn(),
+}));
+vi.mock('@aws-sdk/s3-request-presigner', () => ({ getSignedUrl: vi.fn() }));
+
+describe('signed analytics file manifests', () => {
+    const org = '00000000-0000-0000-0000-000000000001';
+    const prefix = `events/compacted/org_id=${org}/`;
+    const config = {
+        storage: {
+            endpoint: 'https://storage.googleapis.com',
+            bucket: 'example-bucket',
+            region: 'us-east4',
+            accessKey: 'writer-access-key',
+            secretKey: 'writer-secret',
+        },
+        organizationUuid: org,
+        startDate: '2026-09-07',
+        endDate: '2026-09-07',
+    };
+    const key = (stream = 'query_events', date = '2026-09-07') =>
+        `${prefix}stream=${stream}/dt=${date}/part-1.parquet`;
+    const send = vi.fn();
+    const destroy = vi.fn();
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(createS3ClientFromConfig).mockReturnValue({
+            send,
+            destroy,
+        } as unknown as ReturnType<typeof createS3ClientFromConfig>);
+        send.mockResolvedValue({ Contents: [{ Key: key() }] });
+        vi.mocked(getSignedUrl).mockResolvedValue('signed-url');
+    });
+
+    it('uses writer config only for prefix listing and signing exact GETs', async () => {
+        const resolve = createS3AnalyticsSourceResolver(config);
+        expect(createS3ClientFromConfig).not.toHaveBeenCalled();
+        const source = await resolve();
+        expect(createS3ClientFromConfig).toHaveBeenCalledWith({
+            ...config.storage,
+            forcePathStyle: true,
+        });
+        expect(send.mock.calls[0][0]).toBeInstanceOf(ListObjectsV2Command);
+        expect(send.mock.calls[0][0].input).toMatchObject({
+            Bucket: config.storage.bucket,
+            Prefix: prefix,
+        });
+        const [, command, options] = vi.mocked(getSignedUrl).mock.calls[0];
+        expect(command).toBeInstanceOf(GetObjectCommand);
+        expect(command.input).toEqual({ Bucket: 'example-bucket', Key: key() });
+        expect(options).toEqual({ expiresIn: 900 });
+        expect(source).toEqual({
+            scope: `https://storage.googleapis.com/example-bucket/events/compacted/org_id%3D${org}/`,
+            signedUrls: true,
+            tables: [{ name: 'query_events', urls: ['signed-url'] }],
+        });
+        expect(JSON.stringify(source)).not.toContain('writer-');
+        expect(destroy).toHaveBeenCalledOnce();
+    });
+
+    it('handles pagination and only signs known streams in the selected date range', async () => {
+        send.mockResolvedValueOnce({
+            Contents: [
+                { Key: key('query_events', '2026-09-06') },
+                { Key: key('other') },
+                { Key: key() },
+            ],
+            IsTruncated: true,
+            NextContinuationToken: 'next',
+        }).mockResolvedValueOnce({ Contents: [{ Key: key('ai_usage') }] });
+        const source = await createS3AnalyticsSourceResolver(config)();
+        expect(source.tables.map(({ name }) => name)).toEqual([
+            'query_events',
+            'ai_usage',
+        ]);
+        expect(getSignedUrl).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[1][0].input.ContinuationToken).toBe('next');
+    });
+
+    it('refreshes the manifest and signatures on each query', async () => {
+        const resolve = createS3AnalyticsSourceResolver(config);
+        await resolve();
+        await resolve();
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(getSignedUrl).toHaveBeenCalledTimes(2);
+        expect(destroy).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        { ...config, organizationUuid: '../other' },
+        { ...config, organizationUuid: '-'.repeat(36) },
+        { ...config, startDate: '2026-09-08' },
+        { ...config, storage: { ...config.storage, bucket: 'bucket/other' } },
+        {
+            ...config,
+            storage: { ...config.storage, endpoint: 'http://remote.test' },
+        },
+        {
+            ...config,
+            storage: {
+                ...config.storage,
+                endpoint: 'https://user:pass@host.test',
+            },
+        },
+    ])('rejects unsafe config before accessing storage', (invalid) => {
+        expect(() => createS3AnalyticsSourceResolver(invalid)).toThrow();
+        expect(createS3ClientFromConfig).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { Contents: [{ Key: 'events/compacted/org_id=other/file.parquet' }] },
+        { Contents: [] },
+        { Contents: [{ Key: `${prefix}../other/part.parquet` }] },
+        { Contents: [], IsTruncated: true },
+    ])('fails closed on invalid or empty manifests', async (response) => {
+        send.mockResolvedValue(response);
+        await expect(createS3AnalyticsSourceResolver(config)()).rejects.toThrow(
+            'Analytics storage access failed',
+        );
+        expect(getSignedUrl).not.toHaveBeenCalled();
+        expect(destroy).toHaveBeenCalledOnce();
+    });
+
+    it('sanitizes SDK errors without falling back to bucket credentials', async () => {
+        send.mockRejectedValue(
+            new Error('writer-secret and X-Amz-Signature=secret'),
+        );
+        await expect(createS3AnalyticsSourceResolver(config)()).rejects.toThrow(
+            /^Analytics storage access failed\. Check bucket credentials, organization and compacted data availability\.$/,
+        );
+        expect(getSignedUrl).not.toHaveBeenCalled();
+        expect(destroy).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
@@ -20,8 +20,6 @@ describe('signed analytics file manifests', () => {
             secretKey: 'writer-secret',
         },
         organizationUuid: org,
-        startDate: '2026-09-07',
-        endDate: '2026-09-07',
     };
     const key = (stream = 'query_events', date = '2026-09-07') =>
         `${prefix}stream=${stream}/dt=${date}/part-1.parquet`;
@@ -64,10 +62,10 @@ describe('signed analytics file manifests', () => {
         expect(destroy).toHaveBeenCalledOnce();
     });
 
-    it('handles pagination and only signs known streams in the selected date range', async () => {
+    it('includes all retained dates across pages, including year-old data, for supported streams only', async () => {
         send.mockResolvedValueOnce({
             Contents: [
-                { Key: key('query_events', '2026-09-06') },
+                { Key: key('query_events', '2025-09-07') },
                 { Key: key('other') },
                 { Key: key() },
             ],
@@ -79,7 +77,14 @@ describe('signed analytics file manifests', () => {
             'query_events',
             'ai_usage',
         ]);
-        expect(getSignedUrl).toHaveBeenCalledTimes(2);
+        expect(getSignedUrl).toHaveBeenCalledTimes(3);
+        expect(
+            vi
+                .mocked(getSignedUrl)
+                .mock.calls.map(
+                    ([, command]) => (command as GetObjectCommand).input.Key,
+                ),
+        ).toEqual([key('query_events', '2025-09-07'), key(), key('ai_usage')]);
         expect(send.mock.calls[1][0].input.ContinuationToken).toBe('next');
     });
 
@@ -92,10 +97,24 @@ describe('signed analytics file manifests', () => {
         expect(destroy).toHaveBeenCalledTimes(2);
     });
 
+    it('fails rather than exposing partial history when the file cap is exceeded', async () => {
+        send.mockResolvedValue({
+            Contents: Array.from({ length: 1000 }, (_, index) => ({
+                Key: `${prefix}stream=query_events/dt=2025-09-07/part-${index}.parquet`,
+            })),
+            IsTruncated: true,
+            NextContinuationToken: 'next',
+        });
+        await expect(createS3AnalyticsSourceResolver(config)()).rejects.toThrow(
+            'Analytics storage access failed',
+        );
+        expect(getSignedUrl).toHaveBeenCalledTimes(10_000);
+        expect(destroy).toHaveBeenCalledOnce();
+    });
+
     it.each([
         { ...config, organizationUuid: '../other' },
         { ...config, organizationUuid: '-'.repeat(36) },
-        { ...config, startDate: '2026-09-08' },
         { ...config, storage: { ...config.storage, bucket: 'bucket/other' } },
         {
             ...config,

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
@@ -10,8 +10,6 @@ import {
 type S3AnalyticsSourceConfig = {
     storage: S3ConnectionConfig & { bucket: string };
     organizationUuid: string;
-    startDate: string;
-    endDate: string;
 };
 
 const SIGNED_URL_LIFETIME_SECONDS = 900;
@@ -21,20 +19,15 @@ const MAX_FILES = 10_000;
 export const createS3AnalyticsSourceResolver = ({
     storage,
     organizationUuid,
-    startDate,
-    endDate,
 }: S3AnalyticsSourceConfig): (() => Promise<DuckdbParquetSource>) => {
     const { bucket } = storage;
     if (
         !/^[a-z0-9][a-z0-9.-]{1,220}[a-z0-9]$/.test(bucket) ||
         !/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(
             organizationUuid,
-        ) ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(startDate) ||
-        !/^\d{4}-\d{2}-\d{2}$/.test(endDate) ||
-        startDate > endDate
+        )
     ) {
-        throw new ParameterError('Invalid analytics storage scope or dates');
+        throw new ParameterError('Invalid analytics storage scope');
     }
     const endpoint = new URL(storage.endpoint ?? 'https://s3.amazonaws.com');
     if (
@@ -88,7 +81,9 @@ export const createS3AnalyticsSourceResolver = ({
                         /^stream=(query_events|ai_usage)\/dt=(\d{4}-\d{2}-\d{2})\/[a-zA-Z0-9_-]+\.parquet$/.exec(
                             key.slice(prefix.length),
                         );
-                    if (match && match[2] >= startDate && match[2] <= endDate) {
+                    // Expose all retained partitions. Date filters belong to
+                    // the Explore query, not a fixed source-level window.
+                    if (match) {
                         fileCount += 1;
                         if (fileCount > MAX_FILES)
                             throw new Error(

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
@@ -1,0 +1,135 @@
+import { GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { ParameterError } from '@lightdash/common';
+import { type DuckdbParquetSource } from '@lightdash/warehouses';
+import {
+    createS3ClientFromConfig,
+    type S3ConnectionConfig,
+} from '../../../clients/Aws/S3BaseClient';
+
+type S3AnalyticsSourceConfig = {
+    storage: S3ConnectionConfig & { bucket: string };
+    organizationUuid: string;
+    startDate: string;
+    endDate: string;
+};
+
+const SIGNED_URL_LIFETIME_SECONDS = 900;
+const MAX_FILES = 10_000;
+
+/** Server-only: the caller must authorize the persisted project org first. */
+export const createS3AnalyticsSourceResolver = ({
+    storage,
+    organizationUuid,
+    startDate,
+    endDate,
+}: S3AnalyticsSourceConfig): (() => Promise<DuckdbParquetSource>) => {
+    const { bucket } = storage;
+    if (
+        !/^[a-z0-9][a-z0-9.-]{1,220}[a-z0-9]$/.test(bucket) ||
+        !/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(
+            organizationUuid,
+        ) ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(startDate) ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(endDate) ||
+        startDate > endDate
+    ) {
+        throw new ParameterError('Invalid analytics storage scope or dates');
+    }
+    const endpoint = new URL(storage.endpoint ?? 'https://s3.amazonaws.com');
+    if (
+        (endpoint.protocol !== 'https:' &&
+            !(
+                endpoint.protocol === 'http:' &&
+                ['localhost', '127.0.0.1', '[::1]'].includes(endpoint.hostname)
+            )) ||
+        endpoint.username ||
+        endpoint.password ||
+        endpoint.search ||
+        endpoint.hash ||
+        endpoint.pathname !== '/'
+    ) {
+        throw new ParameterError(
+            'Analytics storage requires a secure endpoint',
+        );
+    }
+    const prefix = `events/compacted/org_id=${organizationUuid}/`;
+    const scope = `${endpoint.origin}/${bucket}/${prefix.split('/').map(encodeURIComponent).join('/')}`;
+    // A fresh SDK client per resolution avoids retaining credentials after reads.
+    const config = {
+        ...storage,
+        endpoint: endpoint.origin,
+        forcePathStyle: true,
+    };
+    return async () => {
+        const client = createS3ClientFromConfig(config);
+        try {
+            const tables = new Map<string, string[]>();
+            let continuationToken: string | undefined;
+            let pages = 0;
+            let fileCount = 0;
+            do {
+                // eslint-disable-next-line no-await-in-loop
+                const page = await client.send(
+                    new ListObjectsV2Command({
+                        Bucket: bucket,
+                        Prefix: prefix,
+                        MaxKeys: 1000,
+                        ContinuationToken: continuationToken,
+                    }),
+                    { abortSignal: AbortSignal.timeout(30_000) },
+                );
+                // eslint-disable-next-line no-restricted-syntax
+                for (const { Key: key } of page.Contents ?? []) {
+                    if (!key || !key.startsWith(prefix)) {
+                        throw new Error('Unexpected analytics object scope');
+                    }
+                    const match =
+                        /^stream=(query_events|ai_usage)\/dt=(\d{4}-\d{2}-\d{2})\/[a-zA-Z0-9_-]+\.parquet$/.exec(
+                            key.slice(prefix.length),
+                        );
+                    if (match && match[2] >= startDate && match[2] <= endDate) {
+                        fileCount += 1;
+                        if (fileCount > MAX_FILES)
+                            throw new Error(
+                                'Analytics manifest exceeds file limit',
+                            );
+                        // eslint-disable-next-line no-await-in-loop
+                        const url = await getSignedUrl(
+                            client,
+                            new GetObjectCommand({ Bucket: bucket, Key: key }),
+                            { expiresIn: SIGNED_URL_LIFETIME_SECONDS },
+                        );
+                        const urls = tables.get(match[1]) ?? [];
+                        urls.push(url);
+                        tables.set(match[1], urls);
+                    }
+                }
+                pages += 1;
+                continuationToken = page.IsTruncated
+                    ? page.NextContinuationToken
+                    : undefined;
+                if (page.IsTruncated && (!continuationToken || pages >= 100))
+                    throw new Error('Analytics listing cannot be completed');
+            } while (continuationToken);
+            if (tables.size === 0) {
+                throw new Error('No compacted analytics files found');
+            }
+            return {
+                scope,
+                signedUrls: true,
+                tables: [...tables].map(([name, urls]) => ({
+                    name,
+                    urls: urls.sort(),
+                })),
+            };
+        } catch {
+            // SDK errors may contain credentials, signatures, or object contents.
+            throw new Error(
+                'Analytics storage access failed. Check bucket credentials, organization and compacted data availability.',
+            );
+        } finally {
+            client.destroy();
+        }
+    };
+};

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -231,7 +231,61 @@ describe('internal Parquet projects', () => {
         });
         await expect(
             client.runQuery(`SELECT * FROM read_parquet('${url}')`),
-        ).rejects.toThrow(/not allowed/);
+        ).rejects.toThrow(/query permissions/);
+    });
+
+    it('allows exact signed GET URLs without configuring bucket credentials', async () => {
+        const signedScope = scope.replace('org_id=', 'org_id%3D');
+        const signedUrl = `${url.replace(/=/g, '%3D')}?X-Amz-Signature=test&X-Amz-Expires=900`;
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: async () => ({
+                scope: signedScope,
+                signedUrls: true,
+                tables: [{ name: 'query_events', urls: [signedUrl] }],
+            }),
+        });
+        await client.runQuery('SELECT count(*) FROM query_events');
+        expect(run).toHaveBeenCalledWith(
+            `SET allowed_paths = ['${signedUrl}'];`,
+        );
+        expect(run).not.toHaveBeenCalledWith(
+            expect.stringContaining('CREATE SECRET'),
+        );
+        expect(run).toHaveBeenCalledWith(
+            'SET enable_external_file_cache = false;',
+        );
+    });
+
+    it.each([
+        'SELECT sql FROM duckdb_views()',
+        'SELECT * FROM "information_schema"."views"',
+        'SELECT * FROM sqlite_master',
+        "SELECT * FROM pragma_storage_info('query_events')",
+    ])(
+        'blocks metadata queries that could disclose signed URLs: %s',
+        async (sql) => {
+            const client = new DuckdbWarehouseClient({
+                type: 'duckdb_parquet',
+                resolveSource: async () => source(),
+            });
+            await expect(client.runQuery(sql)).rejects.toThrow(
+                /catalog access/,
+            );
+        },
+    );
+
+    it('redacts signed URLs from native query failures', async () => {
+        run.mockRejectedValue(new Error(`${url}?X-Amz-Signature=private`));
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: async () => source(),
+        });
+        await expect(
+            client.runQuery('SELECT count(*) FROM query_events'),
+        ).rejects.toThrow(
+            /^Internal analytics query failed\. Check storage access and query permissions\.$/,
+        );
     });
 
     it('cannot create privileged readers from public project credentials or shared instances', () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -142,6 +142,8 @@ export type DuckdbS3Credentials = {
 export type DuckdbParquetSource = {
     scope: string;
     tables: { name: string; urls: string[] }[];
+    /** Exact server-signed GET URLs; never combine with bucket credentials. */
+    signedUrls?: boolean;
     httpAuth?: { bearerToken: string };
     s3Config?: DuckdbS3SessionConfig;
 };
@@ -1048,8 +1050,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         const escape = DuckdbWarehouseClient.escapeDuckdbString;
         const literal = (value: string) => `'${escape(value)}'`;
         const scope = new URL(source.scope);
+        const localSignedSource =
+            source.signedUrls &&
+            scope.protocol === 'http:' &&
+            ['localhost', '127.0.0.1', '[::1]'].includes(scope.hostname);
         if (
-            !['https:', 's3:'].includes(scope.protocol) ||
+            (!['https:', 's3:'].includes(scope.protocol) &&
+                !localSignedSource) ||
             scope.username ||
             scope.password ||
             scope.search ||
@@ -1059,6 +1066,14 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         ) {
             throw new ParameterError(
                 'Parquet source requires a scoped remote prefix',
+            );
+        }
+        if (
+            source.signedUrls &&
+            (source.httpAuth || source.s3Config || scope.protocol === 's3:')
+        ) {
+            throw new ParameterError(
+                'Signed Parquet sources cannot carry bucket credentials',
             );
         }
         const names = new Set<string>();
@@ -1078,10 +1093,15 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                 if (
                     parsed.href !== url ||
                     !url.startsWith(source.scope) ||
-                    !url.endsWith('.parquet') ||
-                    parsed.search ||
+                    !parsed.pathname.endsWith('.parquet') ||
+                    (!source.signedUrls && parsed.search) ||
+                    (source.signedUrls &&
+                        (!parsed.searchParams.has('X-Amz-Signature') ||
+                            !/^[a-zA-Z0-9_./=%-]+$/.test(parsed.pathname) ||
+                            /%(?!3D)/i.test(parsed.pathname))) ||
                     parsed.hash ||
-                    /[%*?[\]{}]/.test(parsed.pathname)
+                    /[*?[\]{}]/.test(parsed.pathname) ||
+                    (!source.signedUrls && parsed.pathname.includes('%'))
                 ) {
                     throw new ParameterError(
                         'Parquet file is outside the trusted source prefix',
@@ -1113,6 +1133,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         // Restrict the engine, not just SQL validation. No globbing, arbitrary
         // network reads, local files, or shared spill/cache directories.
         await db.run("SET temp_directory = '';");
+        await db.run('SET enable_http_metadata_cache = false;');
+        await db.run('SET enable_external_file_cache = false;');
+        await db.run('SET parquet_metadata_cache = false;');
         const files = source.tables.flatMap(({ urls }) => urls);
         await db.run(`SET allowed_paths = [${files.map(literal).join(',')}];`);
         await db.run('SET enable_external_access = false;');
@@ -1833,7 +1856,14 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         }
         try {
             if (this.parquetConfig) {
-                return await this.withEphemeralQuerySession(callback);
+                try {
+                    return await this.withEphemeralQuerySession(callback);
+                } catch (error) {
+                    if (error instanceof ParameterError) throw error;
+                    throw new WarehouseQueryError(
+                        'Internal analytics query failed. Check storage access and query permissions.',
+                    );
+                }
             }
             if (this.embeddedConfig) {
                 return await this.withDirectSession(
@@ -2360,6 +2390,16 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         db: DuckdbConnection,
         sql: string,
     ): Promise<void> {
+        if (
+            this.parquetConfig &&
+            /\b(duckdb_\w+|pragma_\w+|sqlite_\w+|pg_\w+|information_schema)\b/i.test(
+                DuckdbWarehouseClient.stripSqlComments(sql),
+            )
+        ) {
+            throw new ParameterError(
+                'Internal analytics catalog access is not allowed',
+            );
+        }
         DuckdbWarehouseClient.validateSqlFunctions(sql);
         DuckdbWarehouseClient.validateUserSqlFileAccess(sql);
         await this.validateSelectSql(db, sql);


### PR DESCRIPTION
## Summary

- Historical access: discover all retained Query Events and AI Usage partitions within the validated org prefix, without source start/end dates. Preserve fail-closed listing/file caps and exact-file signing. A year-old fixture is included alongside recent data; event-timestamp filtering selects the older period correctly.

Second slice of the internal analytics stack: reuse existing usage-event storage credentials in a server-side resolver to provide narrowly scoped Parquet access without CLI authentication or new cloud infrastructure.

- Uses the existing S3 SDK credential configuration to list a validated org prefix and sign exact GET URLs for Query Events and AI Usage files.
- DuckDB receives only 15-minute signed URLs, never the writer access key/secret or a bucket-wide secret. Each session resolves a fresh bounded manifest.
- Adds internal-only support for signed URL parameters and encoded Hive partition paths, retaining exact-file access restrictions.
- Blocks catalog queries that could expose signed view SQL, redacts native errors, and disables file/metadata caches and spill on the isolated analytics instances.
- No new endpoint or public connection setting; the shared analytics-project flag remains in the first PR. The endpoint slice will consume this resolver after org authorization and flag checks.

## Validation

- Latest opt-in standalone GCS test exceeded its existing 120-second whole-test deadline after expanding to all history; do not count it as passing on this revision. Separately, both uncached local API explores completed against the real bucket (approximately 137s Query Events, 123s AI Usage). Latency and test-budget follow-up are tracked in PROD-11111.
- All-history revision: 14 resolver unit tests passed, including year-old file discovery and file-cap failure. Real DuckDB/isolated MinIO smoke test passed with recent + year-old partitions, event-date filtering, cross-org tampering, PUT denial, and expired signatures. Backend typecheck passed.
- 14 focused resolver unit tests and 121 warehouse-client tests passed.
- Real GCS: existing writer HMAC credentials successfully listed the target org and ran Query Events count plus AI Usage count/token aggregation through native DuckDB, without CLI/OAuth authentication. Cloud tests made no writes.
- Isolated local MinIO: actual DuckDB queries over signed URLs passed; changing an org path, using a signed GET for PUT, and using an expired signed URL failed. Catalog inspection was denied and native errors omitted signed URLs. Only the test's uniquely named synthetic bucket/files were created and cleaned up.
- Backend and warehouse typechecks/build, scoped lint/format, and pre-commit secret/unused-export checks passed.
- External tests are opt-in and skipped in regular CI. No cloud credentials or customer data are committed.
- No new UI/API in this slice, so project provisioning and browser acceptance remain the next PR's integration work.

## Compatibility and security

Changes to URL acceptance, catalog restrictions, error redaction, and cache settings apply only to internal analytics Parquet connections. Ordinary warehouse connections are unchanged. No migration or new dependency.

The backend signer still holds write-capable credentials as an explicitly temporary compromise. The signed URLs restrict what DuckDB can access, but a compromised signer or incorrect org authorization remains a risk. This is not a substitute for the dedicated read-only identity tracked in PROD-11103, and does not claim storage isolation for a bucket-wide credential itself.

No Terraform/IAM changes, source-bucket writes, production activation, or credential rotation are included. Keep rollout disabled until endpoint integration and authorization review are complete. Merge after the connector/flag PR and before the endpoint PR.

Relates: [PROD-11059](https://linear.app/lightdash/issue/PROD-11059)
Relates: [PROD-11103](https://linear.app/lightdash/issue/PROD-11103)

Relates: [PROD-11111](https://linear.app/lightdash/issue/PROD-11111)
