### PR TITLE
feat: add Bitbucket Cloud writeback API foundation

### DIFF
--- a/packages/backend/src/clients/bitbucket/Bitbucket.test.ts
+++ b/packages/backend/src/clients/bitbucket/Bitbucket.test.ts
@@ -1,0 +1,432 @@
+import {
+    ConflictError,
+    DbtProjectType,
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    PullRequestState,
+    UnexpectedGitError,
+    type DbtBitBucketProjectConfig,
+} from '@lightdash/common';
+import fetchMock from '../../testing/fetchMock';
+import {
+    commitFiles,
+    createBranch,
+    createPullRequest,
+    declinePullRequest,
+    deleteBranch,
+    getBranch,
+    getFileContent,
+    getPullRequest,
+    getRepository,
+    resolveBitbucketCredentials,
+    updatePullRequest,
+} from './Bitbucket';
+
+const credentials = {
+    owner: 'workspace',
+    repo: 'analytics',
+    token: 'test-token',
+};
+const repositoryUrl =
+    'https://api.bitbucket.org/2.0/repositories/workspace/analytics';
+const connection: DbtBitBucketProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'developer',
+    personal_access_token: credentials.token,
+    repository: 'workspace/analytics',
+    branch: 'main',
+    project_sub_path: '/',
+};
+const branch = { name: 'feature/dbt', target: { hash: 'parent-sha' } };
+const commit = {
+    ...credentials,
+    branch: branch.name,
+    expectedParent: branch.target.hash,
+    message: 'Update semantic layer',
+    changes: [
+        {
+            action: 'upsert' as const,
+            path: 'models/orders.sql',
+            content: 'select 1',
+        },
+    ],
+};
+const pullRequest = {
+    id: 12,
+    title: 'Update semantic layer',
+    state: 'OPEN',
+    source: { branch: { name: branch.name } },
+    destination: { branch: { name: 'main' } },
+};
+
+beforeEach(() => fetchMock.resetMocks());
+
+describe('Bitbucket project credentials', () => {
+    it.each([undefined, '', 'bitbucket.org', ' BITBUCKET.ORG. '])(
+        'accepts the Cloud host %s and normalizes repository suffixes',
+        (host_domain) => {
+            expect(
+                resolveBitbucketCredentials({
+                    ...connection,
+                    host_domain,
+                    repository: ' workspace/analytics.git ',
+                }),
+            ).toEqual(credentials);
+        },
+    );
+
+    it.each([
+        'bitbucket.example.com',
+        'https://bitbucket.org',
+        'bitbucket.org.evil.test',
+    ])('rejects unsupported writeback host %s', (host_domain) => {
+        expect(() =>
+            resolveBitbucketCredentials({ ...connection, host_domain }),
+        ).toThrow(ParameterError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        'analytics',
+        'workspace/group/analytics',
+        '../analytics',
+        'workspace/..',
+        'workspace/analytics?x=1',
+    ])('rejects ambiguous repository %s', (repository) =>
+        expect(() =>
+            resolveBitbucketCredentials({ ...connection, repository }),
+        ).toThrow(ParameterError),
+    );
+
+    it('requires a project token', () => {
+        expect(() =>
+            resolveBitbucketCredentials({
+                ...connection,
+                personal_access_token: ' ',
+            }),
+        ).toThrow(ParameterError);
+    });
+});
+
+describe('Bitbucket API boundary', () => {
+    it.each([
+        [401, ForbiddenError],
+        [403, ForbiddenError],
+        [404, NotFoundError],
+        [409, ConflictError],
+        [400, ParameterError],
+        [500, UnexpectedGitError],
+    ])(
+        'maps HTTP %s without exposing response details or credentials',
+        async (status, ErrorClass) => {
+            fetchMock.mockResponse(
+                JSON.stringify({
+                    error: {
+                        message: `private-upstream-details ${credentials.token}`,
+                    },
+                }),
+                { status },
+            );
+            const result = getRepository(credentials);
+            await expect(result).rejects.toBeInstanceOf(ErrorClass);
+            await expect(result).rejects.not.toThrow(
+                'private-upstream-details',
+            );
+            await expect(result).rejects.not.toThrow(credentials.token);
+        },
+    );
+
+    it('preserves rate limiting as a retryable HTTP 429', async () => {
+        fetchMock.mockResponse('private-upstream-details', { status: 429 });
+        await expect(getRepository(credentials)).rejects.toMatchObject({
+            statusCode: 429,
+        });
+    });
+
+    it('sanitizes transport failures', async () => {
+        fetchMock.mockRejectedValue(
+            new Error(`redirect to https://private.test/${credentials.token}`),
+        );
+        await expect(getRepository(credentials)).rejects.toThrow(
+            'Could not reach the Bitbucket Cloud API',
+        );
+    });
+
+    it.each(['not JSON', JSON.stringify({ private: credentials.token })])(
+        'sanitizes malformed successful responses',
+        async (body) => {
+            fetchMock.mockResponse(body);
+            await expect(getRepository(credentials)).rejects.toThrow(
+                'Bitbucket returned an invalid API response',
+            );
+        },
+    );
+
+    it('uses Bearer authentication and refuses redirects', async () => {
+        fetchMock.mockResponse(
+            JSON.stringify({
+                full_name: 'workspace/analytics',
+                mainbranch: null,
+            }),
+        );
+        await expect(getRepository(credentials)).resolves.toMatchObject({
+            mainbranch: null,
+        });
+        expect(fetchMock).toHaveBeenCalledWith(
+            repositoryUrl,
+            expect.objectContaining({
+                headers: { Authorization: 'Bearer test-token' },
+                redirect: 'error',
+                signal: expect.any(AbortSignal),
+            }),
+        );
+    });
+});
+
+describe('Bitbucket branches and files', () => {
+    it('encodes a slash in a branch name as one API path segment', async () => {
+        fetchMock.mockResponse(JSON.stringify(branch));
+        await getBranch({ ...credentials, branch: 'feature/dbt #1' });
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${repositoryUrl}/refs/branches/feature%2Fdbt%20%231`,
+            expect.any(Object),
+        );
+    });
+
+    it('creates a branch from a specific commit and deletes it without parsing a response', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(branch), { status: 201 });
+        await expect(
+            createBranch({
+                ...credentials,
+                branch: branch.name,
+                sha: 'parent-sha',
+            }),
+        ).resolves.toEqual(branch);
+        expect(fetchMock).toHaveBeenLastCalledWith(
+            `${repositoryUrl}/refs/branches`,
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    name: branch.name,
+                    target: { hash: 'parent-sha' },
+                }),
+            }),
+        );
+        fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+        await expect(
+            deleteBranch({ ...credentials, branch: branch.name }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('pins a file read to the resolved commit and encodes path components', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(branch));
+        fetchMock.mockResponseOnce('version: 2\n');
+        await expect(
+            getFileContent({
+                ...credentials,
+                branch: branch.name,
+                fileName: '/models/sales #1.yml',
+            }),
+        ).resolves.toEqual({
+            content: 'version: 2\n',
+            sha: 'parent-sha',
+        });
+        expect(fetchMock).toHaveBeenLastCalledWith(
+            `${repositoryUrl}/src/parent-sha/models/sales%20%231.yml`,
+            expect.any(Object),
+        );
+    });
+
+    it('commits SQL, YAML, reserved filenames and deletions atomically with an empty 201 response', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(branch));
+        fetchMock.mockResponseOnce('', { status: 201 });
+        await expect(
+            commitFiles({
+                ...commit,
+                changes: [
+                    ...commit.changes,
+                    {
+                        action: 'upsert',
+                        path: 'models/orders.yml',
+                        content: 'version: 2\n',
+                    },
+                    {
+                        action: 'upsert',
+                        path: 'message',
+                        content: 'A file named message',
+                    },
+                    { action: 'delete', path: 'models/old.sql' },
+                    { action: 'delete', path: 'models/old.yml' },
+                ],
+            }),
+        ).resolves.toBeUndefined();
+        const options: RequestInit = fetchMock.mock.calls[1][1];
+        expect(options.method).toBe('POST');
+        expect(options.body).toBeInstanceOf(URLSearchParams);
+        const body = new URLSearchParams(String(options.body));
+        expect(body.get('parents')).toBe('parent-sha');
+        expect(body.get('branch')).toBe(branch.name);
+        expect(body.get('message')).toBe(commit.message);
+        expect(body.get('/message')).toBe('A file named message');
+        expect(body.get('/models/orders.sql')).toBe('select 1');
+        expect(body.get('/models/orders.yml')).toBe('version: 2\n');
+        expect(body.getAll('files')).toEqual([
+            '/models/old.sql',
+            '/models/old.yml',
+        ]);
+    });
+
+    it('does not publish when the branch already advanced', async () => {
+        fetchMock.mockResponseOnce(
+            JSON.stringify({ ...branch, target: { hash: 'new-head' } }),
+        );
+        await expect(commitFiles(commit)).rejects.toBeInstanceOf(ConflictError);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a concurrent update rejected by Bitbucket after the branch check', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(branch));
+        fetchMock.mockResponseOnce(
+            JSON.stringify({
+                error: {
+                    message:
+                        'The parent commit specified (parent-sha) is not the head of branch feature/dbt.',
+                },
+            }),
+            { status: 400 },
+        );
+        await expect(commitFiles(commit)).rejects.toBeInstanceOf(ConflictError);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+        '../secret',
+        'models/../secret',
+        'models\\orders.sql',
+        'models//orders.sql',
+    ])(
+        'rejects unsafe commit path %s before making a request',
+        async (path) => {
+            await expect(
+                commitFiles({
+                    ...commit,
+                    changes: [{ action: 'delete', path }],
+                }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        },
+    );
+
+    it('rejects duplicate normalized paths before making a request', async () => {
+        await expect(
+            commitFiles({
+                ...commit,
+                changes: [
+                    {
+                        action: 'upsert',
+                        path: '/models/orders.sql',
+                        content: 'select 1',
+                    },
+                    { action: 'delete', path: 'models/orders.sql' },
+                ],
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('Bitbucket pull requests', () => {
+    it.each([
+        ['OPEN', PullRequestState.OPEN],
+        ['MERGED', PullRequestState.MERGED],
+        ['DECLINED', PullRequestState.CLOSED],
+        ['SUPERSEDED', PullRequestState.CLOSED],
+    ])('normalizes the %s state', async (state, normalized) => {
+        fetchMock.mockResponse(
+            JSON.stringify({
+                ...pullRequest,
+                state,
+                links: { html: { href: 'https://untrusted.test' } },
+            }),
+        );
+        await expect(
+            getPullRequest({ ...credentials, pullNumber: 12 }),
+        ).resolves.toEqual({
+            number: 12,
+            title: pullRequest.title,
+            state: normalized,
+            html_url:
+                'https://bitbucket.org/workspace/analytics/pull-requests/12',
+            head: branch.name,
+            base: 'main',
+        });
+    });
+
+    it('creates, updates and declines a pull request', async () => {
+        fetchMock.mockResponseOnce(JSON.stringify(pullRequest), {
+            status: 201,
+        });
+        await createPullRequest({
+            ...credentials,
+            title: pullRequest.title,
+            body: 'Description',
+            head: branch.name,
+            base: 'main',
+        });
+        expect(fetchMock).toHaveBeenLastCalledWith(
+            `${repositoryUrl}/pullrequests`,
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    title: pullRequest.title,
+                    description: 'Description',
+                    source: pullRequest.source,
+                    destination: pullRequest.destination,
+                    close_source_branch: true,
+                }),
+            }),
+        );
+        fetchMock.mockResponseOnce(
+            JSON.stringify({ ...pullRequest, title: 'Updated' }),
+        );
+        await expect(
+            updatePullRequest({
+                ...credentials,
+                pullNumber: 12,
+                title: 'Updated',
+                body: 'New description',
+            }),
+        ).resolves.toMatchObject({ title: 'Updated' });
+        expect(fetchMock).toHaveBeenLastCalledWith(
+            `${repositoryUrl}/pullrequests/12`,
+            expect.objectContaining({
+                method: 'PUT',
+                body: JSON.stringify({
+                    title: 'Updated',
+                    description: 'New description',
+                }),
+            }),
+        );
+        fetchMock.mockResponseOnce(
+            JSON.stringify({ ...pullRequest, state: 'DECLINED' }),
+        );
+        await expect(
+            declinePullRequest({ ...credentials, pullNumber: 12 }),
+        ).resolves.toMatchObject({ state: PullRequestState.CLOSED });
+        expect(fetchMock).toHaveBeenLastCalledWith(
+            `${repositoryUrl}/pullrequests/12/decline`,
+            expect.objectContaining({ method: 'POST' }),
+        );
+    });
+
+    it.each([0, -1, 1.5, Number.NaN])(
+        'rejects invalid pull request number %s',
+        async (pullNumber) => {
+            await expect(
+                getPullRequest({ ...credentials, pullNumber }),
+            ).rejects.toBeInstanceOf(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        },
+    );
+});

--- a/packages/backend/src/clients/bitbucket/Bitbucket.ts
+++ b/packages/backend/src/clients/bitbucket/Bitbucket.ts
@@ -1,0 +1,372 @@
+import {
+    ConflictError,
+    DbtProjectType,
+    ForbiddenError,
+    LightdashError,
+    NotFoundError,
+    ParameterError,
+    PullRequestState,
+    UnexpectedGitError,
+    type DbtProjectConfig,
+} from '@lightdash/common';
+import { z } from 'zod';
+
+export type BitbucketCredentials = {
+    owner: string;
+    repo: string;
+    token: string;
+};
+
+type BranchParams = BitbucketCredentials & { branch: string };
+type PullRequestParams = BitbucketCredentials & { pullNumber: number };
+
+const branchSchema = z.object({
+    name: z.string(),
+    target: z.object({ hash: z.string() }),
+});
+const repositorySchema = z.object({
+    full_name: z.string(),
+    mainbranch: z.object({ name: z.string() }).nullable().optional(),
+});
+const pullRequestSchema = z.object({
+    id: z.number().int().positive(),
+    title: z.string(),
+    state: z.enum(['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED']),
+    source: z.object({ branch: z.object({ name: z.string() }) }),
+    destination: z.object({ branch: z.object({ name: z.string() }) }),
+});
+
+export type BitbucketPullRequest = {
+    number: number;
+    title: string;
+    html_url: string;
+    state: PullRequestState;
+    head: string;
+    base: string;
+};
+
+const encodeSegment = (value: string): string => {
+    if (
+        !value ||
+        value === '.' ||
+        value === '..' ||
+        /[\x00-\x1f]/.test(value)
+    ) {
+        throw new ParameterError('Invalid Bitbucket path');
+    }
+    return encodeURIComponent(value);
+};
+
+export const resolveBitbucketCredentials = (
+    connection: DbtProjectConfig,
+): BitbucketCredentials => {
+    if (connection.type !== DbtProjectType.BITBUCKET) {
+        throw new ParameterError('The project is not connected to Bitbucket');
+    }
+    const host = connection.host_domain
+        ?.trim()
+        .toLowerCase()
+        .replace(/\.$/, '');
+    if (host && host !== 'bitbucket.org') {
+        throw new ParameterError(
+            'Writeback supports Bitbucket Cloud (bitbucket.org) only',
+        );
+    }
+    const repository = connection.repository.trim().replace(/\.git$/, '');
+    if (!/^[\w.-]+\/[\w.-]+$/.test(repository)) {
+        throw new ParameterError(
+            'Bitbucket repository must be workspace/repository',
+        );
+    }
+    const [owner, repo] = repository.split('/');
+    encodeSegment(owner);
+    encodeSegment(repo);
+    const token = connection.personal_access_token?.trim();
+    if (!token) {
+        throw new ParameterError(
+            'Configure an API token for this Bitbucket project',
+        );
+    }
+    return { owner, repo, token };
+};
+
+const repositoryUrl = ({ owner, repo }: BitbucketCredentials): string =>
+    `https://api.bitbucket.org/2.0/repositories/${encodeSegment(owner)}/${encodeSegment(repo)}`;
+
+const request = async (
+    credentials: BitbucketCredentials,
+    path: string,
+    options: RequestInit = {},
+): Promise<Response> => {
+    let response: Response;
+    try {
+        response = await fetch(`${repositoryUrl(credentials)}${path}`, {
+            ...options,
+            redirect: 'error',
+            signal: options.signal ?? AbortSignal.timeout(30_000),
+            headers: {
+                ...options.headers,
+                Authorization: `Bearer ${credentials.token}`,
+            },
+        });
+    } catch {
+        // Fetch errors can include request credentials or redirect destinations.
+        throw new UnexpectedGitError('Could not reach the Bitbucket Cloud API');
+    }
+    if (response.ok) {
+        return response;
+    }
+    switch (response.status) {
+        case 401:
+            throw new ForbiddenError(
+                'Bitbucket API token is invalid or expired. Update the project token.',
+            );
+        case 403:
+            throw new ForbiddenError(
+                'Bitbucket denied access. Check repository access, token scopes and workspace write restrictions. Writeback requires repository and pull request read/write permissions.',
+            );
+        case 404:
+            throw new NotFoundError(
+                'Bitbucket resource was not found or is not accessible to the project token',
+            );
+        case 409:
+            throw new ConflictError(
+                'The Bitbucket branch changed. Reload it before retrying.',
+            );
+        case 429:
+            throw new LightdashError({
+                name: 'BitbucketRateLimitError',
+                message: 'Bitbucket API rate limit reached. Retry later.',
+                statusCode: 429,
+                data: {},
+            });
+        case 400: {
+            const error = await response.json().catch(() => null);
+            const parsed = z
+                .object({ error: z.object({ message: z.string() }) })
+                .safeParse(error);
+            if (
+                parsed.success &&
+                /^The parent commit specified .+ is not the head of branch /.test(
+                    parsed.data.error.message,
+                )
+            ) {
+                throw new ConflictError(
+                    'The Bitbucket branch changed. Reload it before retrying.',
+                );
+            }
+            throw new ParameterError(
+                'Bitbucket rejected the request. Check file paths, branch names and the expected parent commit.',
+            );
+        }
+        default:
+            throw new UnexpectedGitError(
+                `Bitbucket API request failed (HTTP ${response.status})`,
+            );
+    }
+};
+
+const readJson = async <T>(
+    response: Response,
+    schema: z.ZodType<T>,
+): Promise<T> => {
+    try {
+        return schema.parse(await response.json());
+    } catch {
+        throw new UnexpectedGitError(
+            'Bitbucket returned an invalid API response',
+        );
+    }
+};
+
+const jsonOptions = (method: string, data: unknown): RequestInit => ({
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+});
+
+export const getRepository = async (credentials: BitbucketCredentials) =>
+    readJson(await request(credentials, ''), repositorySchema);
+
+export const getBranch = async (args: BranchParams) =>
+    readJson(
+        await request(args, `/refs/branches/${encodeSegment(args.branch)}`),
+        branchSchema,
+    );
+
+export const createBranch = async (args: BranchParams & { sha: string }) =>
+    readJson(
+        await request(
+            args,
+            '/refs/branches',
+            jsonOptions('POST', {
+                name: args.branch,
+                target: { hash: args.sha },
+            }),
+        ),
+        branchSchema,
+    );
+
+export const deleteBranch = async (args: BranchParams): Promise<void> => {
+    await request(args, `/refs/branches/${encodeSegment(args.branch)}`, {
+        method: 'DELETE',
+    });
+};
+
+const filePath = (path: string): string => {
+    const normalized = path.replace(/^\//, '');
+    if (normalized.includes('\\')) {
+        throw new ParameterError(
+            'Bitbucket file paths must use forward slashes',
+        );
+    }
+    normalized.split('/').forEach(encodeSegment);
+    return normalized;
+};
+
+export const getFileContent = async (
+    args: BranchParams & { fileName: string },
+): Promise<{ content: string; sha: string }> => {
+    const branch = await getBranch(args);
+    const path = filePath(args.fileName)
+        .split('/')
+        .map(encodeSegment)
+        .join('/');
+    const response = await request(
+        args,
+        `/src/${encodeSegment(branch.target.hash)}/${path}`,
+    );
+    return { content: await response.text(), sha: branch.target.hash };
+};
+
+export type BitbucketFileChange =
+    | { path: string; content: string; action: 'upsert' }
+    | { path: string; action: 'delete' };
+
+export const commitFiles = async (
+    args: BranchParams & {
+        expectedParent: string;
+        message: string;
+        changes: BitbucketFileChange[];
+    },
+): Promise<void> => {
+    if (args.changes.length === 0) {
+        throw new ParameterError(
+            'A Bitbucket commit requires at least one file change',
+        );
+    }
+    const paths = args.changes.map((change) => filePath(change.path));
+    if (new Set(paths).size !== paths.length) {
+        throw new ParameterError(
+            'A Bitbucket commit cannot change the same path twice',
+        );
+    }
+    const current = await getBranch(args);
+    if (current.target.hash !== args.expectedParent) {
+        throw new ConflictError(
+            'The Bitbucket branch changed. Reload it before retrying.',
+        );
+    }
+    const body = new URLSearchParams({
+        branch: args.branch,
+        parents: args.expectedParent,
+        message: args.message,
+    });
+    args.changes.forEach((change, index) => {
+        const path = `/${paths[index]}`;
+        if (change.action === 'delete') {
+            body.append('files', path);
+        } else {
+            body.append(path, change.content);
+        }
+    });
+    // Bitbucket enforces the parent when publishing and returns an empty 201.
+    await request(args, '/src', { method: 'POST', body });
+};
+
+const readPullRequest = async (
+    args: BitbucketCredentials,
+    response: Response,
+): Promise<BitbucketPullRequest> => {
+    const result = await readJson(response, pullRequestSchema);
+    const states: Record<
+        z.infer<typeof pullRequestSchema>['state'],
+        PullRequestState
+    > = {
+        OPEN: PullRequestState.OPEN,
+        MERGED: PullRequestState.MERGED,
+        DECLINED: PullRequestState.CLOSED,
+        SUPERSEDED: PullRequestState.CLOSED,
+    };
+    return {
+        number: result.id,
+        title: result.title,
+        html_url: `https://bitbucket.org/${encodeSegment(args.owner)}/${encodeSegment(args.repo)}/pull-requests/${result.id}`,
+        state: states[result.state],
+        head: result.source.branch.name,
+        base: result.destination.branch.name,
+    };
+};
+
+const pullRequestPath = (number: number): string => {
+    if (!Number.isSafeInteger(number) || number < 1) {
+        throw new ParameterError('Invalid Bitbucket pull request number');
+    }
+    return `/pullrequests/${number}`;
+};
+
+export const getPullRequest = async (
+    args: PullRequestParams,
+): Promise<BitbucketPullRequest> =>
+    readPullRequest(
+        args,
+        await request(args, pullRequestPath(args.pullNumber)),
+    );
+
+export const createPullRequest = async (
+    args: BitbucketCredentials & {
+        title: string;
+        body: string;
+        head: string;
+        base: string;
+    },
+): Promise<BitbucketPullRequest> =>
+    readPullRequest(
+        args,
+        await request(
+            args,
+            '/pullrequests',
+            jsonOptions('POST', {
+                title: args.title,
+                description: args.body,
+                source: { branch: { name: args.head } },
+                destination: { branch: { name: args.base } },
+                close_source_branch: true,
+            }),
+        ),
+    );
+
+export const updatePullRequest = async (
+    args: PullRequestParams & { title: string; body: string },
+): Promise<BitbucketPullRequest> =>
+    readPullRequest(
+        args,
+        await request(
+            args,
+            pullRequestPath(args.pullNumber),
+            jsonOptions('PUT', {
+                title: args.title,
+                description: args.body,
+            }),
+        ),
+    );
+
+export const declinePullRequest = async (
+    args: PullRequestParams,
+): Promise<BitbucketPullRequest> =>
+    readPullRequest(
+        args,
+        await request(args, `${pullRequestPath(args.pullNumber)}/decline`, {
+            method: 'POST',
+        }),
+    );

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.test.ts
@@ -1,9 +1,13 @@
+import { Ability } from '@casl/ability';
 import {
     BinType,
     CustomDimensionType,
     DbtProjectType,
+    ForbiddenError,
     GroupValueMatchType,
     NotFoundError,
+    ParameterError,
+    PossibleAbilities,
     SupportedDbtVersions,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -440,5 +444,87 @@ models:
             expect(updateFile).not.toHaveBeenCalled();
             expect(createPullRequest).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('Bitbucket project credentials', () => {
+    const authorizedUser = {
+        ...user,
+        organizationUuid: 'organization',
+        ability: new Ability<PossibleAbilities>([
+            {
+                action: 'view',
+                subject: 'SourceCode',
+                conditions: {
+                    organizationUuid: 'organization',
+                    projectUuid: 'project',
+                },
+            },
+        ]),
+    };
+    const createService = () => {
+        const project = {
+            name: 'Jaffle',
+            dbtConnection: {
+                type: DbtProjectType.BITBUCKET,
+                repository: 'workspace/jaffle',
+                username: 'bitbucket-user',
+                personal_access_token: 'project-token',
+                branch: 'main',
+                project_sub_path: '/',
+            },
+        };
+        const projectModel = {
+            getSummary: vi
+                .fn()
+                .mockResolvedValue({ organizationUuid: 'organization' }),
+            get: vi.fn().mockResolvedValue(project),
+            getWithSensitiveFields: vi.fn().mockResolvedValue(project),
+        };
+        const service = new GitIntegrationService({
+            lightdashConfig: lightdashConfigMock,
+            analytics: analyticsMock,
+            savedChartModel: SAVED_CHART_MODEL as unknown as SavedChartModel,
+            projectModel: projectModel as unknown as ProjectModel,
+            projectDbtSourcesModel:
+                PROJECT_DBT_SOURCES_MODEL as unknown as ProjectDbtSourcesModel,
+            spaceModel: SPACE_MODEL as unknown as SpaceModel,
+            githubAppInstallationsModel:
+                GITHUB_APP_MODEL as unknown as GithubAppInstallationsModel,
+            githubAppService: {} as GithubAppService,
+            pullRequestsModel: {} as PullRequestsModel,
+        });
+        return { service, projectModel };
+    };
+
+    it('resolves the current repository and project token for an authorized user', async () => {
+        const { service } = createService();
+        await expect(
+            service.getBitbucketCredentials(authorizedUser, 'project'),
+        ).resolves.toEqual({
+            owner: 'workspace',
+            repo: 'jaffle',
+            token: 'project-token',
+            type: DbtProjectType.BITBUCKET,
+        });
+    });
+
+    it('rejects access to another organization before loading the token', async () => {
+        const { service, projectModel } = createService();
+        projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'another-organization',
+        });
+        await expect(
+            service.getBitbucketCredentials(authorizedUser, 'project'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+    });
+
+    it('does not enable the generic Git writeback paths for Bitbucket', async () => {
+        const { service, projectModel } = createService();
+        await expect(
+            service.getGitCredentials(authorizedUser, 'project'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -45,6 +45,7 @@ import {
     WriteBackEvent,
 } from '../../analytics/LightdashAnalytics';
 import { toSessionUser } from '../../auth/account';
+import * as BitbucketClient from '../../clients/bitbucket/Bitbucket';
 import * as GithubClient from '../../clients/github/Github';
 import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -1377,6 +1378,37 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         return {
             prTitle: pullRequest.title,
             prUrl: pullRequest.html_url,
+        };
+    }
+
+    async getBitbucketCredentials(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<
+        BitbucketClient.BitbucketCredentials & {
+            type: DbtProjectType.BITBUCKET;
+        }
+    > {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('SourceCode', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const project =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+        return {
+            ...BitbucketClient.resolveBitbucketCredentials(
+                project.dbtConnection,
+            ),
+            type: DbtProjectType.BITBUCKET,
         };
     }
 

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.test.ts
@@ -1,0 +1,219 @@
+import { Ability } from '@casl/ability';
+import {
+    DbtProjectType,
+    ForbiddenError,
+    PossibleAbilities,
+    PullRequest,
+    PullRequestProvider,
+    PullRequestSource,
+    PullRequestState,
+} from '@lightdash/common';
+import * as BitbucketClient from '../../clients/bitbucket/Bitbucket';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { PullRequestsModel } from '../../models/PullRequestsModel';
+import { GitIntegrationService } from '../GitIntegrationService/GitIntegrationService';
+import { user } from '../ProjectService/ProjectService.mock';
+import { PullRequestsService } from './PullRequestsService';
+
+const authorizedUser = {
+    ...user,
+    organizationUuid: 'organization',
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'view',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+            },
+        },
+    ]),
+};
+const storedPullRequest: PullRequest = {
+    pullRequestUuid: 'pull-request',
+    organizationUuid: 'organization',
+    projectUuid: 'project',
+    createdByUserUuid: null,
+    provider: PullRequestProvider.BITBUCKET,
+    source: PullRequestSource.AI_AGENT,
+    owner: 'workspace',
+    repo: 'jaffle',
+    prNumber: 1,
+    prUrl: 'https://bitbucket.org/workspace/jaffle/pull-requests/1',
+    summary: null,
+    aiThreadUuid: null,
+    aiAgentUuid: null,
+    reviewContext: null,
+    createdAt: new Date('2026-09-09'),
+};
+
+const createService = () => {
+    const projectModel = {
+        getSummary: vi
+            .fn()
+            .mockResolvedValue({ organizationUuid: 'organization' }),
+        get: vi.fn().mockResolvedValue({
+            dbtConnection: { type: DbtProjectType.BITBUCKET },
+        }),
+    };
+    const pullRequestsModel = {
+        getByProject: vi.fn().mockResolvedValue({ data: [storedPullRequest] }),
+    };
+    const gitIntegrationService = {
+        getBitbucketCredentials: vi.fn().mockResolvedValue({
+            owner: 'workspace',
+            repo: 'jaffle',
+            token: 'project-token',
+            type: DbtProjectType.BITBUCKET,
+        }),
+        getGitCredentials: vi.fn(),
+    };
+    const service = new PullRequestsService({
+        lightdashConfig: lightdashConfigMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        pullRequestsModel: pullRequestsModel as unknown as PullRequestsModel,
+        gitIntegrationService:
+            gitIntegrationService as unknown as GitIntegrationService,
+    });
+    return { service, projectModel, pullRequestsModel, gitIntegrationService };
+};
+
+describe('Bitbucket pull request metadata', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('checks access to the resource organization before reading stored pull requests or credentials', async () => {
+        const {
+            service,
+            projectModel,
+            pullRequestsModel,
+            gitIntegrationService,
+        } = createService();
+        projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'another-organization',
+        });
+        await expect(
+            service.getPullRequests(authorizedUser, 'project'),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(pullRequestsModel.getByProject).not.toHaveBeenCalled();
+        expect(
+            gitIntegrationService.getBitbucketCredentials,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('preserves successful metadata when another pull request is inaccessible', async () => {
+        const { service, pullRequestsModel, gitIntegrationService } =
+            createService();
+        const inaccessible = {
+            ...storedPullRequest,
+            pullRequestUuid: 'inaccessible',
+            prNumber: 2,
+        };
+        pullRequestsModel.getByProject.mockResolvedValue({
+            data: [storedPullRequest, inaccessible],
+        });
+        vi.spyOn(BitbucketClient, 'getPullRequest')
+            .mockResolvedValueOnce({
+                number: 1,
+                title: 'Add revenue',
+                state: PullRequestState.OPEN,
+                html_url: storedPullRequest.prUrl,
+                head: 'change',
+                base: 'main',
+            })
+            .mockRejectedValueOnce(new ForbiddenError());
+        const result = await service.getPullRequests(authorizedUser, 'project');
+        expect(result.data).toEqual([
+            {
+                ...storedPullRequest,
+                title: 'Add revenue',
+                state: PullRequestState.OPEN,
+            },
+            { ...inaccessible, title: null, state: null },
+        ]);
+        expect(gitIntegrationService.getGitCredentials).not.toHaveBeenCalled();
+    });
+
+    it('queues large histories and preserves results when a queued request fails', async () => {
+        const { service, pullRequestsModel } = createService();
+        const rows = Array.from({ length: 12 }, (_, index) => ({
+            ...storedPullRequest,
+            pullRequestUuid: `pull-request-${index + 1}`,
+            prNumber: index + 1,
+        }));
+        pullRequestsModel.getByProject.mockResolvedValue({ data: rows });
+        const pending = new Map<number, () => void>();
+        const getPullRequest = vi
+            .spyOn(BitbucketClient, 'getPullRequest')
+            .mockImplementation(async ({ pullNumber }) => {
+                await new Promise<void>((resolve) => {
+                    pending.set(pullNumber, resolve);
+                });
+                pending.delete(pullNumber);
+                if (pullNumber === 9) {
+                    throw new ForbiddenError();
+                }
+                return {
+                    number: pullNumber,
+                    title: `Change ${pullNumber}`,
+                    state: PullRequestState.OPEN,
+                    html_url: `https://bitbucket.org/workspace/jaffle/pull-requests/${pullNumber}`,
+                    head: 'change',
+                    base: 'main',
+                };
+            });
+
+        const result = service.getPullRequests(authorizedUser, 'project');
+        await vi.waitFor(() => {
+            expect(getPullRequest).toHaveBeenCalledTimes(8);
+            expect(pending.size).toBe(8);
+        });
+        [...pending.values()].forEach((resolve) => resolve());
+        await vi.waitFor(() => {
+            expect(getPullRequest).toHaveBeenCalledTimes(12);
+            expect(pending.size).toBe(4);
+        });
+        [...pending.values()].forEach((resolve) => resolve());
+
+        expect((await result).data).toEqual(
+            rows.map((row) => ({
+                ...row,
+                title: row.prNumber === 9 ? null : `Change ${row.prNumber}`,
+                state: row.prNumber === 9 ? null : PullRequestState.OPEN,
+            })),
+        );
+    });
+
+    it.each([
+        { owner: 'old-workspace', repo: 'jaffle' },
+        { owner: 'workspace', repo: 'old-repo' },
+    ])(
+        'never uses the current token for historical repository $owner/$repo',
+        async (repository) => {
+            const { service, pullRequestsModel } = createService();
+            const historic = { ...storedPullRequest, ...repository };
+            pullRequestsModel.getByProject.mockResolvedValue({
+                data: [historic],
+            });
+            const getPullRequest = vi.spyOn(BitbucketClient, 'getPullRequest');
+            expect(
+                (await service.getPullRequests(authorizedUser, 'project')).data,
+            ).toEqual([{ ...historic, title: null, state: null }]);
+            expect(getPullRequest).not.toHaveBeenCalled();
+        },
+    );
+
+    it('keeps stored links usable when project credentials are unavailable', async () => {
+        const { service, gitIntegrationService } = createService();
+        gitIntegrationService.getBitbucketCredentials.mockRejectedValue(
+            new ForbiddenError(),
+        );
+        const getPullRequest = vi.spyOn(BitbucketClient, 'getPullRequest');
+        expect(
+            (await service.getPullRequests(authorizedUser, 'project')).data,
+        ).toEqual([{ ...storedPullRequest, title: null, state: null }]);
+        expect(getPullRequest).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
+++ b/packages/backend/src/services/PullRequestsService/PullRequestsService.ts
@@ -11,6 +11,8 @@ import {
     PullRequestWithStatus,
     SessionUser,
 } from '@lightdash/common';
+import pLimit from 'p-limit';
+import * as BitbucketClient from '../../clients/bitbucket/Bitbucket';
 import * as GithubClient from '../../clients/github/Github';
 import * as GitlabClient from '../../clients/gitlab/Gitlab';
 import type { LightdashConfig } from '../../config/parseConfig';
@@ -57,13 +59,62 @@ export class PullRequestsService extends BaseService {
         repo: string,
         prNumbers: number[],
         credentials: {
-            type: DbtProjectType.GITHUB | DbtProjectType.GITLAB;
+            type:
+                | DbtProjectType.GITHUB
+                | DbtProjectType.GITLAB
+                | DbtProjectType.BITBUCKET;
+            owner: string;
+            repo: string;
             hostDomain?: string;
             token: string;
             installationId?: string;
         },
     ): Promise<Record<number, PullRequestMetadata>> {
         try {
+            if (
+                provider === PullRequestProvider.BITBUCKET &&
+                credentials.type === DbtProjectType.BITBUCKET &&
+                owner === credentials.owner &&
+                repo === credentials.repo
+            ) {
+                const limit = pLimit(8);
+                const results = await Promise.allSettled(
+                    prNumbers.map((pullNumber) =>
+                        limit(() =>
+                            BitbucketClient.getPullRequest({
+                                owner,
+                                repo,
+                                token: credentials.token,
+                                pullNumber,
+                            }),
+                        ),
+                    ),
+                );
+                const failedCount = results.filter(
+                    (result) => result.status === 'rejected',
+                ).length;
+                if (failedCount > 0) {
+                    this.logger.warn(
+                        'Failed to resolve Bitbucket pull request metadata',
+                        { owner, repo, failedCount },
+                    );
+                }
+                return Object.fromEntries(
+                    results.flatMap((result) =>
+                        result.status === 'fulfilled'
+                            ? [
+                                  [
+                                      result.value.number,
+                                      {
+                                          title: result.value.title,
+                                          state: result.value.state,
+                                      },
+                                  ],
+                              ]
+                            : [],
+                    ),
+                );
+            }
             if (
                 provider === PullRequestProvider.GITHUB &&
                 credentials.type === DbtProjectType.GITHUB
@@ -136,10 +187,17 @@ export class PullRequestsService extends BaseService {
         // can't be resolved, still return the stored rows without title/state.
         let credentials;
         try {
-            credentials = await this.gitIntegrationService.getGitCredentials(
-                user,
-                projectUuid,
-            );
+            const project = await this.projectModel.get(projectUuid);
+            credentials =
+                project.dbtConnection.type === DbtProjectType.BITBUCKET
+                    ? await this.gitIntegrationService.getBitbucketCredentials(
+                          user,
+                          projectUuid,
+                      )
+                    : await this.gitIntegrationService.getGitCredentials(
+                          user,
+                          projectUuid,
+                      );
         } catch (error) {
             this.logger.warn(
                 'Could not resolve git credentials for pull requests',
@@ -155,7 +213,7 @@ export class PullRequestsService extends BaseService {
             };
         }
 
-        // Group by provider + repo so each group is one batched API call.
+        // Group by provider + repo before resolving metadata.
         const groups = new Map<string, PullRequest[]>();
         pullRequests.forEach((pr) => {
             const key = `${pr.provider}:${pr.owner}/${pr.repo}`;

--- a/packages/common/src/types/gitIntegration.ts
+++ b/packages/common/src/types/gitIntegration.ts
@@ -29,6 +29,7 @@ export type PullRequestReviewContext = {
 export enum PullRequestProvider {
     GITHUB = 'github',
     GITLAB = 'gitlab',
+    BITBUCKET = 'bitbucket',
 }
 
 export enum PullRequestSource {
@@ -49,7 +50,7 @@ export enum PullRequestState {
 /**
  * A pull request created by a write-back. Only immutable identifiers are
  * persisted; the live title/state are resolved at runtime from the
- * GitHub/GitLab API using provider + owner + repo + prNumber.
+ * Git provider API using provider + owner + repo + prNumber.
  */
 export type PullRequest = {
     pullRequestUuid: string;

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
@@ -1,5 +1,5 @@
 import { DbtProjectType } from '@lightdash/common';
-import { TextInput, Alert, Anchor, PasswordInput } from '@mantine/core';
+import { TextInput, Text, Anchor, PasswordInput } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -13,22 +13,6 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     const form = useFormContext();
     return (
         <>
-            <Alert
-                color="yellow"
-                title="Bitbucket app passwords deprecation"
-                mb="md"
-            >
-                <Anchor
-                    inherit
-                    href="https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    Bitbucket Cloud transitions to API tokens
-                </Anchor>
-                . Existing app passwords will continue working until June 9,
-                2026.
-            </Alert>
             <TextInput
                 name="dbt.username"
                 {...form.getInputProps('dbt.username')}
@@ -44,36 +28,32 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 label="API Token"
                 description={
                     <>
-                        <p>
-                            Bitbucket Cloud users should
+                        <Text component="span" display="block" size="xs">
+                            Bitbucket Cloud requires an{' '}
                             <Anchor
                                 inherit
                                 href="https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/"
                                 target="_blank"
                                 rel="noreferrer"
                             >
-                                {' '}
-                                follow instructions for creating an API Token
-                            </Anchor>
-                        </p>
-                        <p>
-                            Bitbucket Server users should
+                                API token
+                            </Anchor>{' '}
+                            with Repositories: Read permission. Writeback also
+                            requires Repositories: Write and Pull requests: Read
+                            and Write permissions.
+                        </Text>
+                        <Text component="span" display="block" size="xs">
+                            For Bitbucket Server, use an{' '}
                             <Anchor
                                 inherit
                                 href="https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html"
                                 target="_blank"
                                 rel="noreferrer"
                             >
-                                {' '}
-                                follow instructions for creating a HTTP Access
-                                Token
-                            </Anchor>
-                        </p>
-                        <p>
-                            Select <b>Project read</b> and{' '}
-                            <b>Repository read</b> scope when you're creating
-                            the token.
-                        </p>
+                                HTTP access token
+                            </Anchor>{' '}
+                            with Project read and Repository read permissions.
+                        </Text>
                     </>
                 }
                 required={requireSecrets}
@@ -127,8 +107,8 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     <>
                         <p>
                             This is the folder where your <b>dbt_project.yml</b>{' '}
-                            file is found in the GitLab repository you entered
-                            above.
+                            file is found in the Bitbucket repository you
+                            entered above.
                         </p>
                         <p>
                             If your <b>dbt_project.yml</b> file is in the main

--- a/packages/frontend/src/features/pullRequests/utils.test.ts
+++ b/packages/frontend/src/features/pullRequests/utils.test.ts
@@ -1,7 +1,12 @@
-import type { PullRequestProvider, PullRequestSource } from '@lightdash/common';
+import { PullRequestProvider, type PullRequestSource } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import { type PullRequestRow } from './types';
-import { getReviewPath, getThreadPath, getThreadPreviewTarget } from './utils';
+import {
+    getProviderLabel,
+    getReviewPath,
+    getThreadPath,
+    getThreadPreviewTarget,
+} from './utils';
 
 const makeRow = (overrides: Partial<PullRequestRow> = {}): PullRequestRow => ({
     pullRequestUuid: 'pr-1',
@@ -26,6 +31,14 @@ const makeRow = (overrides: Partial<PullRequestRow> = {}): PullRequestRow => ({
 });
 
 describe('pullRequests utils', () => {
+    it.each([
+        [PullRequestProvider.GITHUB, 'GitHub'],
+        [PullRequestProvider.GITLAB, 'GitLab'],
+        [PullRequestProvider.BITBUCKET, 'Bitbucket'],
+    ])('labels %s pull requests', (provider, label) => {
+        expect(getProviderLabel(provider)).toBe(label);
+    });
+
     it('prefers the source review thread over the writeback thread', () => {
         expect(
             getThreadPreviewTarget(

--- a/packages/frontend/src/features/pullRequests/utils.ts
+++ b/packages/frontend/src/features/pullRequests/utils.ts
@@ -48,8 +48,18 @@ export const getStateColor = (state: PullRequestState | null): string => {
     }
 };
 
-export const getProviderLabel = (provider: PullRequestProvider): string =>
-    provider === PullRequestProvider.GITHUB ? 'GitHub' : 'GitLab';
+export const getProviderLabel = (provider: PullRequestProvider): string => {
+    switch (provider) {
+        case PullRequestProvider.GITHUB:
+            return 'GitHub';
+        case PullRequestProvider.GITLAB:
+            return 'GitLab';
+        case PullRequestProvider.BITBUCKET:
+            return 'Bitbucket';
+        default:
+            return assertUnreachable(provider, `Unknown provider ${provider}`);
+    }
+};
 
 /** A distinct Mantine color per source, so each source tag reads differently. */
 export const getSourceColor = (source: PullRequestSource): string => {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1995

## Summary

PR 1 of 2 for the Bitbucket Cloud writeback foundation. Adds repository, branch, file, atomic commit and pull request operations using the API token already stored on a project. Shared pull request history resolves Bitbucket titles and states with bounded concurrency and safe fallbacks.

## Changes

The credential resolver checks project SourceCode access before loading the token. The client uses the fixed Bitbucket Cloud API host, rejects redirects, sanitizes errors, and requires the expected parent commit for writes. Token setup instructions distinguish Cloud and Server permissions. Existing writeback feature gates remain unchanged.

```text
Project token -> authorized Cloud client -> branch + atomic commit -> pull request
Stored PR    -> matching project repo    -> live title/state or stored-URL fallback
```

The stacked follow-up [#28926](https://github.com/lightdash/lightdash/pull/28926) binds token reuse to the repository and username. Review and land both parts before enabling Bitbucket writeback entry points.

## Test plan

- 66 focused backend tests and 6 frontend tests pass; common/backend/frontend typechecks and focused lint pass.
- Live disposable Bitbucket repository: multi-file commit, pinned file read, deletion, PR create/read/update/decline, stale-write and invalid-token rejection. Test branch deleted; main unchanged.
- Local HTTP endpoint with encrypted project token: real PR metadata, anonymous access rejection, invalid-token and historical-repository fallbacks. Disposable fixture removed.
- Token setup copy verified in browser. API regenerated locally; generated files remain release-owned.
