### PR TITLE
fix: bind Bitbucket tokens to repository and username

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.test.ts
@@ -1422,6 +1422,77 @@ describe('ProjectModel', () => {
     });
 
     describe('mergeMissingDbtConfigSecrets', () => {
+        const bitbucketConfig = {
+            type: DbtProjectType.BITBUCKET as const,
+            username: 'user',
+            personal_access_token: 'saved-token',
+            repository: 'workspace/repository',
+            branch: 'main',
+            project_sub_path: '/',
+            host_domain: 'bitbucket.org',
+        };
+
+        test.each([
+            { repository: 'workspace/another-repository' },
+            { repository: 'another-workspace/repository' },
+            { username: 'another-user' },
+            { host_domain: 'bitbucket.example.com' },
+        ])(
+            'does not restore a Bitbucket token after destination change %j',
+            (change) => {
+                const incoming = {
+                    ...bitbucketConfig,
+                    ...change,
+                    personal_access_token: '',
+                };
+                expect(
+                    ProjectModel.mergeMissingDbtConfigSecrets(
+                        incoming,
+                        bitbucketConfig,
+                    ),
+                ).toEqual(incoming);
+            },
+        );
+
+        test.each([
+            {},
+            { branch: 'another-branch' },
+            { project_sub_path: '/dbt' },
+            { host_domain: 'BITBUCKET.ORG.' },
+        ])(
+            'restores a Bitbucket token for the same destination %j',
+            (change) => {
+                const incoming = {
+                    ...bitbucketConfig,
+                    ...change,
+                    personal_access_token: '',
+                };
+                expect(
+                    ProjectModel.mergeMissingDbtConfigSecrets(
+                        incoming,
+                        bitbucketConfig,
+                    ),
+                ).toEqual({
+                    ...incoming,
+                    personal_access_token: 'saved-token',
+                });
+            },
+        );
+
+        test('preserves an explicitly supplied token when the Bitbucket destination changes', () => {
+            const incoming = {
+                ...bitbucketConfig,
+                repository: 'workspace/another-repository',
+                personal_access_token: 'replacement-token',
+            };
+            expect(
+                ProjectModel.mergeMissingDbtConfigSecrets(
+                    incoming,
+                    bitbucketConfig,
+                ),
+            ).toEqual(incoming);
+        });
+
         test('should NOT merge the dbt Cloud API key when the discovery endpoint changes', () => {
             const completeConfig: DbtCloudIDEProjectConfig = {
                 type: DbtProjectType.DBT_CLOUD_IDE,

--- a/packages/backend/src/utils/credentialDestination.ts
+++ b/packages/backend/src/utils/credentialDestination.ts
@@ -74,6 +74,8 @@ const getDbtCredentialDestination = (config: DbtProjectConfig): unknown[] => {
                 normalizeCredentialHost(
                     config.host_domain || DEFAULT_BITBUCKET_HOST_DOMAIN,
                 ),
+                config.repository,
+                config.username,
             ];
         case DbtProjectType.AZURE_DEVOPS:
         case DbtProjectType.DBT:


### PR DESCRIPTION
Related: https://linear.app/lightdash/issue/SPK-1954

## Summary

PR 2 of 2 for the Bitbucket Cloud writeback foundation, stacked on [#28925](https://github.com/lightdash/lightdash/pull/28925). Prevents a project update from silently reusing its stored Bitbucket token after the repository, workspace, or username changes.

## Changes

The existing credential destination comparison now includes the repository and username alongside the normalized host. A destination change leaves an omitted token missing. The project can save that configuration, but API credential resolution requires a token before writeback can proceed. Explicit replacement tokens remain intact. Branch and dbt subfolder changes preserve the existing token.

```text
Before: same host                       -> reuse saved token
After:  same host + repository + user   -> reuse saved token
        changed destination            -> require token again
```

This addresses the Bitbucket portion of SPK-1954. GitHub and GitLab behavior is unchanged; the broader issue remains open.

## Test plan

- Three new regressions fail before the fix: repository, workspace and username changes restore the old token.
- Nine new cases pass after the fix, including unchanged destination, branch/subfolder edits, normalized host, changed host and explicit replacement token.
- 171 backend tests pass across ProjectModel, credential destinations, Bitbucket client and shared PR services. One preexisting unrelated test remains skipped.
- Backend typecheck, focused lint and formatting pass.
