### PR TITLE
docs: explain internal usage analytics architecture and credentials

### DIFF
--- a/docs/usage-analytics/architecture.md
+++ b/docs/usage-analytics/architecture.md
@@ -54,8 +54,10 @@ events/compacted/org_id=<org-uuid>/stream=<stream>/dt=<YYYY-MM-DD>/part-<hash>.p
 Partitions are object-key prefixes grouping related data, not separate databases
 or access-control policies. Org partitioning keeps each output part within one
 org; stream/date partitions keep schemas and time ranges organized. The read
-layer lists one org prefix, then selects supported streams and the configured
-inclusive date range. It does not list the whole bucket and filter rows later.
+layer lists one org prefix, then selects supported streams across all retained
+dates. Date filters belong to Explore queries, not a fixed source window. It does
+not list the whole bucket and filter orgs later. Only compacted Parquet is read;
+today's uncompacted raw events are not yet available through this reader.
 
 The [compactor](../../packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts)
 processes closed date partitions (before today UTC), converts the exact listed
@@ -126,7 +128,7 @@ usage-events writer/compactor configuration too, not only the reader.
 
 [`S3AnalyticsSource`](../../packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts)
 lists `events/compacted/org_id=<validated-org>/`, validates returned keys and
-selects only supported Parquet paths in the date range. It bounds pagination
+selects only supported Parquet paths across all retained dates. It bounds pagination
 (1,000 objects/page, at most 100 pages) and selected files (10,000), and rejects
 incomplete/malformed listings or an empty manifest. It signs exact
 `GetObject` requests for 900 seconds and destroys the per-resolution SDK client.
@@ -189,19 +191,21 @@ no Terraform/IAM change or read-only cutover is included in this stack.
 ## Operations, verification and rollout
 
 - Follow [local testing](local-testing.md) for feature flags, explicit source-org
-  binding, date bounds and the browser-console provisioning request. Keep capture
+  binding and the browser-console provisioning request. Keep capture
   disabled for a read-only local test; never copy another worktree's DB settings.
 - Follow [credential verification](credentials.md) for real-bucket read-only
   smoke tests and disposable MinIO tests of signatures, expiry and denied writes.
-- Missing data: check capture, compaction success, source org, inclusive date
-  bounds and stream schemas. No supported files fails closed; partially missing
+- Missing data: check capture, compaction success, source org, Explore date
+  filters, retention and stream schemas. No supported files fails closed; partially missing
   streams and schema evolution still need rollout design.
 - Access errors: check endpoint, bucket and configured key permissions without
   printing keys, SDK request details or signed URLs. A new query can recover from
   URL expiry; it cannot fix revoked or incorrectly scoped source credentials.
 - Provisioning latency includes storage access. Large org histories can hit the
   listing/file caps; freshness, caching, pagination scale and long-running query
-  behavior require further work before production.
+  behavior require further work before production (PROD-11111). Caps fail rather
+  than silently exposing only part of the history. Historical availability is
+  limited by retained files, not their age; one-year workloads remain unbenchmarked.
 - Before rollout: remove local org overrides, finish production authorization and
   role restrictions, switch to read-only source credentials, review all query and
   cached-result surfaces, and add the admin entry point. Hidden UI and folder

--- a/docs/usage-analytics/architecture.md
+++ b/docs/usage-analytics/architecture.md
@@ -1,0 +1,223 @@
+# Internal usage analytics architecture
+
+This is an engineering reference for the dedicated analytics project: how events
+become queryable Parquet, how the backend obtains access, and which security
+boundaries are implemented. It describes the connector, credential provider and
+project-provisioning stack, not a production-ready customer rollout.
+
+The intended product is a backend-managed metadata project, separate from an
+organization's business models. Users explore fixed dimensions and metrics using
+Lightdash's normal Explore/query flow; this is not just a set of hardcoded report
+queries. It does not require dbt or a MotherDuck account.
+
+## Current implementation versus rollout intent
+
+| Area                   | Implemented                                                                                     | Still required for production                                                    |
+| ---------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Project                | Internal `PREVIEW` project with `provisioning_source=analytics`; both Query Events and AI Usage | Final metadata-project lifecycle and role design                                 |
+| Entry point            | Session-authenticated, org-admin-only create-or-get endpoint                                    | Admin navigation/button; no connector setup UI                                   |
+| Enablement             | `analytics-project` flag plus development mode and explicit local org binding                   | Reviewed production enablement; setting the flag alone cannot enable production  |
+| Source org             | Explicit local-org → source-org configuration                                                   | Derive source org from the persisted, authorized project; remove local overrides |
+| Storage authentication | Existing writer credentials retained in backend; signed GET URLs passed to DuckDB               | Dedicated read-only source credentials, tracked in PROD-11103                    |
+| Models                 | Backend-owned `query_events` and `ai_usage` explores                                            | Reevaluate other streams, metadata enrichment and additional event coverage      |
+
+Historical tickets and handover proposals may describe different designs. They
+are not evidence that production provisioning, resource-name enrichment, exports
+or final role restrictions are implemented.
+
+## End-to-end data flow
+
+```text
+Backend event projections
+  → buffered writer: gzip JSONL in events/raw/ (org / stream / date)
+  → scheduled compactor: typed Parquet in events/compacted/ (same partitions)
+
+Signed-in org admin
+  → create-or-get endpoint → fixed system explores stored in the app database
+  → Explore query → backend authorization and org-scoped file discovery
+  → exact-file signed GET URLs → isolated in-memory DuckDB → query results
+```
+
+### Write path and partitions
+
+The [event registry](../../packages/backend/src/analytics/eventStream/registry.ts)
+allowlists projected events and defines each stream's compacted schema. The
+[buffered writer](../../packages/backend/src/analytics/eventStream/BufferedEventStreamWriter.ts)
+groups records by org, stream and UTC date, and writes independent gzip JSONL
+objects. Writers do not append to a shared Parquet object.
+
+```text
+events/raw/org_id=<org-uuid>/stream=<stream>/dt=<YYYY-MM-DD>/<writer>-<uuid>.jsonl.gz
+events/compacted/org_id=<org-uuid>/stream=<stream>/dt=<YYYY-MM-DD>/part-<hash>.parquet
+```
+
+Partitions are object-key prefixes grouping related data, not separate databases
+or access-control policies. Org partitioning keeps each output part within one
+org; stream/date partitions keep schemas and time ranges organized. The read
+layer lists one org prefix, then selects supported streams and the configured
+inclusive date range. It does not list the whole bucket and filter rows later.
+
+The [compactor](../../packages/backend/src/analytics/eventStream/UsageEventsCompactor.ts)
+processes closed date partitions (before today UTC), converts the exact listed
+raw objects into typed, Zstandard-compressed Parquet, then deletes those raw
+objects only after successful conversion. Unknown streams are skipped. Part
+names are deterministic for the input-key set; late-arriving files can produce
+additional parts. There is not necessarily one file per day or one file per org.
+
+Compaction reduces the small-file overhead of independent writers and produces
+a columnar format suitable for analytics. The reader only sees compacted output,
+so capture is not immediately visible in Explore. This stack does not change the
+writer or nightly process, or establish an exactly-once delivery guarantee.
+
+### Project creation and models
+
+[`ProjectService.ensureAnalyticsProject`](../../packages/backend/src/services/ProjectService/ProjectService.ts)
+backs `POST /api/v1/org/analytics-project`:
+
+1. Check the session's organization, org-management permission, feature flag and
+   development-only gate. No org, bucket, path or credential is accepted in the request.
+2. Verify signed-Parquet access before creating a project. Model compilation is
+   in memory, but the endpoint includes this storage round trip.
+3. Acquire the per-org advisory lock and look for `provisioning_source=analytics`.
+4. Reuse that project or create an internal DuckDB analytics connection, then
+   save both compiled system explores. Repeated calls refresh models without
+   deleting saved content and can repair a previous model-save failure.
+5. Return `{ projectUuid, url, created }`. Redirect to the returned URL.
+
+The lock serializes concurrent lookup/create requests across API pods. Identity
+comes from the internal marker and org, not the display name or slug. The normal
+[`generateUniqueProjectSlug`](../../packages/backend/src/utils/SlugUtils.ts)
+allocator derives `lightdash-analytics` from `Lightdash analytics`, then tries
+`lightdash-analytics-1`, `-2`, etc. within the org. Reused projects keep their slug
+and UUID; a conflicting ordinary project is never repurposed.
+
+[`createAnalyticsExplores`](../../packages/backend/src/services/ProjectService/analyticsProject/createAnalyticsExplores.ts)
+derives dimensions from the compacted schemas and metrics from
+[`systemStreamMetrics`](../../packages/backend/src/analytics/systemExplores/systemStreamMetrics.ts).
+It explicitly includes only `query_events` and `ai_usage`; registering another
+writer stream does not expose another explore automatically. Compiled models
+refer to table names, not signed URLs. SQL and aggregations are generated from
+the user's Explore selections over these fixed models.
+
+## Credentials and trust boundaries
+
+There are three distinct forms of access; none should be confused with the others:
+
+| Layer                    | Credential or authority                                                      | Scope                                                          |
+| ------------------------ | ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| User → Lightdash         | Authenticated session plus org authorization and feature gate                | Access to that org's analytics project                         |
+| Backend → object storage | Server-owned usage-events access key/secret, currently reused from ingestion | Potentially broad bucket access, including writes; not per-org |
+| DuckDB → Parquet         | Short-lived signed GET URLs generated by the backend                         | Exact selected objects, HTTP method and expiry                 |
+
+The current tested cloud path uses GCS's S3-compatible interface and HMAC
+credentials with the AWS S3 SDK. It does not run a cloud CLI, obtain a developer
+OAuth token, provision an identity or require a MotherDuck token.
+
+### Configuration and lifetime
+
+[`parseUsageEventsS3Config`](../../packages/backend/src/config/parseConfig.ts)
+reads `USAGE_EVENTS_S3_ENDPOINT`, `USAGE_EVENTS_S3_BUCKET`,
+`USAGE_EVENTS_S3_REGION`, `USAGE_EVENTS_S3_ACCESS_KEY` and
+`USAGE_EVENTS_S3_SECRET_KEY`. Each falls back to its base `S3_*` setting; a valid
+base storage configuration is still required. These are server configuration,
+not user-editable project credentials. Use the endpoint override to read GCS
+without redirecting ordinary local MinIO storage. This override applies to the
+usage-events writer/compactor configuration too, not only the reader.
+
+[`S3AnalyticsSource`](../../packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts)
+lists `events/compacted/org_id=<validated-org>/`, validates returned keys and
+selects only supported Parquet paths in the date range. It bounds pagination
+(1,000 objects/page, at most 100 pages) and selected files (10,000), and rejects
+incomplete/malformed listings or an empty manifest. It signs exact
+`GetObject` requests for 900 seconds and destroys the per-resolution SDK client.
+The backend still retains its configured credentials; destroying the client
+does not erase that process's configuration or revoke credentials.
+
+Each new DuckDB session resolves a fresh manifest and signatures. Expired URLs
+fail; a new query/session obtains new signatures. Credential rotation must
+refresh backend configuration through the deployment's normal secret/restart
+mechanism; this is not an automatic rotation implementation.
+
+### What reaches DuckDB
+
+The signed manifest contains table names, an expected prefix and exact URLs.
+It contains no bucket access key/secret and no bearer token. A signed URL is
+itself a bearer capability: anyone possessing it may read that object while it
+is valid. Never place one in logs, API responses, tickets or persisted models.
+
+The internal Parquet path in
+[`DuckdbWarehouseClient`](../../packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts):
+
+- Creates isolated in-memory query instances (256 MB memory limit, two threads).
+- Requires HTTPS for remote storage; HTTP is restricted to loopback test endpoints.
+- Validates canonical paths against the trusted scope; disallows arbitrary
+  globbing/path substitution and mixing signed URLs with broad storage secrets.
+- Sets exact `allowed_paths` and disables general external access, disk spilling
+  and the relevant file/metadata caches.
+- Builds temporary views over `read_parquet` for those exact objects only.
+- Restricts user SQL and blocks catalog access that could disclose view SQL;
+  disables profiling and sanitizes native query errors.
+
+DuckDB cache restrictions do not mean Lightdash has no persisted query results.
+The normal result/history paths still exist and need authorization. Analytics
+checks cover project access and result/history retrieval; exports and scheduled
+downloads are blocked in this preview. Flag-off denial is not deletion or
+cryptographic revocation of previously issued capabilities or returned data.
+
+### Org isolation: implemented boundary and remaining risk
+
+[`localAnalyticsProject`](../../packages/backend/src/services/ProjectService/analyticsProject/localAnalyticsProject.ts)
+requires the logged-in project's org to match `LIGHTDASH_LOCAL_ANALYTICS_ORG_UUID`.
+It reads files for `LIGHTDASH_LOCAL_ANALYTICS_SOURCE_ORG_UUID`. This deliberate
+development mapping lets a local org explore an explicitly selected source org;
+it is not production tenant binding. Production execution is rejected even with
+the feature flag enabled. Disabling the flag takes precedence over enabling it.
+
+The prefix filter is a backend authorization boundary, not bucket IAM. Storage
+signatures enforce the exact object/method capability passed to DuckDB, but the
+trusted signer can still access or sign other objects using its broader keys.
+A compromised signer/backend is outside the protection provided by those URLs.
+Tests for path tampering do not prove arbitrary SQL or backend compromise is safe.
+
+Read-only credentials reduce the signer's write/delete privilege exposure. They
+do not, on their own, prevent reads across org prefixes. The deferred identity
+design is a separate deployment-level reader identity plus reviewed app-side org
+binding, not a service account per app org. Creating another key on the writer's
+identity does not narrow permissions. See PROD-11103 for infrastructure guidance;
+no Terraform/IAM change or read-only cutover is included in this stack.
+
+## Operations, verification and rollout
+
+- Follow [local testing](local-testing.md) for feature flags, explicit source-org
+  binding, date bounds and the browser-console provisioning request. Keep capture
+  disabled for a read-only local test; never copy another worktree's DB settings.
+- Follow [credential verification](credentials.md) for real-bucket read-only
+  smoke tests and disposable MinIO tests of signatures, expiry and denied writes.
+- Missing data: check capture, compaction success, source org, inclusive date
+  bounds and stream schemas. No supported files fails closed; partially missing
+  streams and schema evolution still need rollout design.
+- Access errors: check endpoint, bucket and configured key permissions without
+  printing keys, SDK request details or signed URLs. A new query can recover from
+  URL expiry; it cannot fix revoked or incorrectly scoped source credentials.
+- Provisioning latency includes storage access. Large org histories can hit the
+  listing/file caps; freshness, caching, pagination scale and long-running query
+  behavior require further work before production.
+- Before rollout: remove local org overrides, finish production authorization and
+  role restrictions, switch to read-only source credentials, review all query and
+  cached-result surfaces, and add the admin entry point. Hidden UI and folder
+  separation are not substitutes for access control.
+
+The read path has been exercised against real GCS with native DuckDB and via the
+local API for both explores; local UI provisioning was manually confirmed.
+Focused tests cover reuse, access denial and credential boundaries. This is not
+a production multi-tenant security audit or a claim that every warehouse provider
+and failure mode has been validated.
+
+## Related work
+
+- [PROD-11059](https://linear.app/lightdash/issue/PROD-11059): implementation/triage.
+- [PROD-8603](https://linear.app/lightdash/issue/PROD-8603): pipeline architecture.
+- [PROD-11103](https://linear.app/lightdash/issue/PROD-11103): deferred read-only credentials.
+- Stack: [connector + flag](https://github.com/lightdash/lightdash/pull/28909) →
+  [credentials](https://github.com/lightdash/lightdash/pull/28916) →
+  [project endpoint](https://github.com/lightdash/lightdash/pull/28849) → documentation.

--- a/docs/usage-analytics/credentials.md
+++ b/docs/usage-analytics/credentials.md
@@ -1,10 +1,14 @@
 # Analytics storage credentials
 
-The stack is connector + `analytics-project` flag → bucket access (this change)
-→ project provisioning with both system explores. Dedicated read-only credentials
-are deferred to PROD-11103. This change does not enable a public connector or add
-any HTTP endpoint. Provisioning must authorize the persisted project's org and
-check the shared flag before constructing the resolver.
+See [architecture](architecture.md) for the full pipeline and
+[local testing](local-testing.md) for project provisioning.
+
+The stack is connector + `analytics-project` flag → bucket access → project
+provisioning with both system explores → internal documentation. Dedicated
+read-only credentials are deferred to PROD-11103. The credential provider itself
+does not expose an HTTP endpoint or public connector. Its caller must authorize
+the project's org and check the shared flag before constructing the resolver;
+the current development-only source-org mapping is described in the architecture.
 
 ## Reuse existing writer configuration
 

--- a/docs/usage-analytics/local-testing.md
+++ b/docs/usage-analytics/local-testing.md
@@ -1,5 +1,7 @@
 # Local usage analytics triage (PROD-11059)
 
+For the architecture and trust boundaries, see [architecture](architecture.md).
+
 Development-only prototype, not the production metadata-project rollout. It
 creates a `PREVIEW` project with a backend-owned `analytics` provisioning marker
 and an invisible DuckDB `analytics` connection.
@@ -105,7 +107,9 @@ The implementation rejects production execution even with its flag enabled.
 2. Signed-URL bucket access using the existing writer's backend credentials.
 3. Admin create-or-get endpoint, preview provisioning, signed-URL provider, and both
    system models (Query Events and AI Usage). Replaces the provisioning script.
-4. Dedicated read-only credential source, deferred to PROD-11103.
+4. Internal architecture and operational documentation (no runtime changes).
 
-See [storage credential verification](analytics-storage-credentials.md) for the
+Dedicated read-only credentials remain a separate deferred follow-up (PROD-11103).
+
+See [storage credential verification](credentials.md) for the
 opt-in read-only cloud and isolated local security tests.


### PR DESCRIPTION
## Summary

- Updated all-history documentation: all retained supported Parquet partitions are available; date filters belong in Explore. Uncompacted raw events are not available until compaction. Performance work remains tracked in PROD-11111.

Documentation-only fourth PR in the internal usage analytics stack, based on #28849.

- Add an internal architecture reference covering event projection, per-org raw/compacted partitions, compaction, fixed system explores, project provisioning and DuckDB reads.
- Explain credential ownership, backend-only writer key reuse, exact-object signed GET URLs, expiry, SQL/engine restrictions and remaining trusted-backend risk.
- Distinguish local source-org overrides from production tenant binding, and read-only credentials from tenant isolation.
- Document create-or-get idempotency, standard slug collision handling, configuration fallbacks, troubleshooting and production rollout gaps.
- Group the existing local setup and credential verification guides under `docs/usage-analytics/`, with updated cross-links and stack order.

## Validation and scope

- Cross-checked the description against writer, compactor, source resolver, configuration parser, project provisioning, system model compiler and DuckDB implementation.
- Relative Markdown links resolve; repository formatter (oxfmt) and `git diff --check` pass.
- Documentation only: no runtime, migration, credential, infrastructure or feature-flag changes. No customer identifiers, credentials or signed URLs included.
- Existing local generated API files are excluded.
- Read-only identity provisioning remains a separate deferred follow-up; PR4 here is documentation, not an IAM rollout.

Relates: [PROD-11059](https://linear.app/lightdash/issue/PROD-11059)
Relates: [PROD-8603](https://linear.app/lightdash/issue/PROD-8603)
Relates: [PROD-11103](https://linear.app/lightdash/issue/PROD-11103)
Relates: #23450
Closes: [PROD-11109](https://linear.app/lightdash/issue/PROD-11109/document-internal-usage-analytics-architecture-and-credential-handling)

Relates: [PROD-11111](https://linear.app/lightdash/issue/PROD-11111)
