### PR TITLE
fix(previews): stop full-scanning chart versions when remapping data app viz charts

### DIFF
--- a/packages/backend/src/models/AppModel.test.ts
+++ b/packages/backend/src/models/AppModel.test.ts
@@ -6,6 +6,10 @@ import {
     type DbApp,
 } from '../database/entities/apps';
 import { DashboardTileDataAppsTableName } from '../database/entities/dashboards';
+import {
+    SavedChartsTableName,
+    SavedChartVersionsTableName,
+} from '../database/entities/savedCharts';
 import { AppModel } from './AppModel';
 
 const appId = '11111111-1111-4111-8111-111111111111';
@@ -274,5 +278,103 @@ describe('AppModel.findDashboardsContainingApp', () => {
         expect(tracker.history.select[0].bindings).toEqual(
             expect.arrayContaining([projectUuid, dashboardUuid, appId]),
         );
+    });
+});
+
+describe('AppModel.remapPreviewChartVizBindings', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new AppModel({ database });
+    let tracker: Tracker;
+
+    const previewProjectUuid = '55555555-5555-4555-8555-555555555555';
+    const sourceAppUuid = '66666666-6666-4666-8666-666666666666';
+    const previewAppUuid = '77777777-7777-4777-8777-777777777777';
+    const otherSourceAppUuid = '88888888-8888-4888-8888-888888888888';
+    const mappings = [
+        { sourceAppUuid, previewAppUuid, previewAppVersion: 3 },
+        {
+            sourceAppUuid: otherSourceAppUuid,
+            previewAppUuid: '99999999-9999-4999-8999-999999999999',
+            previewAppVersion: 1,
+        },
+    ];
+    const spaceChartsQuery =
+        /"spaces"\."space_id" = "saved_queries"\."space_id"/;
+    const dashboardChartsQuery =
+        /"dashboards"\."dashboard_uuid" = "saved_queries"\."dashboard_uuid"/;
+    const versionCandidatesQuery = /from "saved_queries_versions" where/;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('does nothing without mappings', async () => {
+        await model.remapPreviewChartVizBindings(previewProjectUuid, []);
+
+        expect(tracker.history.all).toHaveLength(0);
+    });
+
+    it('stops after the chart lookup when the preview has no charts', async () => {
+        tracker.on.select(spaceChartsQuery).responseOnce([]);
+        tracker.on.select(dashboardChartsQuery).responseOnce([]);
+
+        await model.remapPreviewChartVizBindings(previewProjectUuid, mappings);
+
+        expect(tracker.history.select).toHaveLength(2);
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('looks up candidate versions by chart id and skips updates when none match', async () => {
+        tracker.on
+            .select(spaceChartsQuery)
+            .responseOnce([{ saved_query_id: 1 }, { saved_query_id: 2 }]);
+        tracker.on
+            .select(dashboardChartsQuery)
+            .responseOnce([{ saved_query_id: 2 }, { saved_query_id: 3 }]);
+        tracker.on.select(versionCandidatesQuery).responseOnce([]);
+
+        await model.remapPreviewChartVizBindings(previewProjectUuid, mappings);
+
+        expect(tracker.history.select).toHaveLength(3);
+        const candidates = tracker.history.select[2];
+        expect(candidates.sql).toContain(`"saved_query_id" = ANY($1::int[])`);
+        expect(candidates.sql).toContain(`"chart_type" = $2`);
+        expect(candidates.sql).not.toContain(`"${SavedChartsTableName}"`);
+        expect(candidates.bindings).toEqual([[1, 2, 3], 'data_app_viz']);
+        expect(tracker.history.update).toHaveLength(0);
+    });
+
+    it('updates only the versions bound to a mapped source app, by version id', async () => {
+        tracker.on
+            .select(spaceChartsQuery)
+            .responseOnce([{ saved_query_id: 1 }]);
+        tracker.on
+            .select(dashboardChartsQuery)
+            .responseOnce([{ saved_query_id: 2 }]);
+        tracker.on.select(versionCandidatesQuery).responseOnce([
+            { saved_queries_version_id: 10, source_app_uuid: sourceAppUuid },
+            { saved_queries_version_id: 11, source_app_uuid: sourceAppUuid },
+            {
+                saved_queries_version_id: 12,
+                source_app_uuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            },
+            { saved_queries_version_id: 13, source_app_uuid: null },
+        ]);
+        tracker.on.update(SavedChartVersionsTableName).responseOnce(2);
+
+        await model.remapPreviewChartVizBindings(previewProjectUuid, mappings);
+
+        expect(tracker.history.update).toHaveLength(1);
+        const update = tracker.history.update[0];
+        expect(update.sql).toContain('jsonb_set');
+        expect(update.sql).toMatch(
+            /where "saved_queries_version_id" = ANY\(\$\d+::int\[\]\)/,
+        );
+        expect(update.sql).not.toContain('chart_config->>');
+        expect(update.bindings).toEqual([previewAppUuid, 3, [10, 11]]);
     });
 });

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -1302,6 +1302,49 @@ export class AppModel {
             .where(`${ProjectTableName}.project_uuid`, previewProjectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
             .select(`${SavedChartsTableName}.saved_query_id`);
+        const [spaceCharts, dashboardCharts] = await Promise.all([
+            spaceChartIds,
+            dashboardChartIds,
+        ]);
+        const previewChartIds = [
+            ...new Set(
+                [...spaceCharts, ...dashboardCharts].map(
+                    (row) => row.saved_query_id,
+                ),
+            ),
+        ];
+        if (previewChartIds.length === 0) {
+            return;
+        }
+
+        // Narrow by the indexed chart id first: chart_type and chart_config
+        // are unindexed, so filtering the whole table on them is a full scan.
+        const candidates = await this.database(SavedChartVersionsTableName)
+            .select<
+                {
+                    saved_queries_version_id: number;
+                    source_app_uuid: string | null;
+                }[]
+            >(
+                'saved_queries_version_id',
+                this.database.raw(
+                    `chart_config->>'dataAppVizUuid' as source_app_uuid`,
+                ),
+            )
+            .whereRaw('?? = ANY(?::int[])', ['saved_query_id', previewChartIds])
+            .where('chart_type', ChartType.DATA_APP_VIZ);
+        const versionIdsBySourceApp = candidates.reduce<Map<string, number[]>>(
+            (acc, { saved_queries_version_id, source_app_uuid }) => {
+                if (source_app_uuid === null) {
+                    return acc;
+                }
+                const ids = acc.get(source_app_uuid) ?? [];
+                ids.push(saved_queries_version_id);
+                acc.set(source_app_uuid, ids);
+                return acc;
+            },
+            new Map(),
+        );
 
         /* eslint-disable no-await-in-loop */
         for (const {
@@ -1309,27 +1352,25 @@ export class AppModel {
             previewAppUuid,
             previewAppVersion,
         } of mappings) {
-            await this.database(SavedChartVersionsTableName)
-                .where('chart_type', ChartType.DATA_APP_VIZ)
-                .whereRaw(`chart_config->>'dataAppVizUuid' = ?`, [
-                    sourceAppUuid,
-                ])
-                .where((chartScope) => {
-                    void chartScope
-                        .whereIn('saved_query_id', spaceChartIds.clone())
-                        .orWhereIn('saved_query_id', dashboardChartIds.clone());
-                })
-                .update({
-                    chart_config: this.database.raw(
-                        `jsonb_set(
-                            jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text)),
-                            '{dataAppVizVersion}',
-                            to_jsonb(?::integer),
-                            true
-                        )`,
-                        [previewAppUuid, previewAppVersion],
-                    ) as unknown as ChartConfig['config'],
-                });
+            const versionIds = versionIdsBySourceApp.get(sourceAppUuid);
+            if (versionIds) {
+                await this.database(SavedChartVersionsTableName)
+                    .whereRaw('?? = ANY(?::int[])', [
+                        'saved_queries_version_id',
+                        versionIds,
+                    ])
+                    .update({
+                        chart_config: this.database.raw(
+                            `jsonb_set(
+                                jsonb_set(chart_config, '{dataAppVizUuid}', to_jsonb(?::text)),
+                                '{dataAppVizVersion}',
+                                to_jsonb(?::integer),
+                                true
+                            )`,
+                            [previewAppUuid, previewAppVersion],
+                        ) as unknown as ChartConfig['config'],
+                    });
+            }
         }
         /* eslint-enable no-await-in-loop */
     }


### PR DESCRIPTION
## Summary

Creating a preview of a project with data apps ran one `UPDATE saved_queries_versions` per data app, filtered on `chart_type` and a `chart_config` JSON key with an OR of two IN subqueries. None of that is indexed, so each statement was a full sequential scan of the table, inside the request the CLI waits on. With a few dozen apps and a multi-million-row table that is minutes per preview, so `lightdash deploy --create` hit the load balancer timeout and reported a 502 while the backend finished anyway.

`remapPreviewChartVizBindings` now:

- resolves the preview's chart ids first (space charts and dashboard charts),
- fetches the `data_app_viz` versions of those charts through the indexed `saved_query_id` column, and
- updates matched versions by primary key, one statement per app that has matches.

It returns early when the preview has no charts or none on a custom chart type, which is the common case. Behaviour is otherwise unchanged and pinned by unit tests.

## Before and after

Bench: Postgres 18, real schema from migrations, 2.2M chart versions (4.6 GB), a preview project with 3,500 charts, 38 data-app mappings. About a third of the size of the affected instances.

| Scenario | Total | Statements | Seq scans on `saved_queries_versions` |
| --- | ---: | ---: | ---: |
| main, warm cache | 344 s | 38 | 40 |
| main, cold cache | 682 s | 38 | 38 |
| this branch | 0.13 s (1.1 s cold) | 3 | 0 |

One statement, `EXPLAIN (ANALYZE, BUFFERS)`: before, a Seq Scan removing 2,226,760 rows by filter and reading 525,713 pages; after, a Bitmap Index Scan on `saved_queries_versions_saved_query_id_index`, 7.5 ms on a preview whose charts carry one version each.

## Testing

- `pnpm -F backend test src/models/AppModel.test.ts`: 4 new tests, 3 of which fail against the old implementation
- `pnpm -F backend test src/ee/services/AppGenerateService/AppGenerateService.vizSchemaCopy.test.ts`
- `pnpm -F backend lint`, `pnpm -F backend typecheck`
- Remap correctness on seeded `data_app_viz` rows in the bench database: every row in the preview project remapped, rows in another project untouched

Closes: #28920
Closes: PROD-11106
