### PR TITLE
fix(api): honour API keys on the feature flag endpoint so the CLI sees organisation overrides

### DIFF
--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -201,6 +201,36 @@ export const allowApiKeyAuthentication: RequestHandler = (req, res, next) => {
         });
 };
 
+/**
+ * For routes that anonymous callers may hit (the login and invite pages read
+ * feature flags) but that the CLI also calls with a personal access token or
+ * service account: authenticate the token when one is sent, otherwise carry
+ * on unauthenticated instead of rejecting the request.
+ */
+export const allowApiKeyAuthenticationIfPresent: RequestHandler = (
+    req,
+    res,
+    next,
+) => {
+    if (!req.headers.authorization) {
+        next();
+        return;
+    }
+    allowApiKeyAuthentication(req, res, (err?: unknown) => {
+        if (err) {
+            next(err);
+            return;
+        }
+        // A token was sent but matched nothing: reject rather than answer as
+        // an anonymous caller, so a CLI with a bad key fails loudly.
+        if (req.account?.isAuthenticated() || req.user?.userUuid) {
+            next();
+            return;
+        }
+        next(new AuthorizationError('Invalid credentials'));
+    });
+};
+
 export const storeOIDCRedirect: RequestHandler = (req, res, next) => {
     const { redirect, inviteCode, isPopup } = req.query;
     req.session.oauth = {};

--- a/packages/backend/src/controllers/v2/FeatureFlagController.ts
+++ b/packages/backend/src/controllers/v2/FeatureFlagController.ts
@@ -22,6 +22,7 @@ import express from 'express';
 import { toSessionUser } from '../../auth/account';
 import {
     allowApiKeyAuthentication,
+    allowApiKeyAuthenticationIfPresent,
     isAuthenticated,
 } from '../authentication/middlewares';
 import { BaseController } from '../baseController';
@@ -57,6 +58,7 @@ export class FeatureFlagController extends BaseController {
      * Get feature flag
      * @summary Get feature flag
      */
+    @Middlewares([allowApiKeyAuthenticationIfPresent])
     @SuccessResponse('200', 'Success')
     @Get('/{featureFlagId}')
     @OperationId('Get feature flag')


### PR DESCRIPTION
The CLI reads the `unnest-repeated-columns` flag from `GET /api/v2/feature-flag/{id}` before compiling explores, sending its personal access token or service account token. That route never authenticated the token: it has no API-key middleware, so the request was evaluated as anonymous and got the flag's instance default, never the organisation override. Any CLI deploy or preview for an organisation with the flag turned on compiled without unnesting, silently. The first preview of the internal analytics project came out with the leaves as dotted dimensions and no unnested tables, while a server-side refresh of the same project, which runs under the user's session, produced them.

The route now authenticates a token when an `Authorization` header is present and answers as that user, rejects a token that matches nothing, and still serves anonymous callers as before, since the register and invite pages read flags before login. Verified locally against an organisation override: API key resolves the override, anonymous gets the default, a bad key gets 401.

Relates: #4102
