### PR TITLE
test(api-tests): run files in parallel and share warehouse projects

### DIFF
--- a/packages/api-tests/CLAUDE.md
+++ b/packages/api-tests/CLAUDE.md
@@ -41,6 +41,15 @@ that race the one under test.
 - Tests run against a live server; there is no in-process app. Keep them
   self-contained — create what you need and clean it up (`afterAll`) rather than
   depending on another test's state.
+- Files run in parallel. A file that mutates state other files read through
+  (seed project settings or embed config, the admin user, org-wide flags,
+  seeded content) must
+  be added to `serialFiles` in `vitest.config.ts`, where it runs alone after
+  the parallel group.
+- Warehouse parity suites use `useSharedWarehouseProject(client, name)` from
+  `helpers/shared-projects.ts` instead of creating their own remote project.
+  Do not change a shared project's settings; create a dedicated project when
+  a suite needs its own configuration.
 - Field references in table-calculation SQL use Lightdash's `${table.field}`
   syntax. Build these via a template helper (e.g.
   `` const fieldReference = (id: string) => `\${${id}}` ``) so the literal

--- a/packages/api-tests/README.md
+++ b/packages/api-tests/README.md
@@ -25,12 +25,29 @@ pnpm -F api-tests lint
 pnpm -F api-tests typecheck
 ```
 
+## How the suite runs
+
+Files run in parallel (`parallel` project in `vitest.config.ts`). Files that
+mutate state every other file reads through (seed project timezone and embed
+config, admin user timezone and attributes, org-wide flags, seeded dashboards) are listed
+in `serialFiles` and run one at a time after the parallel group. Add a file
+there when it changes shared state; keep it out when it only creates its own
+resources.
+
+`vitest.global-setup.ts` creates one project per credentialed remote warehouse
+and kicks off its refresh before any test runs. Parity suites get it with
+`useSharedWarehouseProject(client, 'snowflake')` (`helpers/shared-projects.ts`),
+which waits for the refresh. Never change a shared project's settings from a
+test; create a dedicated project instead.
+
 ## Layout
 
 - `tests/**/*.test.ts` — the test files (Vitest auto-discovers them).
+- `vitest.global-setup.ts` — creates the shared warehouse projects once per run.
 - `helpers/api-client.ts` — `ApiClient` (cookie-aware `get`/`post`/…), the
   `Body<T>` response wrapper, and `SITE_URL`.
 - `helpers/auth.ts` — `login()` and friends, returning a logged-in `ApiClient`.
+- `helpers/shared-projects.ts` — `useSharedWarehouseProject()` for parity suites.
 - `fixtures/` — static request payloads used by some suites.
 
 ## Writing a test

--- a/packages/api-tests/helpers/api-client.ts
+++ b/packages/api-tests/helpers/api-client.ts
@@ -19,6 +19,48 @@ type ApiResponse<T = unknown> = {
     body: T;
 };
 
+// Errors raised before the request was sent, so any method is safe to retry.
+// The preview ingress can refuse connections for a few seconds.
+const CONNECTION_ERROR_CODES = new Set([
+    'ECONNREFUSED',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+]);
+const MAX_CONNECTION_ATTEMPTS = 6;
+
+function isConnectionError(error: unknown): boolean {
+    if (!(error instanceof Error)) return false;
+    const { cause } = error;
+    return (
+        typeof cause === 'object' &&
+        cause !== null &&
+        'code' in cause &&
+        typeof cause.code === 'string' &&
+        CONNECTION_ERROR_CODES.has(cause.code)
+    );
+}
+
+export async function fetchWithConnectionRetry(
+    url: string,
+    init?: RequestInit,
+): Promise<Response> {
+    for (let attempt = 1; ; attempt++) {
+        try {
+            return await fetch(url, init);
+        } catch (error) {
+            if (
+                !isConnectionError(error) ||
+                attempt >= MAX_CONNECTION_ATTEMPTS
+            ) {
+                throw error;
+            }
+            await new Promise<void>((resolve) => {
+                setTimeout(resolve, attempt * 1000);
+            });
+        }
+    }
+}
+
 export class ApiClient {
     private cookies: Map<string, string> = new Map();
 
@@ -66,7 +108,7 @@ export class ApiClient {
             fetchHeaders.Cookie = cookie;
         }
 
-        const resp = await fetch(url, {
+        const resp = await fetchWithConnectionRetry(url, {
             method,
             headers: fetchHeaders,
             body: body != null ? JSON.stringify(body) : undefined,

--- a/packages/api-tests/helpers/projects.ts
+++ b/packages/api-tests/helpers/projects.ts
@@ -1,7 +1,6 @@
 import { WarehouseTypes } from '@lightdash/common';
 import fs from 'fs';
 import path from 'path';
-import { expect } from 'vitest';
 import { ApiClient, Body } from './api-client';
 
 export const BIGQUERY_CREDENTIALS_PATH = path.resolve(
@@ -229,7 +228,6 @@ export async function createProject(
         dbtVersion: 'v1.12',
         warehouseConnection,
     });
-    expect(resp.status).toBe(200);
     return resp.body.results.project.projectUuid;
 }
 
@@ -251,27 +249,28 @@ async function waitForV1JobCompletion(
 }
 
 /**
- * Create a project, run a full refresh, and return its UUID once compiled.
- * Throws if the refresh job fails so callers fail loudly instead of querying
- * an empty project.
+ * Kick off a full refresh (dbt compile + warehouse catalog) and return the job
+ * to wait on, so callers can overlap the compile with other work.
  */
-export async function createAndRefreshProject(
+export async function startProjectRefresh(
     client: ApiClient,
-    projectName: string,
-    warehouseConnection: Record<string, unknown>,
+    projectUuid: string,
 ): Promise<string> {
-    const projectUuid = await createProject(
-        client,
-        projectName,
-        warehouseConnection,
-    );
-
     const refreshResp = await client.post<Body<{ jobUuid: string }>>(
         `/api/v1/projects/${projectUuid}/refresh`,
     );
-    expect(refreshResp.status).toBe(200);
+    return refreshResp.body.results.jobUuid;
+}
 
-    const { jobUuid } = refreshResp.body.results;
+/**
+ * Block until a refresh job finishes. Throws if it fails so callers fail
+ * loudly instead of querying an empty project.
+ */
+export async function waitForProjectRefresh(
+    client: ApiClient,
+    projectName: string,
+    jobUuid: string,
+): Promise<void> {
     const outcome = await waitForV1JobCompletion(client, jobUuid);
     if (outcome === 'ERROR') {
         const jobResp = await client.get<
@@ -290,6 +289,23 @@ export async function createAndRefreshProject(
             `Project refresh timed out for "${projectName}" (job ${jobUuid} still running after poll window)`,
         );
     }
+}
+
+/**
+ * Create a project, run a full refresh, and return its UUID once compiled.
+ */
+export async function createAndRefreshProject(
+    client: ApiClient,
+    projectName: string,
+    warehouseConnection: Record<string, unknown>,
+): Promise<string> {
+    const projectUuid = await createProject(
+        client,
+        projectName,
+        warehouseConnection,
+    );
+    const jobUuid = await startProjectRefresh(client, projectUuid);
+    await waitForProjectRefresh(client, projectName, jobUuid);
     return projectUuid;
 }
 
@@ -300,7 +316,6 @@ export async function deleteProjectsByName(
     const resp = await client.get<
         Body<{ projectUuid: string; name: string }[]>
     >('/api/v1/org/projects');
-    expect(resp.status).toBe(200);
     for (const project of resp.body.results) {
         if (names.includes(project.name)) {
             await client.delete(`/api/v1/org/projects/${project.projectUuid}`);

--- a/packages/api-tests/helpers/shared-projects.ts
+++ b/packages/api-tests/helpers/shared-projects.ts
@@ -1,0 +1,46 @@
+import { inject } from 'vitest';
+import { ApiClient } from './api-client';
+import { waitForProjectRefresh } from './projects';
+
+/**
+ * One project per credentialed remote warehouse, created and refreshed once
+ * per run by `vitest.global-setup.ts` and shared by every parity suite. The
+ * refresh job is still running when tests start; `useSharedWarehouseProject`
+ * waits for it. Suites must not mutate these projects (settings, timezone,
+ * connection): a suite that needs its own configuration creates its own.
+ */
+export type SharedWarehouseProject = {
+    name: string;
+    projectUuid: string;
+    jobUuid: string;
+};
+
+declare module 'vitest' {
+    export interface ProvidedContext {
+        sharedWarehouseProjects: SharedWarehouseProject[];
+    }
+}
+
+export function sharedWarehouseProjectName(warehouseName: string): string {
+    return `shared ${warehouseName} parity project`;
+}
+
+export async function useSharedWarehouseProject(
+    client: ApiClient,
+    warehouseName: string,
+): Promise<string> {
+    const shared = inject('sharedWarehouseProjects').find(
+        (project) => project.name === warehouseName,
+    );
+    if (!shared) {
+        throw new Error(
+            `No shared ${warehouseName} project exists: global setup only creates projects for warehouses with credentials.`,
+        );
+    }
+    await waitForProjectRefresh(
+        client,
+        sharedWarehouseProjectName(warehouseName),
+        shared.jobUuid,
+    );
+    return shared.projectUuid;
+}

--- a/packages/api-tests/tests/async-query.test.ts
+++ b/packages/api-tests/tests/async-query.test.ts
@@ -7,11 +7,12 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import {
-    bigqueryWarehouseConfig,
     createAndRefreshProject,
     deleteProjectsByName,
     hasBigqueryCredentials,
+    hasSnowflakeCredentials,
 } from '../helpers/projects';
+import { useSharedWarehouseProject } from '../helpers/shared-projects';
 
 const apiUrl = '/api/v2';
 
@@ -296,46 +297,21 @@ describe('Async Query API', () => {
         }, 120_000);
     });
 
-    describe.skipIf(!process.env.SNOWFLAKE_ACCOUNT)('Snowflake', () => {
-        let projectUuid: string | undefined;
-        const projectName = 'snowflakeSQL query test';
-
-        afterAll(async () => {
-            if (projectUuid) {
-                await deleteProjectsByName(admin, [projectName]);
-            }
-        });
-
+    describe.skipIf(!hasSnowflakeCredentials())('Snowflake', () => {
         it('should execute async query and get all results paged', async () => {
-            projectUuid = await createAndRefreshProject(admin, projectName, {
-                account: process.env.SNOWFLAKE_ACCOUNT,
-                user: process.env.SNOWFLAKE_USER,
-                password: process.env.SNOWFLAKE_PASSWORD,
-                role: 'SYSADMIN',
-                database: 'SNOWFLAKE_DATABASE_STAGING',
-                warehouse: 'TESTING',
-                schema: 'JAFFLE',
-                type: WarehouseTypes.SNOWFLAKE,
-            });
+            const projectUuid = await useSharedWarehouseProject(
+                admin,
+                'snowflake',
+            );
             await runAsyncQueryTest(admin, projectUuid);
-        }, 120_000);
+        }, 420_000);
     });
 
     describe.skipIf(!hasBigqueryCredentials())('BigQuery', () => {
-        let projectUuid: string | undefined;
-        const projectName = 'bigQuerySQL query test';
-
-        afterAll(async () => {
-            if (projectUuid) {
-                await deleteProjectsByName(admin, [projectName]);
-            }
-        });
-
         it('should execute async query and get all results paged', async () => {
-            projectUuid = await createAndRefreshProject(
+            const projectUuid = await useSharedWarehouseProject(
                 admin,
-                projectName,
-                bigqueryWarehouseConfig(),
+                'bigquery',
             );
             await runAsyncQueryTest(admin, projectUuid);
         }, 420_000);

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -1150,7 +1150,9 @@ describe('Merge queries on the project warehouse', () => {
     // Every other credentialed warehouse: run the same suite against the
     // shared project global setup created for it. Skipped when creds are absent.
     for (const { name } of mergeWarehouseEntries) {
-        describe(name, () => {
+        // Remote warehouses drop a connection now and then ("socket hang up");
+        // one retry keeps that transient from failing the run.
+        describe(name, { retry: 1 }, () => {
             let admin: ApiClient;
             let projectUuid: string;
 

--- a/packages/api-tests/tests/mergeQuery.test.ts
+++ b/packages/api-tests/tests/mergeQuery.test.ts
@@ -24,11 +24,8 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
-import {
-    createAndRefreshProject,
-    deleteProjectsByName,
-    getAvailableWarehouseConfigs,
-} from '../helpers/projects';
+import { getAvailableWarehouseConfigs } from '../helpers/projects';
+import { useSharedWarehouseProject } from '../helpers/shared-projects';
 import { uniqueName } from '../helpers/test-isolation';
 
 // Two independent aggregations of the jaffle dataset, joined on the order
@@ -1150,28 +1147,17 @@ describe('Merge queries on the project warehouse', () => {
         }));
     });
 
-    // Every other credentialed warehouse: spin up a project against its
-    // jaffle dataset and run the same suite. Skipped when creds are absent.
-    for (const { name, config } of mergeWarehouseEntries) {
+    // Every other credentialed warehouse: run the same suite against the
+    // shared project global setup created for it. Skipped when creds are absent.
+    for (const { name } of mergeWarehouseEntries) {
         describe(name, () => {
-            const projectName = `merge ${name} parity test`;
             let admin: ApiClient;
             let projectUuid: string;
 
             beforeAll(async () => {
                 admin = await login();
-                projectUuid = await createAndRefreshProject(
-                    admin,
-                    projectName,
-                    config,
-                );
+                projectUuid = await useSharedWarehouseProject(admin, name);
             }, 420_000);
-
-            afterAll(async () => {
-                if (projectUuid) {
-                    await deleteProjectsByName(admin, [projectName]);
-                }
-            });
 
             registerMergeQueryTests(() => ({
                 client: admin,

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -1,12 +1,9 @@
 import { SEED_PROJECT } from '@lightdash/common';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
-import {
-    createAndRefreshProject,
-    deleteProjectsByName,
-    getAvailableWarehouseConfigs,
-} from '../helpers/projects';
+import { getAvailableWarehouseConfigs } from '../helpers/projects';
+import { useSharedWarehouseProject } from '../helpers/shared-projects';
 
 const apiUrl = '/api/v2';
 
@@ -313,28 +310,17 @@ describe('Pivot query API', () => {
         }));
     });
 
-    // Every other warehouse: spin up a project against its jaffle dataset and
-    // run the same pivot suite. Skipped automatically when creds are absent.
-    for (const { name, config } of pivotWarehouseEntries) {
+    // Every other warehouse: run the same pivot suite against the shared
+    // project global setup created for it. Skipped when creds are absent.
+    for (const { name } of pivotWarehouseEntries) {
         describe(name, () => {
-            const projectName = `pivot ${name} parity test`;
             let admin: ApiClient;
             let projectUuid: string;
 
             beforeAll(async () => {
                 admin = await login();
-                projectUuid = await createAndRefreshProject(
-                    admin,
-                    projectName,
-                    config,
-                );
+                projectUuid = await useSharedWarehouseProject(admin, name);
             }, 420_000);
-
-            afterAll(async () => {
-                if (projectUuid) {
-                    await deleteProjectsByName(admin, [projectName]);
-                }
-            });
 
             registerPivotQueryTests(name, () => ({
                 client: admin,

--- a/packages/api-tests/tests/pivotQuery.test.ts
+++ b/packages/api-tests/tests/pivotQuery.test.ts
@@ -313,7 +313,9 @@ describe('Pivot query API', () => {
     // Every other warehouse: run the same pivot suite against the shared
     // project global setup created for it. Skipped when creds are absent.
     for (const { name } of pivotWarehouseEntries) {
-        describe(name, () => {
+        // Remote warehouses drop a connection now and then ("socket hang up");
+        // one retry keeps that transient from failing the run.
+        describe(name, { retry: 1 }, () => {
             let admin: ApiClient;
             let projectUuid: string;
 

--- a/packages/api-tests/vitest.config.ts
+++ b/packages/api-tests/vitest.config.ts
@@ -1,14 +1,60 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
+
+// Files that mutate state every other file reads through: the seed project's
+// data timezone and embed config (secret + allowed dashboards), the admin
+// user's timezone and attributes, the org results cache flag, and the seeded
+// dashboard. They run one at a time, after the parallel group has finished.
+const serialFiles = [
+    'tests/dataTimezone.test.ts',
+    'tests/queryTimezone.test.ts',
+    'tests/queryTimezoneBoundary.test.ts',
+    'tests/userTimezone.test.ts',
+    'tests/embedManagement.test.ts',
+    'tests/embedChart.test.ts',
+    'tests/embedDashboard.test.ts',
+    'tests/embedTimezone.test.ts',
+    'tests/dataAppVizRender.test.ts',
+    'tests/attributes.test.ts',
+    'tests/catalog.test.ts',
+    'tests/resultsCacheSettings.test.ts',
+    'tests/contentAsCode.test.ts',
+];
+
+const shared = {
+    environment: 'node',
+    testTimeout: 120_000,
+    hookTimeout: 30_000,
+    globals: true,
+    setupFiles: ['vitest.setup.ts'],
+    pool: 'forks' as const,
+};
 
 export default defineConfig({
     test: {
-        include: ['tests/**/*.test.ts'],
-        environment: 'node',
-        testTimeout: 120_000,
-        hookTimeout: 30_000,
-        globals: true,
-        setupFiles: ['vitest.setup.ts'],
-        pool: 'forks',
-        fileParallelism: false,
+        // Runs once per run (root project only): creates the shared warehouse
+        // projects used by the parity suites.
+        globalSetup: ['vitest.global-setup.ts'],
+        projects: [
+            {
+                test: {
+                    ...shared,
+                    name: 'parallel',
+                    include: ['tests/**/*.test.ts'],
+                    exclude: [...configDefaults.exclude, ...serialFiles],
+                    fileParallelism: true,
+                    maxWorkers: 6,
+                    sequence: { groupOrder: 0 },
+                },
+            },
+            {
+                test: {
+                    ...shared,
+                    name: 'serial',
+                    include: serialFiles,
+                    fileParallelism: false,
+                    sequence: { groupOrder: 1 },
+                },
+            },
+        ],
     },
 });

--- a/packages/api-tests/vitest.config.ts
+++ b/packages/api-tests/vitest.config.ts
@@ -42,7 +42,10 @@ export default defineConfig({
                     include: ['tests/**/*.test.ts'],
                     exclude: [...configDefaults.exclude, ...serialFiles],
                     fileParallelism: true,
-                    maxWorkers: 6,
+                    // The preview pod is shared with the Cypress jobs; the
+                    // merge suite bounds this group, so more workers only add
+                    // contention.
+                    maxWorkers: 4,
                     sequence: { groupOrder: 0 },
                 },
             },

--- a/packages/api-tests/vitest.global-setup.ts
+++ b/packages/api-tests/vitest.global-setup.ts
@@ -1,0 +1,52 @@
+import type { TestProject } from 'vitest/node';
+import { SITE_URL } from './helpers/api-client';
+import { login } from './helpers/auth';
+import {
+    createProject,
+    deleteProjectsByName,
+    getAvailableWarehouseConfigs,
+    startProjectRefresh,
+} from './helpers/projects';
+import {
+    SharedWarehouseProject,
+    sharedWarehouseProjectName,
+} from './helpers/shared-projects';
+
+// Databricks is excluded to avoid starting serverless compute; Postgres is
+// covered by the seed project.
+const warehouseEntries = getAvailableWarehouseConfigs({
+    includePostgres: false,
+    includeDatabricks: false,
+});
+
+export default async function setup(project: TestProject) {
+    const health = await fetch(`${SITE_URL}/api/v1/health`).catch(() => null);
+    if (!health?.ok) {
+        throw new Error(
+            `Server health check failed. Is the dev server running at ${SITE_URL}?`,
+        );
+    }
+    const admin = await login();
+    const names = warehouseEntries.map(({ name }) =>
+        sharedWarehouseProjectName(name),
+    );
+    // Clean up projects leaked by an interrupted run (names are not unique)
+    await deleteProjectsByName(admin, names);
+
+    const sharedProjects: SharedWarehouseProject[] = await Promise.all(
+        warehouseEntries.map(async ({ name, config }) => {
+            const projectUuid = await createProject(
+                admin,
+                sharedWarehouseProjectName(name),
+                config,
+            );
+            const jobUuid = await startProjectRefresh(admin, projectUuid);
+            return { name, projectUuid, jobUuid };
+        }),
+    );
+    project.provide('sharedWarehouseProjects', sharedProjects);
+
+    return async () => {
+        await deleteProjectsByName(admin, names);
+    };
+}

--- a/packages/api-tests/vitest.global-setup.ts
+++ b/packages/api-tests/vitest.global-setup.ts
@@ -1,5 +1,5 @@
 import type { TestProject } from 'vitest/node';
-import { SITE_URL } from './helpers/api-client';
+import { fetchWithConnectionRetry, SITE_URL } from './helpers/api-client';
 import { login } from './helpers/auth';
 import {
     createProject,
@@ -20,7 +20,9 @@ const warehouseEntries = getAvailableWarehouseConfigs({
 });
 
 export default async function setup(project: TestProject) {
-    const health = await fetch(`${SITE_URL}/api/v1/health`).catch(() => null);
+    const health = await fetchWithConnectionRetry(
+        `${SITE_URL}/api/v1/health`,
+    ).catch(() => null);
     if (!health?.ok) {
         throw new Error(
             `Server health check failed. Is the dev server running at ${SITE_URL}?`,
@@ -47,6 +49,12 @@ export default async function setup(project: TestProject) {
     project.provide('sharedWarehouseProjects', sharedProjects);
 
     return async () => {
-        await deleteProjectsByName(admin, names);
+        // A leaked project is removed by the next run's setup, so an
+        // unreachable server at teardown must not fail the run.
+        await deleteProjectsByName(admin, names).catch((error: unknown) => {
+            process.stderr.write(
+                `Could not delete shared warehouse projects: ${String(error)}\n`,
+            );
+        });
     };
 }

--- a/packages/api-tests/vitest.setup.ts
+++ b/packages/api-tests/vitest.setup.ts
@@ -1,8 +1,8 @@
 import { beforeAll } from 'vitest';
-import { SITE_URL } from './helpers/api-client';
+import { fetchWithConnectionRetry, SITE_URL } from './helpers/api-client';
 
 beforeAll(async () => {
-    const resp = await fetch(`${SITE_URL}/api/v1/health`);
+    const resp = await fetchWithConnectionRetry(`${SITE_URL}/api/v1/health`);
     if (!resp.ok) {
         throw new Error(
             `Server health check failed (${resp.status}). Is the dev server running at ${SITE_URL}?`,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1073,6 +1073,8 @@ export class SpaceModel {
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereNull(`${SpaceTableName}.parent_space_uuid`)
             .whereNull(`${SpaceTableName}.deleted_at`)
+            .orderBy(`${SpaceTableName}.created_at`, 'asc')
+            .orderBy(`${SpaceTableName}.space_id`, 'asc')
             .select(`${SpaceTableName}.space_uuid`);
         return spaces.map((s: { space_uuid: string }) => s.space_uuid);
     }

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -973,17 +973,19 @@ export class SpacePermissionService extends BaseService {
     ): Promise<string> {
         const allRootSpaceUuids =
             await this.spaceModel.getRootSpaceUuidsForProject(projectUuid);
-        const accessible = await this.getAccessibleSpaceUuids(
-            'view',
-            user,
-            allRootSpaceUuids,
+        const accessible = new Set(
+            await this.getAccessibleSpaceUuids('view', user, allRootSpaceUuids),
         );
-        if (accessible.length === 0) {
+        // Oldest root space first, so the fallback is stable across calls
+        const firstViewable = allRootSpaceUuids.find((spaceUuid) =>
+            accessible.has(spaceUuid),
+        );
+        if (!firstViewable) {
             throw new NotFoundError(
                 `No viewable space found for project ${projectUuid}`,
             );
         }
-        return accessible[0];
+        return firstViewable;
     }
 
     /**

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -971,21 +971,36 @@ export class SpacePermissionService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<string> {
-        const allRootSpaceUuids =
-            await this.spaceModel.getRootSpaceUuidsForProject(projectUuid);
-        const accessible = new Set(
-            await this.getAccessibleSpaceUuids('view', user, allRootSpaceUuids),
-        );
-        // Oldest root space first, so the fallback is stable across calls
-        const firstViewable = allRootSpaceUuids.find((spaceUuid) =>
-            accessible.has(spaceUuid),
-        );
+        // Deleting a root space between listing the spaces and resolving
+        // access makes the access check throw, so resolve once more.
+        const firstViewable = await this.findFirstViewableSpaceUuid(
+            user,
+            projectUuid,
+        ).catch((e: unknown) => {
+            if (e instanceof NotFoundError) {
+                return this.findFirstViewableSpaceUuid(user, projectUuid);
+            }
+            throw e;
+        });
         if (!firstViewable) {
             throw new NotFoundError(
                 `No viewable space found for project ${projectUuid}`,
             );
         }
         return firstViewable;
+    }
+
+    private async findFirstViewableSpaceUuid(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<string | undefined> {
+        const allRootSpaceUuids =
+            await this.spaceModel.getRootSpaceUuidsForProject(projectUuid);
+        const accessible = new Set(
+            await this.getAccessibleSpaceUuids('view', user, allRootSpaceUuids),
+        );
+        // Oldest root space first, so the fallback is stable across calls
+        return allRootSpaceUuids.find((spaceUuid) => accessible.has(spaceUuid));
     }
 
     /**


### PR DESCRIPTION
test-all

## What changed?

The `E2E: API (Vitest)` job takes ~19 minutes, of which ~18 is `vitest run`. Two causes, both addressed here:

**1. Files ran strictly one at a time.** `fileParallelism: false` was inherited when the tests were split out of the Cypress package. The runner sat idle waiting on the preview pod: the sum of per-file durations equalled the wall time.

`vitest.config.ts` now defines two Vitest projects:

- `parallel` (4 workers): every file that only creates and cleans up its own resources.
- `serial` (`groupOrder: 1`, one file at a time, runs after `parallel` finishes): files that mutate state every other file reads through. Today that is the seed project's data timezone (`dataTimezone`, `queryTimezone`, `queryTimezoneBoundary`), its embed config and secret (`embedManagement`, `embedChart`, `embedDashboard`, `embedTimezone`, `dataAppVizRender`), the admin user's timezone (`userTimezone`) and attributes (`attributes`, `catalog`), the org results-cache flag (`resultsCacheSettings`), and the seeded dashboard (`contentAsCode`, see PROD-10740).

**2. The same remote warehouse projects were created and refreshed nine times.** `mergeQuery`, `pivotQuery` and `async-query` each created their own Snowflake, BigQuery and Trino project in `beforeAll`, at roughly a minute per refresh, serially. In the baseline run, `mergeQuery` spent 186s of its 366s in hooks and `pivotQuery` 54s of 96s.

`vitest.global-setup.ts` now creates one project per credentialed remote warehouse once per run, starts its refresh, and provides the UUIDs to tests. Suites call `useSharedWarehouseProject(client, 'snowflake')`, which waits for that refresh, so the compile overlaps with the rest of the parallel group. The global teardown deletes the projects.

`dataTimezone` and `queryTimezone` keep their own BigQuery projects: they change the project's data timezone and start-of-week, which a shared project must not have.

**One backend change, needed for (1):** `getFirstViewableSpaceUuid` picked a space in whatever order Postgres returned root spaces, because `getRootSpaceUuidsForProject` had no `ORDER BY`. Under parallel runs a dashboard created without a `spaceUuid` landed in a space another file was deleting at that moment (`dashboards_space_id_foreign` violation, then 404s). Root spaces are now ordered oldest first and the first viewable one is taken in that order. For real users this only makes "create without a space" deterministic (the oldest space they can view) instead of arbitrary.

## Why is this safe?

- The `serial` group preserves today's guarantee for every file that touches shared state. Everything in `parallel` already used `uniqueName()` and per-file cleanup, which the helper was written for.
- Shared warehouse projects are only queried, never reconfigured. `helpers/shared-projects.ts` documents that rule; a suite that needs its own settings creates its own project, as the timezone suites do.
- `helpers/projects.ts` no longer imports `expect`, so it is usable from global setup. `ApiClient` already throws on non-2xx, so the removed assertions were redundant.
- Verified locally against a backend on an isolated database (Postgres only, no remote credentials): the full suite runs `parallel` then `serial`. The only local failures are environment-bound (merge queries wait on a worker loop that the inline dev scheduler does not run; dbt refresh jobs fail on the local DB role) and fail identically in serial mode. The remote warehouse path can only be exercised on the preview; that is what this PR's CI run verifies.

## Baseline

Run on #28912, job `E2E: API (Vitest)`: 1089s for 51 files / 760 tests.
https://github.com/lightdash/lightdash/actions/runs/34330723156/job/102399859360

## How to test?

- Compare the `E2E: API (Vitest)` job duration on this PR against the baseline above.
- `pnpm -F api-tests test:api` against a local backend runs both projects; `--project parallel` or `--project serial` runs one.

No ticket: confirmed with the author.

## First CI run

Job time went from 1089s to 640s, with 702 tests passing. The parallel group finished in 6.5 minutes (bounded by mergeQuery, whose 48 tests take ~350s on the remote warehouses; its hook time dropped from 186s to 34s). Seven serial files then failed with `ECONNREFUSED` to the preview ingress IP for ~4 seconds, while the app itself kept serving (its logs show queries and dbt jobs completing through the blip). No earlier failed API job shows this error, but the serial group makes it costly: files start back-to-back, and each health check gave up on the first refused connection.

The second commit retries connection-level failures (`ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`) in `ApiClient` and both health checks, with 1s to 5s backoff over six attempts. Those errors mean the request was never sent, so retrying any method is safe. Global teardown now warns instead of failing when it cannot delete the shared projects; the next run's setup removes leaked ones.

## Second CI run

The retry held: all serial files passed. The run took 836s because everything on the preview was slower than in run 1 (the same permission suites took 2x to 3x longer, and 3 of 5 Cypress App jobs timed out on element waits, which they passed in run 1 and pass on other branches). One Snowflake merge test failed with a warehouse-side `socket hang up`, a transient. The third commit drops the parallel group to 4 workers: the merge suite bounds that group anyway, so extra workers only added contention on the pod the App jobs share.

## Third CI run

806s, all five App jobs green again with 4 workers, 759 tests passing. One Snowflake merge test failed, a different one from run 2, with the same `socket hang up` from the warehouse on a merge source query. The preview pod's own Snowflake query rate was lower than in run 1 (which passed), so this is not a concurrency limit; it is a connection drop the product does not retry, and a longer busy window on the pod makes it more likely. The fourth commit gives the remote-warehouse parity describes `retry: 1`, matching the Cypress suites' retries. It is scoped to those describes so a real ordering race elsewhere still fails.

## Fourth CI run

808s, App jobs green, 759 tests passing, one failure — this time in the postgres seed-project merge describe, so not the warehouse transient the retry covers. Creating a chart without a space 404'd naming a space uuid that has no row at all in the preview database, while the space the fallback would have chosen (the seeded one, oldest) was present and viewable.

The cause is the enumeration, not the choice: `getFirstViewableSpaceUuid` asks for access on every root space at once, and that bulk access check throws `NotFoundError` when any space in the list was deleted in the meantime. A parallel file deleting its own space made an unrelated create fail. The fifth commit resolves once more before giving up, which is also the honest behaviour for a real user whose colleague deletes a space mid-request. Existing unit tests for that service pass.

## Fifth CI run — green

`E2E: API (Vitest)` passed in 631s against the 1089s baseline, with all 51 files and 760 tests, and every other E2E and CLI job green.

| | Baseline | This PR |
|---|---|---|
| Job wall time | 1089s | 631s |
| Files run at once | 1 | 4, then the serial group |
| Remote warehouse project refreshes | 9 | 3 |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvPuSerk4whVcgRZbyMYA2
