### PR TITLE
fix(scheduler): show alert filters and local next-run times

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDetailConditions.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDetailConditions.tsx
@@ -2,13 +2,14 @@ import {
     NotificationFrequency,
     type SchedulerAndTargets,
 } from '@lightdash/common'; // pragma: allowlist secret
-import { Collapse, Group, Stack, Text } from '@mantine/core';
+import { Collapse, Group, Paper, Stack, Text } from '@mantine/core';
 import {
     IconBell,
     IconChevronDown,
     IconChevronRight,
     IconFilter,
     IconVariable,
+    type Icon,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
@@ -18,16 +19,44 @@ import {
     getAlertConditionSummaries,
     getSchedulerFilterSummaries,
     getSchedulerParameterSummaries,
+    type ConditionSummary,
 } from './schedulerDetailSummary';
 
 const SUMMARY_PREVIEW_COUNT = 2;
 
+const conditionKey = (condition: ConditionSummary): string =>
+    `${condition.field}|${condition.operator}|${condition.value}`;
+
+const ConditionPart: FC<{ children: string; emphasis?: boolean }> = ({
+    children,
+    emphasis,
+}) => (
+    <Paper radius="xl" px="xs" py={2}>
+        <Text size="xs" fw={emphasis ? 600 : 500}>
+            {children}
+        </Text>
+    </Paper>
+);
+
+const ConditionRow: FC<{ condition: ConditionSummary }> = ({ condition }) => (
+    <Group gap={6} wrap="wrap">
+        <ConditionPart>{condition.field}</ConditionPart>
+        <Text size="xs" c="dimmed">
+            {condition.operator}
+        </Text>
+        {condition.value && (
+            <ConditionPart emphasis>{condition.value}</ConditionPart>
+        )}
+    </Group>
+);
+
 const ConditionSection: FC<{
-    icon: typeof IconBell;
+    icon: Icon;
     label: string;
-    items: string[];
+    items: ConditionSummary[];
     expandable: boolean;
-}> = ({ icon, label, items, expandable }) => {
+    footnote?: string;
+}> = ({ icon, label, items, expandable, footnote }) => {
     const [expanded, setExpanded] = useState(false);
     const extraItems = expandable ? items.slice(SUMMARY_PREVIEW_COUNT) : [];
     const previewItems = extraItems.length
@@ -39,21 +68,23 @@ const ConditionSection: FC<{
             <MantineIcon icon={icon} size="md" color="ldGray.5" />
             <Stack gap={4}>
                 <span className={classes.detailMetaLabel}>{label}</span>
-                <Stack gap={2}>
+                <Stack gap={6}>
                     {previewItems.map((item) => (
-                        <Text key={item} size="sm">
-                            {item}
-                        </Text>
+                        <ConditionRow
+                            key={conditionKey(item)}
+                            condition={item}
+                        />
                     ))}
                 </Stack>
                 {extraItems.length > 0 && (
                     <>
                         <Collapse in={expanded}>
-                            <Stack gap={2}>
+                            <Stack gap={6}>
                                 {extraItems.map((item) => (
-                                    <Text key={item} size="sm">
-                                        {item}
-                                    </Text>
+                                    <ConditionRow
+                                        key={conditionKey(item)}
+                                        condition={item}
+                                    />
                                 ))}
                             </Stack>
                         </Collapse>
@@ -83,6 +114,11 @@ const ConditionSection: FC<{
                         </PolymorphicGroupButton>
                     </>
                 )}
+                {footnote && (
+                    <Text size="xs" c="dimmed">
+                        {footnote}
+                    </Text>
+                )}
             </Stack>
         </Group>
     );
@@ -110,25 +146,18 @@ export const SchedulerDetailConditions: FC<Props> = ({ scheduler }) => {
     return (
         <>
             {alertSummaries.length > 0 && (
-                <Group gap="sm" wrap="nowrap" align="flex-start">
-                    <MantineIcon icon={IconBell} size="md" color="ldGray.5" />
-                    <Stack gap={4}>
-                        <span className={classes.detailMetaLabel}>Alert</span>
-                        <Stack gap={2}>
-                            {alertSummaries.map((summary) => (
-                                <Text key={summary} size="sm">
-                                    {summary}
-                                </Text>
-                            ))}
-                        </Stack>
-                        {scheduler.notificationFrequency ===
-                            NotificationFrequency.ONCE && (
-                            <Text size="xs" c="dimmed">
-                                Notifies only once
-                            </Text>
-                        )}
-                    </Stack>
-                </Group>
+                <ConditionSection
+                    icon={IconBell}
+                    label="Alert"
+                    items={alertSummaries}
+                    expandable={false}
+                    footnote={
+                        scheduler.notificationFrequency ===
+                        NotificationFrequency.ONCE
+                            ? 'Notifies only once'
+                            : undefined
+                    }
+                />
             )}
 
             {filterSummaries.length > 0 && (

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDetailConditions.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerDetailConditions.tsx
@@ -1,0 +1,161 @@
+import {
+    NotificationFrequency,
+    type SchedulerAndTargets,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { Collapse, Group, Stack, Text } from '@mantine/core';
+import {
+    IconBell,
+    IconChevronDown,
+    IconChevronRight,
+    IconFilter,
+    IconVariable,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../../../components/common/PolymorphicGroupButton';
+import classes from './SchedulerDeliveryModal.module.css';
+import {
+    getAlertConditionSummaries,
+    getSchedulerFilterSummaries,
+    getSchedulerParameterSummaries,
+} from './schedulerDetailSummary';
+
+const SUMMARY_PREVIEW_COUNT = 2;
+
+const ConditionSection: FC<{
+    icon: typeof IconBell;
+    label: string;
+    items: string[];
+    expandable: boolean;
+}> = ({ icon, label, items, expandable }) => {
+    const [expanded, setExpanded] = useState(false);
+    const extraItems = expandable ? items.slice(SUMMARY_PREVIEW_COUNT) : [];
+    const previewItems = extraItems.length
+        ? items.slice(0, SUMMARY_PREVIEW_COUNT)
+        : items;
+
+    return (
+        <Group gap="sm" wrap="nowrap" align="flex-start">
+            <MantineIcon icon={icon} size="md" color="ldGray.5" />
+            <Stack gap={4}>
+                <span className={classes.detailMetaLabel}>{label}</span>
+                <Stack gap={2}>
+                    {previewItems.map((item) => (
+                        <Text key={item} size="sm">
+                            {item}
+                        </Text>
+                    ))}
+                </Stack>
+                {extraItems.length > 0 && (
+                    <>
+                        <Collapse in={expanded}>
+                            <Stack gap={2}>
+                                {extraItems.map((item) => (
+                                    <Text key={item} size="sm">
+                                        {item}
+                                    </Text>
+                                ))}
+                            </Stack>
+                        </Collapse>
+                        <PolymorphicGroupButton
+                            component="button"
+                            type="button"
+                            gap={4}
+                            wrap="nowrap"
+                            w="fit-content"
+                            aria-expanded={expanded}
+                            onClick={() => setExpanded((value) => !value)}
+                        >
+                            <Text size="xs" c="dimmed">
+                                {expanded
+                                    ? 'Show less'
+                                    : `and ${extraItems.length} more`}
+                            </Text>
+                            <MantineIcon
+                                icon={
+                                    expanded
+                                        ? IconChevronDown
+                                        : IconChevronRight
+                                }
+                                size="sm"
+                                color="dimmed"
+                            />
+                        </PolymorphicGroupButton>
+                    </>
+                )}
+            </Stack>
+        </Group>
+    );
+};
+
+type Props = {
+    scheduler: SchedulerAndTargets;
+};
+
+export const SchedulerDetailConditions: FC<Props> = ({ scheduler }) => {
+    const alertSummaries = getAlertConditionSummaries(scheduler.thresholds);
+    const filterSummaries = getSchedulerFilterSummaries(scheduler);
+    const parameterSummaries = getSchedulerParameterSummaries(
+        'parameters' in scheduler ? scheduler.parameters : undefined,
+    );
+
+    if (
+        alertSummaries.length === 0 &&
+        filterSummaries.length === 0 &&
+        parameterSummaries.length === 0
+    ) {
+        return null;
+    }
+
+    return (
+        <>
+            {alertSummaries.length > 0 && (
+                <Group gap="sm" wrap="nowrap" align="flex-start">
+                    <MantineIcon icon={IconBell} size="md" color="ldGray.5" />
+                    <Stack gap={4}>
+                        <span className={classes.detailMetaLabel}>Alert</span>
+                        <Stack gap={2}>
+                            {alertSummaries.map((summary) => (
+                                <Text key={summary} size="sm">
+                                    {summary}
+                                </Text>
+                            ))}
+                        </Stack>
+                        {scheduler.notificationFrequency ===
+                            NotificationFrequency.ONCE && (
+                            <Text size="xs" c="dimmed">
+                                Notifies only once
+                            </Text>
+                        )}
+                    </Stack>
+                </Group>
+            )}
+
+            {filterSummaries.length > 0 && (
+                <ConditionSection
+                    icon={IconFilter}
+                    label={
+                        filterSummaries.length === 1
+                            ? '1 filter'
+                            : `${filterSummaries.length} filters`
+                    }
+                    items={filterSummaries}
+                    expandable
+                />
+            )}
+
+            {parameterSummaries.length > 0 && (
+                <ConditionSection
+                    icon={IconVariable}
+                    label={
+                        parameterSummaries.length === 1
+                            ? '1 parameter'
+                            : `${parameterSummaries.length} parameters`
+                    }
+                    items={parameterSummaries}
+                    expandable
+                />
+            )}
+        </>
+    );
+};

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -256,8 +256,6 @@ const SchedulerDetail: FC<{
                 ? getNextRuns(
                       scheduler.cron,
                       scheduler.timezone || project?.schedulerTimezone,
-                      3,
-                      'local',
                   )
                 : [],
         [
@@ -362,12 +360,6 @@ const SchedulerDetail: FC<{
                                         </Group>
                                     ))}
                                 </Stack>
-                                {nextRuns[0]?.timeZoneName && (
-                                    <Text size="xs" c="dimmed">
-                                        Times shown in{' '}
-                                        {nextRuns[0].timeZoneName}
-                                    </Text>
-                                )}
                             </Stack>
                         </Group>
                     )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/SchedulerList.tsx
@@ -72,6 +72,7 @@ import { getSchedulerDeliveryType } from '../../types';
 import { isDeliveryListScheduler } from './deliveryListFilter';
 import { getNextRuns } from './nextRuns';
 import classes from './SchedulerDeliveryModal.module.css';
+import { SchedulerDetailConditions } from './SchedulerDetailConditions';
 
 dayjs.extend(relativeTime);
 
@@ -255,6 +256,8 @@ const SchedulerDetail: FC<{
                 ? getNextRuns(
                       scheduler.cron,
                       scheduler.timezone || project?.schedulerTimezone,
+                      3,
+                      'local',
                   )
                 : [],
         [
@@ -316,6 +319,8 @@ const SchedulerDetail: FC<{
                 </Stack>
 
                 <Stack gap="lg" mt="sm">
+                    <SchedulerDetailConditions scheduler={scheduler} />
+
                     <Group gap="sm" wrap="nowrap" align="flex-start">
                         <MantineIcon
                             icon={IconClock}
@@ -357,6 +362,12 @@ const SchedulerDetail: FC<{
                                         </Group>
                                     ))}
                                 </Stack>
+                                {nextRuns[0]?.timeZoneName && (
+                                    <Text size="xs" c="dimmed">
+                                        Times shown in{' '}
+                                        {nextRuns[0].timeZoneName}
+                                    </Text>
+                                )}
                             </Stack>
                         </Group>
                     )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.test.ts
@@ -15,24 +15,22 @@ describe('getNextRuns', () => {
         expect(getNextRuns('', 'UTC')).toEqual([]);
     });
 
-    it('formats upcoming hourly runs in the schedule timezone', () => {
+    it('formats upcoming hourly runs with the schedule timezone', () => {
         const runs = getNextRuns('22 * * * *', 'UTC', 2);
 
         expect(runs.map((run) => run.label)).toEqual([
-            'Wed, Sep 9 · 9:22 AM',
-            'Wed, Sep 9 · 10:22 AM',
+            'Wed, Sep 9 · 9:22 AM UTC',
+            'Wed, Sep 9 · 10:22 AM UTC',
         ]);
         expect(runs[0]?.timeZoneName).toBe('UTC');
     });
 
-    it('formats the same instants in the viewer timezone', () => {
-        const runs = getNextRuns('22 * * * *', 'UTC', 2, 'Europe/London');
+    it('labels runs in a non-UTC schedule timezone', () => {
+        const [run] = getNextRuns('22 * * * *', 'Europe/London', 1);
 
-        expect(runs.map((run) => run.label)).toEqual([
-            'Wed, Sep 9 · 10:22 AM',
-            'Wed, Sep 9 · 11:22 AM',
-        ]);
-        expect(runs[0]?.timeZoneName).not.toBe('UTC');
-        expect(runs[0]?.timeZoneName).toBeTruthy();
+        expect(run?.label).toMatch(/^Wed, Sep 9 · 10:22 AM /);
+        expect(run?.label).not.toMatch(/UTC$/);
+        expect(run?.timeZoneName).toBeTruthy();
+        expect(run?.timeZoneName).not.toBe('UTC');
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNextRuns } from './nextRuns';
+
+describe('getNextRuns', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-09-09T09:20:00.000Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns no runs without a cron expression', () => {
+        expect(getNextRuns('', 'UTC')).toEqual([]);
+    });
+
+    it('formats upcoming hourly runs in the schedule timezone', () => {
+        const runs = getNextRuns('22 * * * *', 'UTC', 2);
+
+        expect(runs.map((run) => run.label)).toEqual([
+            'Wed, Sep 9 · 9:22 AM',
+            'Wed, Sep 9 · 10:22 AM',
+        ]);
+        expect(runs[0]?.timeZoneName).toBe('UTC');
+    });
+
+    it('formats the same instants in the viewer timezone', () => {
+        const runs = getNextRuns('22 * * * *', 'UTC', 2, 'Europe/London');
+
+        expect(runs.map((run) => run.label)).toEqual([
+            'Wed, Sep 9 · 10:22 AM',
+            'Wed, Sep 9 · 11:22 AM',
+        ]);
+        expect(runs[0]?.timeZoneName).not.toBe('UTC');
+        expect(runs[0]?.timeZoneName).toBeTruthy();
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.ts
@@ -4,21 +4,51 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 
 dayjs.extend(relativeTime);
 
-export type NextRun = { label: string; relative: string };
+export type NextRun = {
+    label: string;
+    relative: string;
+    timeZoneName: string;
+};
 
+const getShortTimeZoneName = (date: Date, timeZone: string): string => {
+    try {
+        return (
+            new Intl.DateTimeFormat(undefined, {
+                timeZone,
+                timeZoneName: 'short',
+            })
+                .formatToParts(date)
+                .find((part) => part.type === 'timeZoneName')?.value ?? timeZone
+        );
+    } catch {
+        return timeZone;
+    }
+};
+
+/**
+ * Upcoming run instants are computed in `timezone` (the schedule / project
+ * zone). Pass `displayTimezone` (IANA or `'local'`) to format those instants
+ * in the viewer's zone instead of the schedule zone.
+ */
 export const getNextRuns = (
     cron: string,
     timezone: string | undefined,
     count = 3,
+    displayTimezone?: string,
 ): NextRun[] => {
     if (!cron) return [];
     try {
         const schedule = getSchedule(stringToArray(cron), new Date(), timezone);
         return Array.from({ length: count }, () => {
             const next = schedule.next();
+            const displayed = displayTimezone
+                ? next.setZone(displayTimezone)
+                : next;
+            const jsDate = next.toJSDate();
             return {
-                label: next.toFormat('ccc, LLL d · h:mm a'),
-                relative: dayjs(next.toJSDate()).fromNow(),
+                label: displayed.toFormat('ccc, LLL d · h:mm a'),
+                relative: dayjs(jsDate).fromNow(),
+                timeZoneName: getShortTimeZoneName(jsDate, displayed.zoneName),
             };
         });
     } catch {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/nextRuns.ts
@@ -25,30 +25,22 @@ const getShortTimeZoneName = (date: Date, timeZone: string): string => {
     }
 };
 
-/**
- * Upcoming run instants are computed in `timezone` (the schedule / project
- * zone). Pass `displayTimezone` (IANA or `'local'`) to format those instants
- * in the viewer's zone instead of the schedule zone.
- */
 export const getNextRuns = (
     cron: string,
     timezone: string | undefined,
     count = 3,
-    displayTimezone?: string,
 ): NextRun[] => {
     if (!cron) return [];
     try {
         const schedule = getSchedule(stringToArray(cron), new Date(), timezone);
         return Array.from({ length: count }, () => {
             const next = schedule.next();
-            const displayed = displayTimezone
-                ? next.setZone(displayTimezone)
-                : next;
             const jsDate = next.toJSDate();
+            const timeZoneName = getShortTimeZoneName(jsDate, next.zoneName);
             return {
-                label: displayed.toFormat('ccc, LLL d · h:mm a'),
+                label: `${next.toFormat('ccc, LLL d · h:mm a')} ${timeZoneName}`,
                 relative: dayjs(jsDate).fromNow(),
-                timeZoneName: getShortTimeZoneName(jsDate, displayed.zoneName),
+                timeZoneName,
             };
         });
     } catch {

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.test.ts
@@ -75,8 +75,16 @@ describe('getAlertConditionSummaries', () => {
                 },
             ]),
         ).toEqual([
-            'Orders order count is greater than 100',
-            'Payments total revenue increased by 10%',
+            {
+                field: 'Orders order count',
+                operator: 'is greater than',
+                value: '100',
+            },
+            {
+                field: 'Payments total revenue',
+                operator: 'increased by',
+                value: '10%',
+            },
         ]);
     });
 });
@@ -107,7 +115,13 @@ describe('getSchedulerFilterSummaries', () => {
             }),
         );
 
-        expect(summaries).toEqual(['Orders status is completed']);
+        expect(summaries).toEqual([
+            {
+                field: 'Orders status',
+                operator: 'is',
+                value: 'completed',
+            },
+        ]);
     });
 
     it('summarises dashboard filter overrides and skips disabled rules', () => {
@@ -139,7 +153,13 @@ describe('getSchedulerFilterSummaries', () => {
             }),
         );
 
-        expect(summaries).toEqual(['Status is completed']);
+        expect(summaries).toEqual([
+            {
+                field: 'Status',
+                operator: 'is',
+                value: 'completed',
+            },
+        ]);
     });
 });
 
@@ -151,8 +171,16 @@ describe('getSchedulerParameterSummaries', () => {
                 status: ['completed', 'pending'],
             }),
         ).toEqual([
-            'Date granularity is month',
-            'Status is completed, pending',
+            {
+                field: 'Date granularity',
+                operator: 'is',
+                value: 'month',
+            },
+            {
+                field: 'Status',
+                operator: 'is',
+                value: 'completed, pending',
+            },
         ]);
     });
 });

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.test.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.test.ts
@@ -1,0 +1,158 @@
+import {
+    FilterOperator,
+    SchedulerFormat,
+    ThresholdOperator,
+    type SchedulerAndTargets,
+} from '@lightdash/common'; // pragma: allowlist secret
+import { describe, expect, it } from 'vitest';
+import {
+    getAlertConditionSummaries,
+    getSchedulerFilterSummaries,
+    getSchedulerParameterSummaries,
+} from './schedulerDetailSummary';
+
+const chartScheduler = (
+    overrides: Partial<SchedulerAndTargets>,
+): SchedulerAndTargets =>
+    ({
+        schedulerUuid: 'scheduler-uuid',
+        slug: 'test-alert',
+        name: 'Test',
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        createdBy: 'user-1',
+        createdByName: 'Jane',
+        format: SchedulerFormat.IMAGE,
+        cron: '22 * * * *',
+        savedChartUuid: 'chart-1',
+        savedChartName: 'Orders',
+        dashboardUuid: null,
+        dashboardName: null,
+        savedSqlUuid: null,
+        savedSqlName: null,
+        appUuid: null,
+        appName: null,
+        options: {},
+        enabled: true,
+        includeLinks: true,
+        plainTextEmail: false,
+        targets: [],
+        ...overrides,
+    }) as SchedulerAndTargets;
+
+const dashboardScheduler = (
+    overrides: Partial<SchedulerAndTargets>,
+): SchedulerAndTargets =>
+    ({
+        ...chartScheduler({
+            savedChartUuid: null,
+            savedChartName: null,
+            dashboardUuid: 'dashboard-1',
+            dashboardName: 'Sales',
+            selectedTabs: null,
+        }),
+        ...overrides,
+    }) as SchedulerAndTargets;
+
+describe('getAlertConditionSummaries', () => {
+    it('returns nothing without thresholds', () => {
+        expect(getAlertConditionSummaries(undefined)).toEqual([]);
+        expect(getAlertConditionSummaries([])).toEqual([]);
+    });
+
+    it('summarises comparison and percent thresholds', () => {
+        expect(
+            getAlertConditionSummaries([
+                {
+                    operator: ThresholdOperator.GREATER_THAN,
+                    fieldId: 'orders_order_count',
+                    value: 100,
+                },
+                {
+                    operator: ThresholdOperator.INCREASED_BY,
+                    fieldId: 'payments_total_revenue',
+                    value: 10,
+                },
+            ]),
+        ).toEqual([
+            'Orders order count is greater than 100',
+            'Payments total revenue increased by 10%',
+        ]);
+    });
+});
+
+describe('getSchedulerFilterSummaries', () => {
+    it('summarises chart filter rules', () => {
+        const summaries = getSchedulerFilterSummaries(
+            chartScheduler({
+                filters: {
+                    dimensions: {
+                        id: 'and-1',
+                        and: [
+                            {
+                                id: 'status',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.EQUALS,
+                                values: ['completed'],
+                            },
+                            {
+                                id: 'empty',
+                                target: { fieldId: 'orders_status' },
+                                operator: FilterOperator.EQUALS,
+                                values: [],
+                            },
+                        ],
+                    },
+                },
+            }),
+        );
+
+        expect(summaries).toEqual(['Orders status is completed']);
+    });
+
+    it('summarises dashboard filter overrides and skips disabled rules', () => {
+        const summaries = getSchedulerFilterSummaries(
+            dashboardScheduler({
+                filters: [
+                    {
+                        id: 'status',
+                        target: {
+                            fieldId: 'orders_status',
+                            tableName: 'orders',
+                        },
+                        operator: FilterOperator.EQUALS,
+                        values: ['completed'],
+                        label: 'Status',
+                    },
+                    {
+                        id: 'amount',
+                        target: {
+                            fieldId: 'payments_amount',
+                            tableName: 'payments',
+                        },
+                        operator: FilterOperator.GREATER_THAN,
+                        values: [50],
+                        label: undefined,
+                        disabled: true,
+                    },
+                ],
+            }),
+        );
+
+        expect(summaries).toEqual(['Status is completed']);
+    });
+});
+
+describe('getSchedulerParameterSummaries', () => {
+    it('formats scalar and list parameter values', () => {
+        expect(
+            getSchedulerParameterSummaries({
+                date_granularity: 'month',
+                status: ['completed', 'pending'],
+            }),
+        ).toEqual([
+            'Date granularity is month',
+            'Status is completed, pending',
+        ]);
+    });
+});

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.ts
@@ -14,6 +14,12 @@ import {
     type ThresholdOptions,
 } from '@lightdash/common'; // pragma: allowlist secret
 
+export type ConditionSummary = {
+    field: string;
+    operator: string;
+    value: string;
+};
+
 const THRESHOLD_OPERATOR_TEXT: Record<ThresholdOperator, string> = {
     [ThresholdOperator.GREATER_THAN]: 'is greater than',
     [ThresholdOperator.LESS_THAN]: 'is less than',
@@ -23,17 +29,20 @@ const THRESHOLD_OPERATOR_TEXT: Record<ThresholdOperator, string> = {
 
 export const getAlertConditionSummaries = (
     thresholds: ThresholdOptions[] | undefined,
-): string[] => {
+): ConditionSummary[] => {
     if (!thresholds?.length) return [];
 
     return thresholds.map((threshold) => {
         const isPercent =
             threshold.operator === ThresholdOperator.INCREASED_BY ||
             threshold.operator === ThresholdOperator.DECREASED_BY;
-        const operator =
-            THRESHOLD_OPERATOR_TEXT[threshold.operator] ?? threshold.operator;
-        const value = `${threshold.value}${isPercent ? '%' : ''}`;
-        return `${friendlyName(threshold.fieldId)} ${operator} ${value}`;
+        return {
+            field: friendlyName(threshold.fieldId),
+            operator:
+                THRESHOLD_OPERATOR_TEXT[threshold.operator] ??
+                threshold.operator,
+            value: `${threshold.value}${isPercent ? '%' : ''}`,
+        };
     });
 };
 
@@ -49,13 +58,17 @@ const getFilterTargetLabel = (
 const formatFilterRule = (
     rule: FilterRule,
     fallbackLabel?: string | null,
-): string => {
+): ConditionSummary => {
     const { field, operator, value } = getConditionalRuleLabel(
         rule,
         rule.settings ? FilterType.DATE : FilterType.STRING,
         getFilterTargetLabel(rule, fallbackLabel),
     );
-    return [field, operator, value].filter(Boolean).join(' ');
+    return {
+        field,
+        operator,
+        value: value ?? '',
+    };
 };
 
 const isActiveFilterRule = (rule: FilterRule): boolean =>
@@ -63,7 +76,7 @@ const isActiveFilterRule = (rule: FilterRule): boolean =>
 
 export const getSchedulerFilterSummaries = (
     scheduler: SchedulerAndTargets,
-): string[] => {
+): ConditionSummary[] => {
     if (isDashboardScheduler(scheduler) && Array.isArray(scheduler.filters)) {
         return scheduler.filters
             .filter(isActiveFilterRule)
@@ -87,11 +100,12 @@ export const getSchedulerFilterSummaries = (
 
 export const getSchedulerParameterSummaries = (
     parameters: ParametersValuesMap | undefined,
-): string[] => {
+): ConditionSummary[] => {
     if (!parameters) return [];
 
-    return Object.entries(parameters).map(([key, value]) => {
-        const display = Array.isArray(value) ? value.join(', ') : String(value);
-        return `${friendlyName(key)} is ${display}`;
-    });
+    return Object.entries(parameters).map(([key, value]) => ({
+        field: friendlyName(key),
+        operator: 'is',
+        value: Array.isArray(value) ? value.join(', ') : String(value),
+    }));
 };

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.ts
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/layout/schedulerDetailSummary.ts
@@ -1,0 +1,97 @@
+import {
+    FilterType,
+    friendlyName,
+    getConditionalRuleLabel,
+    getFilterRules,
+    isChartScheduler,
+    isDashboardScheduler,
+    isEmptyDashboardFilterRule,
+    ThresholdOperator,
+    type DashboardFilterRule,
+    type FilterRule,
+    type ParametersValuesMap,
+    type SchedulerAndTargets,
+    type ThresholdOptions,
+} from '@lightdash/common'; // pragma: allowlist secret
+
+const THRESHOLD_OPERATOR_TEXT: Record<ThresholdOperator, string> = {
+    [ThresholdOperator.GREATER_THAN]: 'is greater than',
+    [ThresholdOperator.LESS_THAN]: 'is less than',
+    [ThresholdOperator.INCREASED_BY]: 'increased by',
+    [ThresholdOperator.DECREASED_BY]: 'decreased by',
+};
+
+export const getAlertConditionSummaries = (
+    thresholds: ThresholdOptions[] | undefined,
+): string[] => {
+    if (!thresholds?.length) return [];
+
+    return thresholds.map((threshold) => {
+        const isPercent =
+            threshold.operator === ThresholdOperator.INCREASED_BY ||
+            threshold.operator === ThresholdOperator.DECREASED_BY;
+        const operator =
+            THRESHOLD_OPERATOR_TEXT[threshold.operator] ?? threshold.operator;
+        const value = `${threshold.value}${isPercent ? '%' : ''}`;
+        return `${friendlyName(threshold.fieldId)} ${operator} ${value}`;
+    });
+};
+
+const getFilterTargetLabel = (
+    rule: FilterRule,
+    fallbackLabel?: string | null,
+): string => {
+    if (fallbackLabel) return fallbackLabel;
+    const target = rule.target as { fieldId?: string; fieldRef?: string };
+    return friendlyName(target.fieldId ?? target.fieldRef ?? '');
+};
+
+const formatFilterRule = (
+    rule: FilterRule,
+    fallbackLabel?: string | null,
+): string => {
+    const { field, operator, value } = getConditionalRuleLabel(
+        rule,
+        rule.settings ? FilterType.DATE : FilterType.STRING,
+        getFilterTargetLabel(rule, fallbackLabel),
+    );
+    return [field, operator, value].filter(Boolean).join(' ');
+};
+
+const isActiveFilterRule = (rule: FilterRule): boolean =>
+    !rule.disabled && !isEmptyDashboardFilterRule(rule);
+
+export const getSchedulerFilterSummaries = (
+    scheduler: SchedulerAndTargets,
+): string[] => {
+    if (isDashboardScheduler(scheduler) && Array.isArray(scheduler.filters)) {
+        return scheduler.filters
+            .filter(isActiveFilterRule)
+            .map((rule: DashboardFilterRule) =>
+                formatFilterRule(rule, rule.label),
+            );
+    }
+
+    if (
+        isChartScheduler(scheduler) &&
+        scheduler.filters &&
+        !Array.isArray(scheduler.filters)
+    ) {
+        return getFilterRules(scheduler.filters)
+            .filter(isActiveFilterRule)
+            .map((rule) => formatFilterRule(rule));
+    }
+
+    return [];
+};
+
+export const getSchedulerParameterSummaries = (
+    parameters: ParametersValuesMap | undefined,
+): string[] => {
+    if (!parameters) return [];
+
+    return Object.entries(parameters).map(([key, value]) => {
+        const display = Array.isArray(value) ? value.join(', ') : String(value);
+        return `${friendlyName(key)} is ${display}`;
+    });
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description:
The scheduled delivery / alert detail panel showed cadence, recipients, and next runs, but not the threshold condition or any filters/parameters applied to the delivery. Upcoming run times were also formatted in the schedule timezone with no zone label, so UTC times read as local wall-clock times.

This adds a detail summary for:

- Alert condition (field, operator, threshold, notify-once)
- Applied filters (chart or dashboard), expandable when there are more than two
- Parameters, with the same expand pattern

Field, operator, and value render as separate pieces (pills for field and value, dimmed text for the operator) so the condition is easier to scan.

Next runs include the short timezone name on each timestamp, GCP-style (`Wed, Sep 9 · 9:22 AM UTC`). Times stay in the schedule timezone.

[Alert and filter chips in the detail panel](https://cursor.com/agents/bc-a9fb4265-04df-52d6-95d2-a0c00f1c9872/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falert_filter_condition_chips.webp)

No existing ticket for this change.

### Risk assessment:
- [ ] This is a high-risk change


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lightdash.slack.com/archives/C0AD7R21BLG/p1788945770316129?thread_ts=1788945770.316129&cid=C0AD7R21BLG)

<div><a href="https://cursor.com/agents/bc-a9fb4265-04df-52d6-95d2-a0c00f1c9872?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9fb4265-04df-52d6-95d2-a0c00f1c9872&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

