### PR TITLE
fix: accelerate all-history analytics Parquet queries

### DIFF
--- a/docs/usage-analytics/architecture.md
+++ b/docs/usage-analytics/architecture.md
@@ -150,17 +150,29 @@ is valid. Never place one in logs, API responses, tickets or persisted models.
 The internal Parquet path in
 [`DuckdbWarehouseClient`](../../packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts):
 
-- Creates isolated in-memory query instances (256 MB memory limit, two threads).
+- Creates isolated in-memory query instances (256 MB DuckDB memory limit, 32
+  threads to overlap remote footer and column reads). Explicit caller resource
+  limits override these internal-reader defaults; other DuckDB defaults are unchanged.
 - Requires HTTPS for remote storage; HTTP is restricted to loopback test endpoints.
 - Validates canonical paths against the trusted scope; disallows arbitrary
   globbing/path substitution and mixing signed URLs with broad storage secrets.
-- Sets exact `allowed_paths` and disables general external access, disk spilling
-  and the relevant file/metadata caches.
+- Sets exact `allowed_paths` and disables general external access and disk spilling.
+- Enables HTTP metadata, Parquet metadata and external-file caching only inside
+  the private query instance. The instance is closed on success or failure;
+  neither cached bytes nor signed URLs are reused by another request or org.
 - Builds temporary views over `read_parquet` for those exact objects only.
 - Restricts user SQL and blocks catalog access that could disclose view SQL;
   disables profiling and sanitizes native query errors.
 
-DuckDB cache restrictions do not mean Lightdash has no persisted query results.
+Schema binding retains `union_by_name=true` so older files can lack newer columns.
+Caching prevents repeated remote metadata reads during binding, validation and
+execution. This does not remove all-history discovery, skip old files or change
+the 10,000-file cap. Large histories still require further scaling work (PROD-11111);
+these settings do not guarantee a latency ceiling for arbitrary data volumes.
+Each concurrent query has its own thread budget; deployment-wide and per-org
+concurrency limits still need validation before customer rollout.
+
+The query-local cache lifetime does not mean Lightdash has no persisted query results.
 The normal result/history paths still exist and need authorization. Analytics
 checks cover project access and result/history retrieval; exports and scheduled
 downloads are blocked in this preview. Flag-off denial is not deletion or

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.smoke.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 const db = await instance.connect();
                 try {
                     await db.run(
-                        `COPY (SELECT 42::INTEGER AS tokens, TIMESTAMP '2026-09-07' AS event_ts) TO '${fixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
+                        `COPY (SELECT 42::INTEGER AS tokens, TIMESTAMP '2026-09-07' AS event_ts, 7::INTEGER AS new_metric) TO '${fixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
                     );
                     await db.run(
                         `COPY (SELECT 42::INTEGER AS tokens, TIMESTAMP '2025-09-07' AS event_ts) TO '${historicalFixture.replace(/'/g, "''")}' (FORMAT PARQUET)`,
@@ -104,6 +104,28 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                         )
                     ).rows,
                 ).toEqual([{ total: '84' }]);
+                // Historical files may predate fields added to the stream.
+                expect(
+                    (
+                        await reader.runQuery(
+                            'SELECT count(new_metric) AS populated, sum(new_metric) AS total FROM query_events',
+                        )
+                    ).rows,
+                ).toEqual([{ populated: '1', total: '7' }]);
+                const otherReader = new DuckdbWarehouseClient({
+                    type: 'duckdb_parquet',
+                    resolveSource: createS3AnalyticsSourceResolver({
+                        storage,
+                        organizationUuid: otherOrg,
+                    }),
+                });
+                expect(
+                    (
+                        await otherReader.runQuery(
+                            'SELECT sum(tokens) AS total FROM query_events',
+                        )
+                    ).rows,
+                ).toEqual([{ total: '42' }]);
                 expect(
                     (
                         await reader.runQuery(
@@ -120,6 +142,11 @@ describe.skipIf(!process.env.ANALYTICS_S3_SMOKE_ENDPOINT)(
                 ).toEqual([{ total: '42' }]);
                 await expect(
                     reader.runQuery('SELECT sql FROM duckdb_views()'),
+                ).rejects.toThrow(/catalog access/);
+                await expect(
+                    reader.runQuery(
+                        'SELECT * FROM duckdb_external_file_cache()',
+                    ),
                 ).rejects.toThrow(/catalog access/);
                 const source = await resolveSource();
                 expect(source).not.toHaveProperty('s3Config');

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -184,6 +184,50 @@ describe('internal Parquet projects', () => {
             ),
         );
         expect(client.credentials).not.toHaveProperty('httpAuth');
+        expect(run).toHaveBeenCalledWith("SET memory_limit = '256MB';");
+        for (const cache of [
+            'enable_http_metadata_cache',
+            'enable_external_file_cache',
+            'parquet_metadata_cache',
+        ]) {
+            expect(run).toHaveBeenCalledWith(`SET ${cache} = true;`);
+        }
+        const statements = run.mock.calls.map(([sql]) => sql as string);
+        const bind = statements.findIndex((sql) =>
+            sql.startsWith('CREATE VIEW'),
+        );
+        expect(run).toHaveBeenCalledWith('SET threads = 32;');
+        expect(statements[bind]).toContain('union_by_name = true');
+        const instance = await createInstanceMock.mock.results[0].value;
+        expect(instance.closeSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('honors explicit thread limits during metadata binding and execution', async () => {
+        const client = new DuckdbWarehouseClient(
+            { type: 'duckdb_parquet', resolveSource: async () => source() },
+            { sharedResourceLimits: { threads: 1, memoryLimit: '128MB' } },
+        );
+        await client.runQuery('SELECT count(*) FROM query_events');
+        expect(run).toHaveBeenCalledWith("SET memory_limit = '128MB';");
+        expect(run).toHaveBeenCalledWith('SET threads = 1;');
+        expect(run).not.toHaveBeenCalledWith('SET threads = 32;');
+        expect(run).not.toHaveBeenCalledWith('SET threads = 2;');
+    });
+
+    it('closes the private cache when view binding fails', async () => {
+        run.mockImplementation(async (sql: string) => {
+            if (sql.startsWith('CREATE VIEW'))
+                throw new Error('binding failed');
+        });
+        const client = new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: async () => source(),
+        });
+        await expect(
+            client.runQuery('SELECT count(*) FROM query_events'),
+        ).rejects.toThrow(/Internal analytics query failed/);
+        const instance = await createInstanceMock.mock.results[0].value;
+        expect(instance.closeSync).toHaveBeenCalledTimes(1);
     });
 
     it.each([
@@ -253,12 +297,13 @@ describe('internal Parquet projects', () => {
             expect.stringContaining('CREATE SECRET'),
         );
         expect(run).toHaveBeenCalledWith(
-            'SET enable_external_file_cache = false;',
+            'SET enable_external_file_cache = true;',
         );
     });
 
     it.each([
         'SELECT sql FROM duckdb_views()',
+        'SELECT * FROM duckdb_external_file_cache()',
         'SELECT * FROM "information_schema"."views"',
         'SELECT * FROM sqlite_master',
         "SELECT * FROM pragma_storage_info('query_events')",

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -716,7 +716,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         this.sharedResourceLimits = isParquet
             ? {
                   memoryLimit: '256MB',
-                  threads: 2,
+                  // Remote Parquet scans are I/O-bound. Overlap footer and
+                  // column reads; this limit belongs only to the private reader.
+                  threads: 32,
                   ...options?.sharedResourceLimits,
               }
             : options?.sharedResourceLimits;
@@ -1133,9 +1135,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
         // Restrict the engine, not just SQL validation. No globbing, arbitrary
         // network reads, local files, or shared spill/cache directories.
         await db.run("SET temp_directory = '';");
-        await db.run('SET enable_http_metadata_cache = false;');
-        await db.run('SET enable_external_file_cache = false;');
-        await db.run('SET parquet_metadata_cache = false;');
+        // These caches live only in this query's private, memory-limited
+        // instance, which is closed in withEphemeralQuerySession's finally.
+        // Reuse metadata between view binding, validation and execution without
+        // retaining files or signed URLs across requests or organizations.
+        await db.run('SET enable_http_metadata_cache = true;');
+        await db.run('SET enable_external_file_cache = true;');
+        await db.run('SET parquet_metadata_cache = true;');
         const files = source.tables.flatMap(({ urls }) => urls);
         await db.run(`SET allowed_paths = [${files.map(literal).join(',')}];`);
         await db.run('SET enable_external_access = false;');


### PR DESCRIPTION
## Summary

Reduce repeated remote metadata reads when querying all retained internal analytics Parquet partitions. The internal reader now enables HTTP metadata, Parquet metadata and external-file caches inside each private ephemeral DuckDB instance, and defaults to 32 threads to overlap remote I/O instead of two. Explicit resource limits still override the defaults.

This is PR5 in the analytics stack, based on the internal docs PR. No source date cutoff, schema-union removal, retry disabling, new credentials, shared-instance cache, or disk spill is introduced. Ordinary DuckDB/MotherDuck/DuckLake configuration paths are unchanged.

## Validation

- Focused warehouse suite: 124 tests passed; warehouse typecheck and changed-file lint passed.
- Real DuckDB + disposable MinIO: both streams, historical schema evolution, date filtering, separate orgs, signed URL tampering, PUT denial, expiry and cache-catalog disclosure denial passed.
- Read-only cloud smoke test passed for both streams.
- Cold all-history daily aggregation improved from roughly 111 seconds to 4–5 seconds in direct DuckDB testing.
- Local API, result cache explicitly bypassed: daily AI call queries 6.0s / 4.9s; daily Query Events count 5.5s. These measurements describe the tested dataset, not a latency guarantee.
- Local API provisioning remains idempotent under concurrent calls; anonymous/viewer access and cached-result retrieval are denied.
- Live browser: daily AI bar chart, pre-September date filter, empty historical range, and stacked AI-model series all render correctly. Main browser queries took approximately 4.8–5.3s; the totals row issues a separate query and appears later.
- Cloud Build & Test, OpenAPI compatibility and latest Release-safety preview passed. Deploy Preview still running at the latest check.

## Security and rollout

The existing feature flag and development-only gate remain unchanged. Exact signed GET allowlists, blocked arbitrary external reads/catalog queries, sanitized failures, the 256 MB DuckDB memory setting, and private-instance cleanup on success/failure remain enforced. Cached data and capabilities are not shared across requests or orgs. No new security issue was identified within the focused checks; this is not a production isolation certification.

Residual risks: each concurrent query can now use 32 threads, so per-org/deployment concurrency and large-history memory/load testing remain required before customer rollout. File discovery still scans the retained manifest and retains the existing 10,000-file cap. Read-only signer credentials remain separate work. No migration or public API change.

Relates: PROD-11111
Relates: PROD-11059
Relates: #23450

### Risk assessment

- [ ] This is a high-risk change

Bounded to the existing development-only internal analytics reader. Production resource sizing remains unverified.
