### PR TITLE
fix(query): avoid empty totals projections

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.test.ts
@@ -10,7 +10,9 @@ import {
     VizIndexType,
 } from '@lightdash/common';
 import {
+    bigqueryClientMock,
     EXPLORE,
+    EXPLORE_BIGQUERY,
     INTRINSIC_USER_ATTRIBUTES,
     METRIC_QUERY,
     QUERY_BUILDER_UTC_TIMEZONE,
@@ -185,6 +187,45 @@ describe('QueryComposer', () => {
                 expect(composer.getSql({ columnLimit: 100 })).toMatchSnapshot();
             },
         );
+
+        it('returns valid empty BigQuery SQL when no totalable fields remain', () => {
+            const composer = new QueryComposer(
+                {
+                    metricQuery: {
+                        ...TOTALS_SOURCE_METRIC_QUERY,
+                        dimensions: ['table1_dim1'],
+                        metrics: [],
+                        filters: {
+                            dimensions: {
+                                id: 'root',
+                                and: [
+                                    {
+                                        id: 'filter',
+                                        target: { fieldId: 'table1_dim1' },
+                                        operator: FilterOperator.NOT_EQUALS,
+                                        values: [1, 2],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                    totalConfiguration: {
+                        kind: 'columnTotal',
+                        subtotalDimensions: undefined,
+                    },
+                },
+                {
+                    ...CONTEXT,
+                    explore: EXPLORE_BIGQUERY,
+                    warehouseSqlBuilder: bigqueryClientMock,
+                },
+            );
+
+            expect(composer.getFields()).toEqual({});
+            expect(composer.getSql({ columnLimit: 100 })).toBe(
+                'SELECT NULL AS __lightdash_empty_total WHERE 1 = 0',
+            );
+        });
 
         describe('metric-filtered source (filtered dimension groups)', () => {
             const METRIC_FILTERED_TOTALS_SOURCE: MetricQuery = {

--- a/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
+++ b/packages/backend/src/utils/QueryBuilder/QueryComposer.ts
@@ -333,6 +333,14 @@ export class QueryComposer {
      */
     getSql({ columnLimit }: { columnLimit: number }): string {
         const compiledQuery = this.compile();
+
+        if (
+            this.definition.totalConfiguration &&
+            Object.keys(compiledQuery.fields).length === 0
+        ) {
+            return 'SELECT NULL AS __lightdash_empty_total WHERE 1 = 0';
+        }
+
         const pivotConfiguration = this.getPivotConfiguration();
 
         if (!pivotConfiguration) {


### PR DESCRIPTION
## Problem

A dashboard totals request can legitimately end up with no remaining dimensions, metrics, or table calculations after the totals query is derived. The shared query composer still emitted a SELECT with an empty projection, which BigQuery rejects as invalid SQL.

## Intended outcome

Return a successful empty totals result when there are no totalable fields, while leaving normal totals queries unchanged.

## Implementation

- Detect a totals query whose compiled field map is empty.
- Emit a portable zero-row sentinel query: SELECT NULL AS __lightdash_empty_total WHERE 1 = 0.
- Keep the existing totals source, filters, and normal metric compilation paths unchanged.
- Add a BigQuery regression test at the query-composer boundary.

## Deterministic reproduction before the fix

Using the BigQuery explore fixture, create a totals QueryComposer with a dimension-only source query, an active not-equals filter, no metrics, and column-total configuration. QueryComposer.getSql() emitted:

    SELECT

    FROM `db`.`schema`.`table1` AS `table1`
    WHERE ...
    LIMIT 1

The effective query had zero dimensions, metrics, table calculations, and compiled fields.

## Validation after the fix

Running the same reproduction now emits:

    SELECT NULL AS __lightdash_empty_total WHERE 1 = 0

Local public API validation on the seeded Jaffle Shop project:

- A dimension-only filtered source query completed successfully.
- POST /api/v2/projects/:projectUuid/query/:queryUuid/calculate-total completed with status ready, rows [], fields {}, and no error.
- Query history recorded the zero-row sentinel SQL.
- A normal dimension-plus-metric totals request still returned the expected total revenue value.
- The seeded saved chart loaded successfully in the browser.

## Tests

- pnpm -F backend test src/utils/QueryBuilder/QueryComposer.test.ts — 13 passed
- pnpm -F backend typecheck — passed
- pnpm -F backend exec oxlint on the changed files — passed
- git diff --check — passed

## Compatibility and rollout

No migration, feature flag, API contract, generated artifact, dependency, or permission change. The guard is restricted to totals queries with zero compiled fields. The returned row set stays empty because the sentinel predicate is always false.

Screenshots are not applicable; this is a backend SQL-generation fix and was validated through the public API plus query history.

Closes: PROD-11084
Closes: #28874