### PR TITLE
fix(pre-aggregates): serve a deduplicated parent metric only on an exact dimension match

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -5,6 +5,7 @@ import {
     FieldType,
     FilterOperator,
     GroupValueMatchType,
+    JoinRelationship,
     MetricType,
     PreAggregateMissReason,
     preAggregateUtils,
@@ -3183,6 +3184,151 @@ describe('findMatch sql_filter coverage', () => {
         expect(result).toStrictEqual({
             hit: true,
             preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+});
+
+describe('deduplicated metrics on the one side of a join', () => {
+    const exploreWithHits = ({
+        dimensions,
+        metrics,
+    }: {
+        dimensions: string[];
+        metrics: string[];
+    }): Explore => ({
+        name: 'sessions',
+        label: 'Sessions',
+        tags: [],
+        baseTable: 'sessions',
+        targetDatabase: SupportedDbtAdapter.BIGQUERY,
+        joinedTables: [
+            {
+                table: 'hits',
+                sqlOn: 'TRUE',
+                compiledSqlOn: 'TRUE',
+                type: 'left',
+                relationship: JoinRelationship.ONE_TO_MANY,
+                tablesReferences: ['sessions'],
+            },
+        ],
+        tables: {
+            sessions: {
+                name: 'sessions',
+                label: 'Sessions',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'sessions',
+                primaryKey: ['id'],
+                dimensions: {
+                    device: makeDimension({
+                        name: 'device',
+                        table: 'sessions',
+                    }),
+                },
+                metrics: {
+                    session_count: makeMetric({
+                        name: 'session_count',
+                        type: MetricType.COUNT,
+                        table: 'sessions',
+                    }),
+                    last_visit: makeMetric({
+                        name: 'last_visit',
+                        type: MetricType.MAX,
+                        table: 'sessions',
+                    }),
+                },
+                lineageGraph: {},
+            },
+            hits: {
+                name: 'hits',
+                label: 'Hits',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'hits',
+                dimensions: {
+                    product: makeDimension({ name: 'product', table: 'hits' }),
+                },
+                metrics: {
+                    hit_count: makeMetric({
+                        name: 'hit_count',
+                        type: MetricType.COUNT,
+                        table: 'hits',
+                    }),
+                },
+                lineageGraph: {},
+            },
+        },
+        preAggregates: [{ name: 'sessions_by_product', dimensions, metrics }],
+    });
+    const productDef = () =>
+        exploreWithHits({
+            dimensions: ['device', 'hits.product'],
+            metrics: ['session_count', 'last_visit', 'hits.hit_count'],
+        });
+
+    it('misses a parent count at a coarser grain than the many-side dimensions', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['sessions_device'],
+                metrics: ['sessions_session_count'],
+            }),
+            productDef(),
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH,
+            fieldId: 'sessions_session_count',
+        });
+    });
+
+    it('serves the parent count on an exact dimension match', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['sessions_device', 'hits_product'],
+                metrics: ['sessions_session_count'],
+            }),
+            productDef(),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'sessions_by_product',
+            miss: null,
+        });
+    });
+
+    it('re-aggregates a many-side count and an inflation-proof parent metric', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['sessions_device'],
+                metrics: ['hits_hit_count', 'sessions_last_visit'],
+            }),
+            productDef(),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'sessions_by_product',
+            miss: null,
+        });
+    });
+
+    it('re-aggregates the parent count when the definition never joins the many side', () => {
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: [],
+                metrics: ['sessions_session_count'],
+            }),
+            exploreWithHits({
+                dimensions: ['device'],
+                metrics: ['session_count'],
+            }),
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'sessions_by_product',
             miss: null,
         });
     });

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -16,6 +16,7 @@ import {
     Explore,
     FieldId,
     FieldReferenceError,
+    findTablesWithMetricInflation,
     flattenFilterGroup,
     ForbiddenError,
     getCustomGroupOrderSql,
@@ -26,10 +27,12 @@ import {
     getFixedWidthBinSelectSql,
     getIntrinsicUserAttributeRegex,
     getItemId,
+    getJoinedTables,
     getSqlForTruncatedDate,
     getUserAttributeRegex,
     IntrinsicUserAttributes,
     isCompiledCustomSqlDimension,
+    isInflationProofMetric,
     isSqlTableCalculation,
     JoinRelationship,
     lightdashVariablePattern,
@@ -44,10 +47,17 @@ import {
     UserAttributeValueMap,
     WeekDay,
     type EscapedParameterValue,
+    type FindTablesWithMetricInflationArgs,
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
-import { intersection, isArray } from 'lodash';
+import { isArray } from 'lodash';
 import { hasUserAttribute } from '../../services/UserAttributesService/UserAttributeUtils';
+
+export {
+    findTablesWithMetricInflation,
+    getJoinedTables,
+    isInflationProofMetric,
+};
 
 export type TotalQueryKind =
     | 'grandTotal'
@@ -945,236 +955,7 @@ export const getCustomBinDimensionSql = ({
     };
 };
 
-/*
- * Returns list of intermediary/extra joined tables based on the current joined tables
- */
-export const getJoinedTables = (
-    explore: Explore,
-    tableNames: string[],
-): string[] => {
-    if (tableNames.length === 0) {
-        return [];
-    }
-    const allNewReferences = explore.joinedTables.reduce<string[]>(
-        (sum, joinedTable) => {
-            if (tableNames.includes(joinedTable.table)) {
-                const joinTableReferences =
-                    joinedTable.tablesReferences ||
-                    parseAllReferences(
-                        // fallback for old explores, it might be incorrect when the join as an alias
-                        joinedTable.sqlOn,
-                        joinedTable.table,
-                    ).map(({ refTable }) => refTable);
-
-                const newReferencesInJoin = joinTableReferences.reduce<
-                    string[]
-                >(
-                    (acc, refTable) =>
-                        !tableNames.includes(refTable)
-                            ? [...acc, refTable]
-                            : acc,
-                    [],
-                );
-                return [...sum, ...newReferencesInJoin];
-            }
-            return sum;
-        },
-        [],
-    );
-    return [...allNewReferences, ...getJoinedTables(explore, allNewReferences)];
-};
-
-/**
- * Determines if a metric type is "inflation-proof" (not affected by join inflation)
- */
-export const isInflationProofMetric = (metricType: MetricType): boolean =>
-    [
-        MetricType.COUNT_DISTINCT,
-        MetricType.SUM_DISTINCT,
-        MetricType.AVERAGE_DISTINCT,
-        MetricType.MIN,
-        MetricType.MAX,
-    ].includes(metricType);
-
-const findTablesWithInflationFromJoin = (join: CompiledExploreJoin) => {
-    const tablesWithInflation = new Set<string>();
-    if (!join.tablesReferences) {
-        // Skip, as we can't detect inflation without knowing table references in join SQL
-        return tablesWithInflation;
-    }
-    if (join.relationship === JoinRelationship.ONE_TO_MANY) {
-        // The tables used to join the table can have metric inflation
-        const joinFrom = join.tablesReferences.filter(
-            (table) => table !== join.table,
-        );
-        joinFrom.forEach(tablesWithInflation.add.bind(tablesWithInflation));
-    } else if (join.relationship === JoinRelationship.MANY_TO_ONE) {
-        // The table being joined can have metric inflation
-        tablesWithInflation.add(join.table);
-    }
-
-    return tablesWithInflation;
-};
-
-const findChainedOneToOneTableJoins = ({
-    tables,
-    possibleJoins,
-}: {
-    tables: Set<string>;
-    possibleJoins: CompiledExploreJoin[];
-}) => {
-    const result = new Set<string>();
-    // Keep track of visited tables to avoid infinite recursion
-    const visited = new Set<string>();
-
-    const findReferences = (currentTables: Set<string>) => {
-        const newTables = new Set<string>();
-
-        for (const tableName of currentTables) {
-            if (!visited.has(tableName)) {
-                visited.add(tableName);
-                possibleJoins.forEach((join) => {
-                    if (
-                        join.tablesReferences &&
-                        join.tablesReferences.includes(tableName) &&
-                        (!join.relationship ||
-                            join.relationship === JoinRelationship.ONE_TO_ONE)
-                    ) {
-                        join.tablesReferences.forEach((from) => {
-                            if (!result.has(from)) {
-                                result.add(from);
-                                newTables.add(from);
-                            }
-                        });
-                    }
-                });
-            }
-        }
-
-        // Recursively process newly found tables
-        if (newTables.size > 0) {
-            findReferences(newTables);
-        }
-    };
-
-    findReferences(tables);
-    return result;
-};
-
-export const findTablesWithMetricInflation = ({
-    baseTable,
-    joinedTables,
-    possibleJoins,
-    tables,
-}: Pick<
-    FindMetricInflationWarningsProps,
-    'baseTable' | 'joinedTables' | 'possibleJoins' | 'tables'
->): {
-    tablesWithMetricInflation: Set<string>;
-    joinWithoutRelationship: Set<string>;
-    tablesWithoutPrimaryKey: Set<string>;
-} => {
-    const tablesWithMetricInflation = new Set<string>();
-    const joinWithoutRelationship = new Set<string>();
-    const tablesWithoutPrimaryKey = new Set<string>();
-
-    // Check if any join has a many-to-many relationship
-    const hasManyToManyJoin = Array.from(joinedTables).some((joinedTable) => {
-        if (joinedTable === baseTable) return false;
-
-        const join = possibleJoins.find(
-            (possibleJoin) => possibleJoin.table === joinedTable,
-        );
-        return join?.relationship === JoinRelationship.MANY_TO_MANY;
-    });
-
-    // If there's a many-to-many join, all tables (including base table) have inflation
-    if (hasManyToManyJoin) {
-        joinedTables.forEach(
-            tablesWithMetricInflation.add.bind(tablesWithMetricInflation),
-        );
-        // Also add the base table
-        tablesWithMetricInflation.add(baseTable);
-    } else {
-        joinedTables.forEach((joinedTable) => {
-            if (
-                !tables[joinedTable]?.primaryKey &&
-                !tables[joinedTable]?.nestedFrom
-            ) {
-                // Warn the user about missing primary key so we can detect possible metric inflation
-                tablesWithoutPrimaryKey.add(joinedTable);
-            }
-
-            if (joinedTable === baseTable) {
-                // skip base table
-                return;
-            }
-
-            const join = possibleJoins.find(
-                (possibleJoin) => possibleJoin.table === joinedTable,
-            );
-            if (!join) {
-                throw new Error(`Join ${joinedTable} not found`);
-            }
-            if (!join.tablesReferences) {
-                // Skip, as we can't detect inflation without knowing table references in join SQL
-                return;
-            }
-            if (!join.relationship) {
-                // Warn the user about missing relationship so we can detect possible metric inflation
-                joinWithoutRelationship.add(joinedTable);
-            } else {
-                // Finds tables with inflation in this join
-                const tablesWithInflationFromJoin =
-                    findTablesWithInflationFromJoin(join);
-                // Finds chained joins with one-to-one relationship
-                const chainedTablesWithInflation =
-                    findChainedOneToOneTableJoins({
-                        tables: tablesWithInflationFromJoin,
-                        possibleJoins,
-                    });
-                const newTablesWithInflation = new Set([
-                    ...tablesWithInflationFromJoin,
-                    ...chainedTablesWithInflation,
-                ]);
-                if (
-                    intersection(
-                        Array.from(tablesWithMetricInflation),
-                        Array.from(newTablesWithInflation),
-                    ).length > 0
-                ) {
-                    // if there are multiple one-to-many or many-to-one joins affecting the same table, all tables in the query can have metric inflation
-                    joinedTables.forEach(
-                        tablesWithMetricInflation.add.bind(
-                            tablesWithMetricInflation,
-                        ),
-                    );
-                } else {
-                    // otherwise, add tables with inflation related to this join
-                    newTablesWithInflation.forEach(
-                        tablesWithMetricInflation.add.bind(
-                            tablesWithMetricInflation,
-                        ),
-                    );
-                }
-            }
-        });
-    }
-
-    return {
-        tablesWithMetricInflation,
-        joinWithoutRelationship,
-        tablesWithoutPrimaryKey,
-    };
-};
-
-type FindMetricInflationWarningsProps = {
-    tables: {
-        [tableName: string]: Pick<CompiledTable, 'primaryKey' | 'nestedFrom'>;
-    };
-    possibleJoins: Explore['joinedTables']; // all joins metadata
-    baseTable: Explore['baseTable']; // query table
-    joinedTables: Set<string>; // query joined tables
+type FindMetricInflationWarningsProps = FindTablesWithMetricInflationArgs & {
     metrics: Pick<CompiledMetric, 'name' | 'table' | 'type' | 'label'>[]; // metrics in query
 };
 

--- a/packages/common/src/compiler/joinInflation.ts
+++ b/packages/common/src/compiler/joinInflation.ts
@@ -1,0 +1,240 @@
+import { intersection } from 'lodash';
+import {
+    JoinRelationship,
+    type CompiledExploreJoin,
+    type CompiledTable,
+    type Explore,
+} from '../types/explore';
+import { MetricType } from '../types/field';
+import { parseAllReferences } from './exploreCompiler';
+
+export type FindTablesWithMetricInflationArgs = {
+    tables: {
+        [tableName: string]: Pick<CompiledTable, 'primaryKey' | 'nestedFrom'>;
+    };
+    /** Every join the explore defines. */
+    possibleJoins: Explore['joinedTables'];
+    baseTable: Explore['baseTable'];
+    /** Tables the query actually joins. */
+    joinedTables: Set<string>;
+};
+
+/*
+ * Returns list of intermediary/extra joined tables based on the current joined tables
+ */
+export const getJoinedTables = (
+    explore: Explore,
+    tableNames: string[],
+): string[] => {
+    if (tableNames.length === 0) {
+        return [];
+    }
+    const allNewReferences = explore.joinedTables.reduce<string[]>(
+        (sum, joinedTable) => {
+            if (tableNames.includes(joinedTable.table)) {
+                const joinTableReferences =
+                    joinedTable.tablesReferences ||
+                    parseAllReferences(
+                        // fallback for old explores, it might be incorrect when the join as an alias
+                        joinedTable.sqlOn,
+                        joinedTable.table,
+                    ).map(({ refTable }) => refTable);
+
+                const newReferencesInJoin = joinTableReferences.reduce<
+                    string[]
+                >(
+                    (acc, refTable) =>
+                        !tableNames.includes(refTable)
+                            ? [...acc, refTable]
+                            : acc,
+                    [],
+                );
+                return [...sum, ...newReferencesInJoin];
+            }
+            return sum;
+        },
+        [],
+    );
+    return [...allNewReferences, ...getJoinedTables(explore, allNewReferences)];
+};
+
+/**
+ * Determines if a metric type is "inflation-proof" (not affected by join inflation)
+ */
+export const isInflationProofMetric = (metricType: MetricType): boolean =>
+    [
+        MetricType.COUNT_DISTINCT,
+        MetricType.SUM_DISTINCT,
+        MetricType.AVERAGE_DISTINCT,
+        MetricType.MIN,
+        MetricType.MAX,
+    ].includes(metricType);
+
+const findTablesWithInflationFromJoin = (join: CompiledExploreJoin) => {
+    const tablesWithInflation = new Set<string>();
+    if (!join.tablesReferences) {
+        // Skip, as we can't detect inflation without knowing table references in join SQL
+        return tablesWithInflation;
+    }
+    if (join.relationship === JoinRelationship.ONE_TO_MANY) {
+        // The tables used to join the table can have metric inflation
+        const joinFrom = join.tablesReferences.filter(
+            (table) => table !== join.table,
+        );
+        joinFrom.forEach(tablesWithInflation.add.bind(tablesWithInflation));
+    } else if (join.relationship === JoinRelationship.MANY_TO_ONE) {
+        // The table being joined can have metric inflation
+        tablesWithInflation.add(join.table);
+    }
+
+    return tablesWithInflation;
+};
+
+const findChainedOneToOneTableJoins = ({
+    tables,
+    possibleJoins,
+}: {
+    tables: Set<string>;
+    possibleJoins: CompiledExploreJoin[];
+}) => {
+    const result = new Set<string>();
+    // Keep track of visited tables to avoid infinite recursion
+    const visited = new Set<string>();
+
+    const findReferences = (currentTables: Set<string>) => {
+        const newTables = new Set<string>();
+
+        for (const tableName of currentTables) {
+            if (!visited.has(tableName)) {
+                visited.add(tableName);
+                possibleJoins.forEach((join) => {
+                    if (
+                        join.tablesReferences &&
+                        join.tablesReferences.includes(tableName) &&
+                        (!join.relationship ||
+                            join.relationship === JoinRelationship.ONE_TO_ONE)
+                    ) {
+                        join.tablesReferences.forEach((from) => {
+                            if (!result.has(from)) {
+                                result.add(from);
+                                newTables.add(from);
+                            }
+                        });
+                    }
+                });
+            }
+        }
+
+        // Recursively process newly found tables
+        if (newTables.size > 0) {
+            findReferences(newTables);
+        }
+    };
+
+    findReferences(tables);
+    return result;
+};
+
+export const findTablesWithMetricInflation = ({
+    baseTable,
+    joinedTables,
+    possibleJoins,
+    tables,
+}: FindTablesWithMetricInflationArgs): {
+    tablesWithMetricInflation: Set<string>;
+    joinWithoutRelationship: Set<string>;
+    tablesWithoutPrimaryKey: Set<string>;
+} => {
+    const tablesWithMetricInflation = new Set<string>();
+    const joinWithoutRelationship = new Set<string>();
+    const tablesWithoutPrimaryKey = new Set<string>();
+
+    // Check if any join has a many-to-many relationship
+    const hasManyToManyJoin = Array.from(joinedTables).some((joinedTable) => {
+        if (joinedTable === baseTable) return false;
+
+        const join = possibleJoins.find(
+            (possibleJoin) => possibleJoin.table === joinedTable,
+        );
+        return join?.relationship === JoinRelationship.MANY_TO_MANY;
+    });
+
+    // If there's a many-to-many join, all tables (including base table) have inflation
+    if (hasManyToManyJoin) {
+        joinedTables.forEach(
+            tablesWithMetricInflation.add.bind(tablesWithMetricInflation),
+        );
+        // Also add the base table
+        tablesWithMetricInflation.add(baseTable);
+    } else {
+        joinedTables.forEach((joinedTable) => {
+            if (
+                !tables[joinedTable]?.primaryKey &&
+                !tables[joinedTable]?.nestedFrom
+            ) {
+                // Warn the user about missing primary key so we can detect possible metric inflation
+                tablesWithoutPrimaryKey.add(joinedTable);
+            }
+
+            if (joinedTable === baseTable) {
+                // skip base table
+                return;
+            }
+
+            const join = possibleJoins.find(
+                (possibleJoin) => possibleJoin.table === joinedTable,
+            );
+            if (!join) {
+                throw new Error(`Join ${joinedTable} not found`);
+            }
+            if (!join.tablesReferences) {
+                // Skip, as we can't detect inflation without knowing table references in join SQL
+                return;
+            }
+            if (!join.relationship) {
+                // Warn the user about missing relationship so we can detect possible metric inflation
+                joinWithoutRelationship.add(joinedTable);
+            } else {
+                // Finds tables with inflation in this join
+                const tablesWithInflationFromJoin =
+                    findTablesWithInflationFromJoin(join);
+                // Finds chained joins with one-to-one relationship
+                const chainedTablesWithInflation =
+                    findChainedOneToOneTableJoins({
+                        tables: tablesWithInflationFromJoin,
+                        possibleJoins,
+                    });
+                const newTablesWithInflation = new Set([
+                    ...tablesWithInflationFromJoin,
+                    ...chainedTablesWithInflation,
+                ]);
+                if (
+                    intersection(
+                        Array.from(tablesWithMetricInflation),
+                        Array.from(newTablesWithInflation),
+                    ).length > 0
+                ) {
+                    // if there are multiple one-to-many or many-to-one joins affecting the same table, all tables in the query can have metric inflation
+                    joinedTables.forEach(
+                        tablesWithMetricInflation.add.bind(
+                            tablesWithMetricInflation,
+                        ),
+                    );
+                } else {
+                    // otherwise, add tables with inflation related to this join
+                    newTablesWithInflation.forEach(
+                        tablesWithMetricInflation.add.bind(
+                            tablesWithMetricInflation,
+                        ),
+                    );
+                }
+            }
+        });
+    }
+
+    return {
+        tablesWithMetricInflation,
+        joinWithoutRelationship,
+        tablesWithoutPrimaryKey,
+    };
+};

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1,4 +1,9 @@
 import { parseAllReferences } from '../../compiler/exploreCompiler';
+import {
+    findTablesWithMetricInflation,
+    getJoinedTables,
+    isInflationProofMetric,
+} from '../../compiler/joinInflation';
 import { getReferencedDimension } from '../../compiler/referenceLookup';
 import type { Explore } from '../../types/explore';
 import {
@@ -875,6 +880,7 @@ const missCloseness: Record<PreAggregateMissReason, number> = {
     [PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE]: 0,
     [PreAggregateMissReason.NON_ADDITIVE_METRIC]: 1,
     [PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH]: 1,
+    [PreAggregateMissReason.DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH]: 1,
     [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]: 2,
     [PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE]: 2,
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]: 3,
@@ -886,6 +892,76 @@ const missCloseness: Record<PreAggregateMissReason, number> = {
 
 const isRawTimeInterval = (timeInterval: TimeFrames | undefined): boolean =>
     !timeInterval || timeInterval === TimeFrames.RAW;
+
+/**
+ * Tables whose metrics the materialisation computes through the primary-key
+ * deduplication CTE. The materialisation joins every table its fields
+ * reference; a metric on the "one" side of a one-to-many join among them is
+ * right at the definition's own grain but can't be summed across the "many"
+ * side's dimensions, so it must be served on an exact match only.
+ */
+const getDeduplicatedMetricTables = ({
+    explore,
+    defDimensions,
+    defMetrics,
+    dimensionsByFieldId,
+    metricsByFieldId,
+}: {
+    explore: Explore;
+    defDimensions: ReadonlySet<string>;
+    defMetrics: ReadonlySet<string>;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+    metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
+}): ReadonlySet<string> => {
+    const referencedTables = new Set<string>([explore.baseTable]);
+    const addFieldTables = (field: {
+        table: string;
+        tablesReferences?: string[];
+    }) =>
+        (field.tablesReferences?.length
+            ? field.tablesReferences
+            : [field.table]
+        ).forEach((table) => referencedTables.add(table));
+    dimensionsByFieldId.forEach((dimension) => {
+        if (
+            getDimensionReferences({
+                dimension,
+                baseTable: explore.baseTable,
+            }).some((reference) => defDimensions.has(reference))
+        ) {
+            addFieldTables(dimension);
+        }
+    });
+    Object.values(metricsByFieldId).forEach((metric) => {
+        if (
+            getMetricReferences({
+                metric,
+                baseTable: explore.baseTable,
+            }).some((reference) => defMetrics.has(reference))
+        ) {
+            addFieldTables(metric);
+        }
+    });
+    const joinedTables = new Set([
+        ...referencedTables,
+        ...getJoinedTables(explore, Array.from(referencedTables)),
+    ]);
+    try {
+        return findTablesWithMetricInflation({
+            baseTable: explore.baseTable,
+            joinedTables,
+            possibleJoins: explore.joinedTables,
+            tables: explore.tables,
+        }).tablesWithMetricInflation;
+    } catch {
+        // A join the explore can't describe: fall back to treating every
+        // metric as re-aggregable, the behaviour before this check existed.
+        return new Set();
+    }
+};
 
 // Exact match (see docs/pre-aggregates/CONTEXT.md): selected dimensions
 // set-equal to the definition's, time dimension at exactly its granularity.
@@ -1147,6 +1223,25 @@ const getMissForDef = ({
     };
 
     const defMetrics = new Set(preAggregateDef.metrics);
+    let deduplicatedMetricTables: ReadonlySet<string> | null = null;
+    const isDeduplicatedMetric = (metric: {
+        table: string;
+        type: MetricType;
+    }): boolean => {
+        if (isInflationProofMetric(metric.type)) {
+            return false;
+        }
+        if (deduplicatedMetricTables === null) {
+            deduplicatedMetricTables = getDeduplicatedMetricTables({
+                explore,
+                defDimensions,
+                defMetrics,
+                dimensionsByFieldId,
+                metricsByFieldId,
+            });
+        }
+        return deduplicatedMetricTables.has(metric.table);
+    };
     for (const metricFieldId of metricQuery.metrics) {
         const metric = metricsByFieldId[metricFieldId];
         if (!metric) {
@@ -1175,6 +1270,12 @@ const getMissForDef = ({
         switch (representation.kind) {
             case PreAggregateMetricRepresentationKind.DIRECT:
             case PreAggregateMetricRepresentationKind.DECOMPOSED:
+                if (isDeduplicatedMetric(metric) && !isExactMatch()) {
+                    return {
+                        reason: PreAggregateMissReason.DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH,
+                        fieldId: metricFieldId,
+                    };
+                }
                 break;
             case PreAggregateMetricRepresentationKind.EXACT_ONLY:
                 if (!isExactMatch()) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -69,6 +69,7 @@ export * from './authorization/types';
 export * from './compiler/compilationReport';
 export * from './compiler/exploreCompiler';
 export * from './compiler/filtersCompiler';
+export * from './compiler/joinInflation';
 export * from './compiler/lightdashModelConverter';
 export * from './compiler/parameters';
 export * from './compiler/referenceLookup';

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -68,6 +68,7 @@ export enum PreAggregateMissReason {
     METRIC_NOT_IN_PRE_AGGREGATE = 'metric_not_in_pre_aggregate',
     NON_ADDITIVE_METRIC = 'non_additive_metric',
     NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH = 'non_additive_metric_requires_exact_match',
+    DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH = 'deduplicated_metric_requires_exact_match',
     CUSTOM_SQL_METRIC = 'custom_sql_metric',
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
     SQL_FILTER_FIELD_NOT_IN_PRE_AGGREGATE = 'sql_filter_field_not_in_pre_aggregate',
@@ -100,6 +101,10 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH;
+          fieldId: FieldId;
+      }
+    | {
+          reason: PreAggregateMissReason.DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH;
           fieldId: FieldId;
       }
     | {
@@ -211,6 +216,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.NON_ADDITIVE_METRIC]: 'Non-additive metric',
     [PreAggregateMissReason.NON_ADDITIVE_METRIC_REQUIRES_EXACT_MATCH]:
         'Non-additive metric: select exactly the pre-aggregate dimensions',
+    [PreAggregateMissReason.DEDUPLICATED_METRIC_REQUIRES_EXACT_MATCH]:
+        'Metric deduplicated across a join: select exactly the pre-aggregate dimensions',
     [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
         'Filter dimension not in pre-aggregate',


### PR DESCRIPTION
A pre-aggregate grouped by dimensions from the "many" side of a one-to-many join and carrying a `count` or `sum` from the "one" side served coarser queries with inflated numbers. The materialisation deduplicates that metric by the parent's primary key, so each stored row is a distinct count for its group, and adding rows across the many-side dimension counts each parent once per child. Orders by country served from an orders × product pre-aggregate: an order with two products counted twice. The metric type still said `count`, so the matcher treated it as safe to add up.

The matcher now checks the join shape as well as the metric type. A metric deduplicated across a join is served only on an exact match of the pre-aggregate's dimensions, the same rule `count_distinct` already follows; anything coarser goes to the warehouse with a new miss reason. Metrics on the many side and `min`/`max` re-aggregate as before. The join-inflation helpers the query builder uses for its fan-out warnings moved to common so the matcher can share them.

Closes: ZAP-1022
