### PR TITLE
fix(cli): prioritize LIGHTDASH_PROJECT over active previews

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -158,6 +158,18 @@ The `--non-interactive` flag is designed for environments where interactive prom
 |----------|-------------|
 | `CI=true` | Equivalent to `--non-interactive` |
 | `LIGHTDASH_API_KEY` | API token for authentication (can be used instead of `--token`) |
+| `LIGHTDASH_PROJECT` | Target project UUID; overrides the saved default and active preview unless `--project` is passed |
+
+For project selection in commands such as `deploy`, `download`, and `upload`,
+`--project` takes precedence over `LIGHTDASH_PROJECT`. Either override bypasses
+active-preview selection in both interactive and non-interactive runs, without
+clearing the saved preview. If neither override is set (or `LIGHTDASH_PROJECT`
+is empty), an active preview remains the default in non-interactive runs;
+interactive runs prompt when both a default project and a preview are available.
+
+```bash
+LIGHTDASH_PROJECT=<target-project-uuid> lightdash deploy --non-interactive
+```
 
 Credentials resolve in the usual order: command flags, then environment variables, then the config file written by `lightdash login`. So a `LIGHTDASH_API_KEY` left in your shell profile is used ahead of your saved login — `lightdash login` warns when this is the case, and `unset LIGHTDASH_API_KEY` restores the saved token.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -136,36 +136,39 @@ The `--non-interactive` flag is designed for environments where interactive prom
 
 ### Global Options
 
-| Flag | Description |
-|------|-------------|
+| Flag                | Description                                                                                                                 |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `--non-interactive` | Disable all interactive prompts. Commands auto-select defaults where possible. Designed for CI/CD and agentic coding tools. |
 
 ### Command-Specific Options
 
-| Command | Flag | Description |
-|---------|------|-------------|
-| `login` | `--token <token>` | Authenticate with personal access token (bypasses OAuth) |
-| `login` | `--email <email>` | Login with email and password |
-| `login` | `--project <uuid>` | Select a specific project by UUID after login |
-| `deploy` | `-y, --assume-yes` | Answer yes to all confirmation prompts |
-| `generate` | `-y, --assume-yes` | Answer yes to prompts |
-| `dbt run` | `-y, --assume-yes` | Answer yes to prompts |
-| `rename` | `-y, --assume-yes` | Answer yes to prompts |
+| Command    | Flag               | Description                                              |
+| ---------- | ------------------ | -------------------------------------------------------- |
+| `login`    | `--token <token>`  | Authenticate with personal access token (bypasses OAuth) |
+| `login`    | `--email <email>`  | Login with email and password                            |
+| `login`    | `--project <uuid>` | Select a specific project by UUID after login            |
+| `deploy`   | `-y, --assume-yes` | Answer yes to all confirmation prompts                   |
+| `generate` | `-y, --assume-yes` | Answer yes to prompts                                    |
+| `dbt run`  | `-y, --assume-yes` | Answer yes to prompts                                    |
+| `rename`   | `-y, --assume-yes` | Answer yes to prompts                                    |
 
 ### Environment Variables
 
-| Variable | Description |
-|----------|-------------|
-| `CI=true` | Equivalent to `--non-interactive` |
-| `LIGHTDASH_API_KEY` | API token for authentication (can be used instead of `--token`) |
+| Variable            | Description                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------ |
+| `CI=true`           | Equivalent to `--non-interactive`                                                                |
+| `LIGHTDASH_API_KEY` | API token for authentication (can be used instead of `--token`)                                  |
 | `LIGHTDASH_PROJECT` | Target project UUID; overrides the saved default and active preview unless `--project` is passed |
 
 For project selection in commands such as `deploy`, `download`, and `upload`,
 `--project` takes precedence over `LIGHTDASH_PROJECT`. Either override bypasses
 active-preview selection in both interactive and non-interactive runs, without
-clearing the saved preview. If neither override is set (or `LIGHTDASH_PROJECT`
-is empty), an active preview remains the default in non-interactive runs;
-interactive runs prompt when both a default project and a preview are available.
+clearing the saved preview. When `LIGHTDASH_PROJECT` overrides an active preview
+the CLI warns which preview it ignored, so a variable left in a shell profile or
+`.env` does not silently redirect commands you meant to run against the preview.
+If neither override is set (or `LIGHTDASH_PROJECT` is empty), an active preview
+remains the default in non-interactive runs; interactive runs prompt when both a
+default project and a preview are available.
 
 ```bash
 LIGHTDASH_PROJECT=<target-project-uuid> lightdash deploy --non-interactive
@@ -215,6 +218,7 @@ lightdash deploy \
 ### Behavior in Non-Interactive Mode
 
 When `--non-interactive` is set (or `CI=true`):
+
 - **Project selection**: Automatically selects the first available project
 - **Confirmation prompts**: Fail with descriptive error unless `--assume-yes` is provided
 - **OAuth login**: Not available - use `--token` or `--email` with `LIGHTDASH_CLI_PASSWORD` env var instead
@@ -265,7 +269,7 @@ rm /tmp/lightdash_pass.txt
 
 The CLI supports these environment variables for authentication:
 
-| Variable | Description |
-|----------|-------------|
-| `LIGHTDASH_CLI_EMAIL` | Email for login (alternative to `--email`) |
+| Variable                 | Description                                    |
+| ------------------------ | ---------------------------------------------- |
+| `LIGHTDASH_CLI_EMAIL`    | Email for login (alternative to `--email`)     |
 | `LIGHTDASH_CLI_PASSWORD` | Password for email login (used with `--email`) |

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,7 +1,12 @@
 import { promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
 import * as os from 'os';
 import * as path from 'path';
-import { ensureConfigFilePermissions, writeConfigToFile } from './config';
+import {
+    ensureConfigFilePermissions,
+    getConfig,
+    writeConfigToFile,
+} from './config';
 
 // Masking file-type bits is the standard way to assert POSIX permissions.
 // eslint-disable-next-line no-bitwise
@@ -44,4 +49,44 @@ describePosix('CLI config permissions', () => {
         expect(permissionBits((await fs.stat(configDir)).mode)).toBe(0o700);
         expect(permissionBits((await fs.stat(configPath)).mode)).toBe(0o600);
     });
+});
+
+describe('CLI project environment override', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it.each([
+        ['other-project', undefined],
+        ['stored-project', 'Stored project'],
+        ['', 'Stored project'],
+        [undefined, 'Stored project'],
+    ])(
+        'only retains the cached name for its own project (override: %s)',
+        async (projectOverride, expectedName) => {
+            vi.stubEnv('LIGHTDASH_PROJECT', projectOverride);
+            vi.spyOn(fs, 'chmod').mockResolvedValue(undefined);
+            vi.spyOn(fs, 'readFile').mockResolvedValue(
+                yaml.dump({
+                    user: { anonymousUuid: 'anonymous-user' },
+                    context: {
+                        project: 'stored-project',
+                        projectName: 'Stored project',
+                        previewProject: 'preview-project',
+                        previewName: 'Preview project',
+                    },
+                }),
+            );
+
+            const config = await getConfig();
+
+            expect(config.context).toMatchObject({
+                project: projectOverride || 'stored-project',
+                projectName: expectedName,
+                previewProject: 'preview-project',
+                previewName: 'Preview project',
+            });
+        },
+    );
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -118,6 +118,11 @@ export const getConfig = async (): Promise<Config> => {
             apiKey: process.env.LIGHTDASH_API_KEY || rawConfig.context?.apiKey,
             project:
                 process.env.LIGHTDASH_PROJECT || rawConfig.context?.project,
+            projectName:
+                process.env.LIGHTDASH_PROJECT &&
+                process.env.LIGHTDASH_PROJECT !== rawConfig.context?.project
+                    ? undefined
+                    : rawConfig.context?.projectName,
             serverUrl:
                 process.env.LIGHTDASH_URL || rawConfig.context?.serverUrl,
             proxyAuthorization:

--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -1,6 +1,7 @@
 import { RenameType, SchedulerJobStatus } from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig } from '../config';
+import GlobalState from '../globalState';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProject } from './dbt/refresh';
 import { renameHandler } from './renameHandler';
@@ -66,6 +67,7 @@ describe('renameHandler follow-up validation', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.stubEnv('LIGHTDASH_PROJECT', undefined);
         vi.mocked(checkLightdashVersion).mockResolvedValue(undefined);
         vi.mocked(getConfig).mockResolvedValue({
             context: {
@@ -87,6 +89,7 @@ describe('renameHandler follow-up validation', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.unstubAllEnvs();
     });
 
     const trackedEvents = () =>
@@ -94,6 +97,37 @@ describe('renameHandler follow-up validation', () => {
             event: payload.event,
             properties: payload.properties,
         }));
+
+    test.each([undefined, baseOptions.project])(
+        'targets the environment project unless --project overrides it (%s)',
+        async (explicitProject) => {
+            const envProject = '22222222-2222-4222-8222-222222222222';
+            vi.stubEnv('LIGHTDASH_PROJECT', envProject);
+            vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(true);
+            vi.mocked(getConfig).mockResolvedValue({
+                context: {
+                    apiKey: 'test-key',
+                    serverUrl: 'http://localhost',
+                    project: envProject,
+                    previewProject: '33333333-3333-4333-8333-333333333333',
+                    previewName: 'Stale preview',
+                },
+            });
+            mockApi(null);
+
+            await renameHandler({ ...baseOptions, project: explicitProject });
+
+            const expectedProject = explicitProject || envProject;
+            expect(lightdashApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: 'POST',
+                    url: `/api/v1/projects/${expectedProject}/rename`,
+                }),
+            );
+            expect(errorOutput.join('\n')).toContain(expectedProject);
+            expect(errorOutput.join('\n')).not.toContain('Stale preview');
+        },
+    );
 
     test('reports a failed validation job as a validation failure, not a rename failure', async () => {
         mockApi(VALIDATION_JOB_ID);

--- a/packages/cli/src/handlers/renameHandler.test.ts
+++ b/packages/cli/src/handlers/renameHandler.test.ts
@@ -1,4 +1,9 @@
-import { RenameType, SchedulerJobStatus } from '@lightdash/common';
+import {
+    Project,
+    ProjectType,
+    RenameType,
+    SchedulerJobStatus,
+} from '@lightdash/common';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig } from '../config';
 import GlobalState from '../globalState';
@@ -34,6 +39,7 @@ const emptyResults = {
 
 const RENAME_JOB_ID = 'rename-job-id';
 const VALIDATION_JOB_ID = 'validation-job-id';
+const PREVIEW_PROJECT = '33333333-3333-4333-8333-333333333333';
 
 describe('renameHandler follow-up validation', () => {
     let errorOutput: string[];
@@ -60,6 +66,15 @@ describe('renameHandler follow-up validation', () => {
             }
             if (url.includes('/validate?jobId=')) {
                 return [];
+            }
+            if (
+                method === 'GET' &&
+                url === `/api/v1/projects/${PREVIEW_PROJECT}`
+            ) {
+                return {
+                    projectUuid: PREVIEW_PROJECT,
+                    type: ProjectType.PREVIEW,
+                } as Project;
             }
             throw new Error(`Unexpected API call: ${method} ${url}`);
         });
@@ -109,7 +124,7 @@ describe('renameHandler follow-up validation', () => {
                     apiKey: 'test-key',
                     serverUrl: 'http://localhost',
                     project: envProject,
-                    previewProject: '33333333-3333-4333-8333-333333333333',
+                    previewProject: PREVIEW_PROJECT,
                     previewName: 'Stale preview',
                 },
             });
@@ -124,8 +139,15 @@ describe('renameHandler follow-up validation', () => {
                     url: `/api/v1/projects/${expectedProject}/rename`,
                 }),
             );
-            expect(errorOutput.join('\n')).toContain(expectedProject);
-            expect(errorOutput.join('\n')).not.toContain('Stale preview');
+            const output = errorOutput.join('\n');
+            expect(output).toContain(`Renaming in project: ${expectedProject}`);
+            if (explicitProject) {
+                expect(output).not.toContain('Stale preview');
+            } else {
+                expect(output).toContain(
+                    'active preview "Stale preview" ignored',
+                );
+            }
         },
     );
 

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -17,7 +17,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { getProject } from './dbt/refresh';
-import { resolveProjectFlag } from './resolveProjectFlag';
+import { resolveProjectOverride } from './selectProject';
 import {
     getJobState,
     getValidation,
@@ -90,10 +90,14 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         );
     }
 
-    const projectOverride = options.project || process.env.LIGHTDASH_PROJECT;
-    const projectUuid = projectOverride
-        ? await resolveProjectFlag(projectOverride)
-        : config.context.previewProject || config.context.project;
+    const overrideProjectUuid = await resolveProjectOverride(
+        config,
+        options.project,
+    );
+    const projectUuid =
+        overrideProjectUuid ||
+        config.context.previewProject ||
+        config.context.project;
     if (!projectUuid) {
         throw new LightdashError({
             message: 'No project selected. Run lightdash config set-project',
@@ -104,7 +108,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
     }
 
     // Log current project info
-    if (projectOverride) {
+    if (overrideProjectUuid) {
         console.error(
             `\n${styles.success('Renaming in project:')} ${projectUuid}\n`,
         );

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -90,8 +90,9 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         );
     }
 
-    const projectUuid = options.project
-        ? await resolveProjectFlag(options.project)
+    const projectOverride = options.project || process.env.LIGHTDASH_PROJECT;
+    const projectUuid = projectOverride
+        ? await resolveProjectFlag(projectOverride)
         : config.context.previewProject || config.context.project;
     if (!projectUuid) {
         throw new LightdashError({
@@ -103,7 +104,7 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
     }
 
     // Log current project info
-    if (options.project) {
+    if (projectOverride) {
         console.error(
             `\n${styles.success('Renaming in project:')} ${projectUuid}\n`,
         );

--- a/packages/cli/src/handlers/selectProject.test.ts
+++ b/packages/cli/src/handlers/selectProject.test.ts
@@ -1,7 +1,7 @@
-import { ProjectType } from '@lightdash/common';
+import { LightdashError, ProjectType } from '@lightdash/common';
 import inquirer from 'inquirer';
 import type { MockedFunction, MockInstance } from 'vitest';
-import { Config } from '../config';
+import { Config, unsetPreviewProject } from '../config';
 import GlobalState from '../globalState';
 import { lightdashApi } from './dbt/apiClient';
 import { logSelectedProject, selectProject } from './selectProject';
@@ -40,17 +40,21 @@ describe('selectProject', () => {
     });
 
     it.each([true, false])(
-        'uses LIGHTDASH_PROJECT instead of an active preview (non-interactive: %s)',
+        'uses LIGHTDASH_PROJECT instead of an active preview and warns (non-interactive: %s)',
         async (nonInteractive) => {
             vi.stubEnv('LIGHTDASH_PROJECT', MAIN_UUID);
             vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(
                 nonInteractive,
             );
+            const log = vi
+                .spyOn(GlobalState, 'log')
+                .mockImplementation(() => {});
             mockPreviewProjectResponse(PREVIEW_UUID);
             const config: Config = {
                 context: {
                     project: MAIN_UUID,
                     previewProject: PREVIEW_UUID,
+                    previewName: 'My preview',
                 },
             };
 
@@ -59,9 +63,55 @@ describe('selectProject', () => {
                 isPreview: false,
             });
             expect(inquirer.prompt).not.toHaveBeenCalled();
-            expect(mockLightdashApi).not.toHaveBeenCalled();
+            expect(log).toHaveBeenCalledTimes(1);
+            const warning = String(log.mock.calls[0][0]);
+            expect(warning).toContain(
+                `Using project ${MAIN_UUID} from LIGHTDASH_PROJECT`,
+            );
+            expect(warning).toContain('active preview "My preview" ignored');
+            expect(warning).toContain(`--project ${PREVIEW_UUID}`);
         },
     );
+
+    it('clears a deleted preview instead of warning when LIGHTDASH_PROJECT is set', async () => {
+        vi.stubEnv('LIGHTDASH_PROJECT', MAIN_UUID);
+        const log = vi.spyOn(GlobalState, 'log').mockImplementation(() => {});
+        mockLightdashApi.mockRejectedValueOnce(
+            new LightdashError({
+                message: 'Not found',
+                name: 'NotFoundError',
+                statusCode: 404,
+                data: {},
+            }),
+        );
+
+        expect(
+            await selectProject({
+                context: { project: MAIN_UUID, previewProject: PREVIEW_UUID },
+            }),
+        ).toEqual({ projectUuid: MAIN_UUID, isPreview: false });
+        expect(unsetPreviewProject).toHaveBeenCalledTimes(1);
+        expect(log).not.toHaveBeenCalled();
+    });
+
+    it.each<[string, NonNullable<Config['context']>]>([
+        ['no preview is active', { project: MAIN_UUID }],
+        [
+            'LIGHTDASH_PROJECT points at the preview itself',
+            { project: MAIN_UUID, previewProject: PREVIEW_UUID },
+        ],
+    ])('does not warn when %s', async (_label, context) => {
+        const envProject = context.previewProject ?? MAIN_UUID;
+        vi.stubEnv('LIGHTDASH_PROJECT', envProject);
+        const log = vi.spyOn(GlobalState, 'log').mockImplementation(() => {});
+        mockPreviewProjectResponse(PREVIEW_UUID);
+
+        expect(await selectProject({ context })).toEqual({
+            projectUuid: envProject,
+            isPreview: false,
+        });
+        expect(log).not.toHaveBeenCalled();
+    });
 
     it('returns the preview project (without prompting) when the stored main and preview UUIDs are the same', async () => {
         // This is the misconfigured state produced by an older `set-project`

--- a/packages/cli/src/handlers/selectProject.test.ts
+++ b/packages/cli/src/handlers/selectProject.test.ts
@@ -1,6 +1,8 @@
 import { ProjectType } from '@lightdash/common';
+import inquirer from 'inquirer';
 import type { MockedFunction, MockInstance } from 'vitest';
 import { Config } from '../config';
+import GlobalState from '../globalState';
 import { lightdashApi } from './dbt/apiClient';
 import { logSelectedProject, selectProject } from './selectProject';
 
@@ -27,9 +29,39 @@ const mockPreviewProjectResponse = (uuid: string) => {
 };
 
 describe('selectProject', () => {
-    afterEach(() => {
-        vi.clearAllMocks();
+    beforeEach(() => {
+        vi.stubEnv('LIGHTDASH_PROJECT', undefined);
     });
+
+    afterEach(() => {
+        vi.resetAllMocks();
+        vi.restoreAllMocks();
+        vi.unstubAllEnvs();
+    });
+
+    it.each([true, false])(
+        'uses LIGHTDASH_PROJECT instead of an active preview (non-interactive: %s)',
+        async (nonInteractive) => {
+            vi.stubEnv('LIGHTDASH_PROJECT', MAIN_UUID);
+            vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(
+                nonInteractive,
+            );
+            mockPreviewProjectResponse(PREVIEW_UUID);
+            const config: Config = {
+                context: {
+                    project: MAIN_UUID,
+                    previewProject: PREVIEW_UUID,
+                },
+            };
+
+            expect(await selectProject(config)).toEqual({
+                projectUuid: MAIN_UUID,
+                isPreview: false,
+            });
+            expect(inquirer.prompt).not.toHaveBeenCalled();
+            expect(mockLightdashApi).not.toHaveBeenCalled();
+        },
+    );
 
     it('returns the preview project (without prompting) when the stored main and preview UUIDs are the same', async () => {
         // This is the misconfigured state produced by an older `set-project`
@@ -55,37 +87,71 @@ describe('selectProject', () => {
         });
     });
 
-    it('uses an explicit --project UUID as-is, without any API call, even when a preview is active', async () => {
-        const config: Config = {
-            context: {
-                project: MAIN_UUID,
-                previewProject: PREVIEW_UUID,
-            },
-        } as Config;
-        const explicitUuid = '00000000-0000-0000-0000-000000000003';
+    it.each([undefined, MAIN_UUID])(
+        'uses an explicit --project UUID ahead of the environment (%s) and active preview',
+        async (envProject) => {
+            vi.stubEnv('LIGHTDASH_PROJECT', envProject);
+            const config: Config = {
+                context: {
+                    project: MAIN_UUID,
+                    previewProject: PREVIEW_UUID,
+                },
+            } as Config;
+            const explicitUuid = '00000000-0000-0000-0000-000000000003';
 
-        const selection = await selectProject(config, explicitUuid);
+            const selection = await selectProject(config, explicitUuid);
 
-        expect(selection).toEqual({
-            projectUuid: explicitUuid,
-            isPreview: false,
-        });
-        expect(mockLightdashApi).not.toHaveBeenCalled();
-    });
+            expect(selection).toEqual({
+                projectUuid: explicitUuid,
+                isPreview: false,
+            });
+            expect(mockLightdashApi).not.toHaveBeenCalled();
+        },
+    );
 
-    it('resolves an explicit --project slug through the org projects list', async () => {
-        const config: Config = {
-            context: { project: MAIN_UUID },
-        } as Config;
-        mockLightdashApi.mockResolvedValueOnce([
-            { projectUuid: PREVIEW_UUID, slug: 'other', name: 'Other' },
-            { projectUuid: MAIN_UUID, slug: 'jaffle-shop', name: 'Jaffle' },
-        ] as never);
+    it.each(['flag', 'env'])(
+        'resolves a project slug from the %s through the org projects list',
+        async (source) => {
+            if (source === 'env')
+                vi.stubEnv('LIGHTDASH_PROJECT', 'jaffle-shop');
+            const config: Config = {
+                context: { project: MAIN_UUID },
+            } as Config;
+            mockLightdashApi.mockResolvedValueOnce([
+                { projectUuid: PREVIEW_UUID, slug: 'other', name: 'Other' },
+                { projectUuid: MAIN_UUID, slug: 'jaffle-shop', name: 'Jaffle' },
+            ] as never);
 
-        const selection = await selectProject(config, 'jaffle-shop');
+            const selection = await selectProject(
+                config,
+                source === 'flag' ? 'jaffle-shop' : undefined,
+            );
 
-        expect(selection).toEqual({ projectUuid: MAIN_UUID, isPreview: false });
-    });
+            expect(selection).toEqual({
+                projectUuid: MAIN_UUID,
+                isPreview: false,
+            });
+        },
+    );
+
+    it.each([undefined, ''])(
+        'keeps the active preview default without an environment override (%s)',
+        async (envProject) => {
+            vi.stubEnv('LIGHTDASH_PROJECT', envProject);
+            vi.spyOn(GlobalState, 'isNonInteractive').mockReturnValue(true);
+            mockPreviewProjectResponse(PREVIEW_UUID);
+
+            expect(
+                await selectProject({
+                    context: {
+                        project: MAIN_UUID,
+                        previewProject: PREVIEW_UUID,
+                    },
+                }),
+            ).toEqual({ projectUuid: PREVIEW_UUID, isPreview: true });
+            expect(inquirer.prompt).not.toHaveBeenCalled();
+        },
+    );
 
     it('returns the main project when only the main project is configured', async () => {
         const config: Config = {

--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -44,12 +44,52 @@ const validatePreviewProject = async (
     }
 };
 
+const warnIgnoredPreview = async (
+    config: Config,
+    projectUuid: string,
+): Promise<void> => {
+    const previewProject = await validatePreviewProject(
+        config.context?.previewProject,
+    );
+    if (!previewProject || previewProject === projectUuid) {
+        return;
+    }
+    const previewName = config.context?.previewName;
+    const previewLabel = previewName ? `"${previewName}"` : previewProject;
+    GlobalState.log(
+        styles.warning(
+            `\nUsing project ${projectUuid} from LIGHTDASH_PROJECT; active preview ${previewLabel} ignored.\nPass --project ${previewProject} or unset LIGHTDASH_PROJECT to target the preview.\n`,
+        ),
+    );
+};
+
+/**
+ * Resolves an explicit project override: `--project` wins over
+ * LIGHTDASH_PROJECT, and either one bypasses an active preview.
+ * Returns undefined when neither is set.
+ */
+export const resolveProjectOverride = async (
+    config: Config,
+    explicitProject: string | undefined,
+): Promise<string | undefined> => {
+    if (explicitProject) {
+        return resolveProjectFlag(explicitProject);
+    }
+    const envProject = process.env.LIGHTDASH_PROJECT;
+    if (!envProject) {
+        return undefined;
+    }
+    const projectUuid = await resolveProjectFlag(envProject);
+    await warnIgnoredPreview(config, projectUuid);
+    return projectUuid;
+};
+
 /**
  * Resolves which project to use, prompting the user if there's an active preview.
  *
  * Priority:
  * 1. If `explicitProject` is provided (via --project flag), use it
- * 2. If LIGHTDASH_PROJECT is set, use it
+ * 2. If LIGHTDASH_PROJECT is set, use it (warns when a preview is ignored)
  * 3. If there's an active preview and we're in interactive mode, ask the user
  * 4. In non-interactive mode with active preview, use preview project
  * 5. Fall back to the main project
@@ -58,12 +98,12 @@ export const selectProject = async (
     config: Config,
     explicitProject?: string,
 ): Promise<ProjectSelection | undefined> => {
-    const projectOverride = explicitProject || process.env.LIGHTDASH_PROJECT;
-    if (projectOverride) {
-        return {
-            projectUuid: await resolveProjectFlag(projectOverride),
-            isPreview: false,
-        };
+    const overrideProjectUuid = await resolveProjectOverride(
+        config,
+        explicitProject,
+    );
+    if (overrideProjectUuid) {
+        return { projectUuid: overrideProjectUuid, isPreview: false };
     }
 
     const mainProject = config.context?.project;

--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -49,18 +49,19 @@ const validatePreviewProject = async (
  *
  * Priority:
  * 1. If `explicitProject` is provided (via --project flag), use it
- * 2. If there's an active preview and we're in interactive mode, ask the user
- * 3. In non-interactive mode with active preview, use preview project
- * 4. Fall back to the main project
+ * 2. If LIGHTDASH_PROJECT is set, use it
+ * 3. If there's an active preview and we're in interactive mode, ask the user
+ * 4. In non-interactive mode with active preview, use preview project
+ * 5. Fall back to the main project
  */
 export const selectProject = async (
     config: Config,
     explicitProject?: string,
 ): Promise<ProjectSelection | undefined> => {
-    // If explicit project provided via --project flag, use it
-    if (explicitProject) {
+    const projectOverride = explicitProject || process.env.LIGHTDASH_PROJECT;
+    if (projectOverride) {
         return {
-            projectUuid: await resolveProjectFlag(explicitProject),
+            projectUuid: await resolveProjectFlag(projectOverride),
             isPreview: false,
         };
     }


### PR DESCRIPTION
## Problem

`LIGHTDASH_PROJECT` is documented as "overrides the project UUID in the config file, useful when you want to target a specific project without using `--project`", but it only filled the *production* slot of the config. With a preview still recorded locally, non-interactive runs picked the preview anyway, so a CI deploy with `LIGHTDASH_PROJECT` set silently landed in a stale preview project for four days (customer report in PROD-11044).

## Fix

Project selection now resolves `--project` > `LIGHTDASH_PROJECT` > active preview > saved project, in both interactive and non-interactive runs, through one helper (`resolveProjectOverride`) shared by `selectProject` (deploy, download, upload, slug-update, apps) and the rename command's separate path.

When the environment variable overrides an active preview the CLI warns instead of switching silently:

```
Using project <uuid> from LIGHTDASH_PROJECT; active preview "my-feature" ignored.
Pass --project <preview uuid> or unset LIGHTDASH_PROJECT to target the preview.
```

The stored preview is validated before warning, so a preview that was already deleted is cleared from the config rather than reported. The saved preview is never cleared by the override itself; `stop-preview` and `set-project` keep their meaning.

`getConfig` also stops returning the cached project *name* when the env var points at a different project, so logs no longer print a stale name next to the overridden UUID.

## Design discussion

The mental model raised in review ("once you start a preview, later commands target it until `set-project` or `stop-preview`") still holds for the config-file case: with no override set, an active preview is the non-interactive default and interactive runs prompt. The env var is treated as an explicit instruction, the same category as `--project`, because that is what the docs already promise and what every CI template relies on. The warning covers the local-dev case of a `LIGHTDASH_PROJECT` left in a shell profile or `.env`.

## Regression analysis

- Official `cli-actions` templates (`deploy.yml`, `start-preview.yml`, `close-preview.yml`, `lightdash-validate.yml`) all set `LIGHTDASH_PROJECT` to the production project. `start-preview` and `stop-preview` do not go through project selection (they use the env project as the *upstream* to copy content from, and the preview by name), so preview workflows are unchanged. `deploy` and `validate` already targeted the env project on a fresh runner; on a runner with persisted CLI state they now do too, which is the fix.
- `lightdash validate` never auto-selected a preview (only via `--preview`), so its behaviour is unchanged.
- `--project` behaviour is unchanged: no warning, no extra API call.
- Behaviour change only when all three hold: no `--project`, `LIGHTDASH_PROJECT` set, and a preview recorded in the local config. Previously: preview (non-interactive) or prompt (interactive). Now: env project plus a warning naming the ignored preview.
- One extra `GET /api/v1/projects/:uuid` in that same case, to validate the preview before warning.

## Verification

- `pnpm -F cli test`: 57 files, 706 tests pass, including new coverage for env-over-preview in both modes, the warning text, no warning without a preview or when the env var names the preview itself, deleted-preview cleanup, slug resolution from the env var, `--project` precedence, empty env var keeping the preview default, and rename targeting.
- `pnpm -F cli typecheck`, `pnpm -F cli lint`, `oxfmt` clean.
- Rebased on `main` (2.194.1).

Docs follow-up: lightdash/mintlify-docs#1243 updates the CLI reference and the preview guide.

Closes: [PROD-11044](https://linear.app/lightdash/issue/PROD-11044)
Closes #28836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhkPTUcayHNKi2jkr3bgKs
