### PR TITLE
feat(ai): support Bitbucket Cloud writeback pull requests

### DIFF
--- a/packages/backend/src/clients/bitbucket/Bitbucket.test.ts
+++ b/packages/backend/src/clients/bitbucket/Bitbucket.test.ts
@@ -337,6 +337,27 @@ describe('Bitbucket branches and files', () => {
 });
 
 describe('Bitbucket pull requests', () => {
+    it('preserves source and destination repository identities for fork validation', async () => {
+        fetchMock.mockResponse(
+            JSON.stringify({
+                ...pullRequest,
+                source: {
+                    ...pullRequest.source,
+                    repository: { full_name: 'fork/analytics' },
+                },
+                destination: {
+                    ...pullRequest.destination,
+                    repository: { full_name: 'workspace/analytics' },
+                },
+            }),
+        );
+        await expect(
+            getPullRequest({ ...credentials, pullNumber: 12 }),
+        ).resolves.toMatchObject({
+            sourceRepository: 'fork/analytics',
+            destinationRepository: 'workspace/analytics',
+        });
+    });
     it.each([
         ['OPEN', PullRequestState.OPEN],
         ['MERGED', PullRequestState.MERGED],
@@ -360,6 +381,8 @@ describe('Bitbucket pull requests', () => {
                 'https://bitbucket.org/workspace/analytics/pull-requests/12',
             head: branch.name,
             base: 'main',
+            sourceRepository: null,
+            destinationRepository: null,
         });
     });
 

--- a/packages/backend/src/clients/bitbucket/Bitbucket.ts
+++ b/packages/backend/src/clients/bitbucket/Bitbucket.ts
@@ -32,8 +32,14 @@ const pullRequestSchema = z.object({
     id: z.number().int().positive(),
     title: z.string(),
     state: z.enum(['OPEN', 'MERGED', 'DECLINED', 'SUPERSEDED']),
-    source: z.object({ branch: z.object({ name: z.string() }) }),
-    destination: z.object({ branch: z.object({ name: z.string() }) }),
+    source: z.object({
+        branch: z.object({ name: z.string() }),
+        repository: z.object({ full_name: z.string() }).nullish(),
+    }),
+    destination: z.object({
+        branch: z.object({ name: z.string() }),
+        repository: z.object({ full_name: z.string() }).nullish(),
+    }),
 });
 
 export type BitbucketPullRequest = {
@@ -43,6 +49,8 @@ export type BitbucketPullRequest = {
     state: PullRequestState;
     head: string;
     base: string;
+    sourceRepository?: string | null;
+    destinationRepository?: string | null;
 };
 
 const encodeSegment = (value: string): string => {
@@ -57,9 +65,9 @@ const encodeSegment = (value: string): string => {
     return encodeURIComponent(value);
 };
 
-export const resolveBitbucketCredentials = (
+export const resolveBitbucketRepository = (
     connection: DbtProjectConfig,
-): BitbucketCredentials => {
+): Pick<BitbucketCredentials, 'owner' | 'repo'> => {
     if (connection.type !== DbtProjectType.BITBUCKET) {
         throw new ParameterError('The project is not connected to Bitbucket');
     }
@@ -81,6 +89,16 @@ export const resolveBitbucketCredentials = (
     const [owner, repo] = repository.split('/');
     encodeSegment(owner);
     encodeSegment(repo);
+    return { owner, repo };
+};
+
+export const resolveBitbucketCredentials = (
+    connection: DbtProjectConfig,
+): BitbucketCredentials => {
+    const { owner, repo } = resolveBitbucketRepository(connection);
+    if (connection.type !== DbtProjectType.BITBUCKET) {
+        throw new ParameterError('The project is not connected to Bitbucket');
+    }
     const token = connection.personal_access_token?.trim();
     if (!token) {
         throw new ParameterError(
@@ -305,6 +323,8 @@ const readPullRequest = async (
         state: states[result.state],
         head: result.source.branch.name,
         base: result.destination.branch.name,
+        sourceRepository: result.source.repository?.full_name ?? null,
+        destinationRepository: result.destination.repository?.full_name ?? null,
     };
 };
 

--- a/packages/backend/src/ee/services/AiAgentAdminService.test.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.test.ts
@@ -1791,6 +1791,52 @@ describe('AiAgentAdminService review notification settings', () => {
 });
 
 describe('getAiAgentReviewItemWritebackEligibility', () => {
+    it.each([true, false])(
+        'uses the Bitbucket project token without an app installation (token: %s)',
+        (hasProjectToken) => {
+            expect(
+                getAiAgentReviewItemWritebackEligibility({
+                    item: makeReviewItem(),
+                    reviewsEnabled: true,
+                    projectContextEnabled: false,
+                    projectAccess: {
+                        provider: PullRequestProvider.BITBUCKET,
+                        hasProjectToken,
+                    },
+                    hasSemanticWritebackConfig: true,
+                    sourceThreadHasWritebackPr: false,
+                }),
+            ).toEqual({
+                eligible: hasProjectToken,
+                provider: PullRequestProvider.BITBUCKET,
+                strategy: 'semantic_layer',
+                reason: hasProjectToken ? null : 'bitbucket_token_missing',
+            });
+        },
+    );
+
+    it('does not enable Bitbucket project-context writeback', () => {
+        expect(
+            getAiAgentReviewItemWritebackEligibility({
+                item: makeReviewItem({
+                    source: 'manual',
+                    primaryRootCause: 'project_context',
+                }),
+                reviewsEnabled: true,
+                projectContextEnabled: true,
+                projectAccess: {
+                    provider: PullRequestProvider.BITBUCKET,
+                    hasProjectToken: true,
+                },
+                hasSemanticWritebackConfig: true,
+                sourceThreadHasWritebackPr: false,
+            }),
+        ).toMatchObject({
+            eligible: false,
+            reason: 'unsupported_source_control',
+        });
+    });
+
     it('allows semantic layer writeback on GitHub when configured', () => {
         expect(
             getAiAgentReviewItemWritebackEligibility({

--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -119,6 +119,7 @@ import { sanitizeToolResultForDump } from './ai/utils/threadDumpSanitizer';
 import { type AiAgentReviewClassifierService } from './AiAgentReviewClassifierService';
 import { type AiAgentReviewNotificationService } from './AiAgentReviewNotificationService';
 import { type AiAgentService } from './AiAgentService/AiAgentService';
+import { isBitbucketCloudConnection } from './AiAgentService/writebackConnection';
 import { type AiOrganizationSettingsService } from './AiOrganizationSettingsService';
 import { type WritebackPreviewService } from './AiWritebackService/WritebackPreviewService';
 import { type ProjectContextService } from './ProjectContextService/ProjectContextService';
@@ -164,8 +165,12 @@ const parsePullRequestUrl = (
 
 type ProjectWritebackAccess =
     | {
-          provider: PullRequestProvider;
+          provider: PullRequestProvider.GITHUB | PullRequestProvider.GITLAB;
           hasGitAppInstallation: boolean;
+      }
+    | {
+          provider: PullRequestProvider.BITBUCKET;
+          hasProjectToken: boolean;
       }
     | {
           provider: null;
@@ -333,7 +338,20 @@ export const getAiAgentReviewItemWritebackEligibility = (args: {
             projectAccess.provider,
         );
     }
-    if (!projectAccess.hasGitAppInstallation) {
+    if (
+        projectAccess.provider === PullRequestProvider.BITBUCKET &&
+        !projectAccess.hasProjectToken
+    ) {
+        return unavailableWritebackEligibility(
+            'bitbucket_token_missing',
+            strategy,
+            projectAccess.provider,
+        );
+    }
+    if (
+        projectAccess.provider !== PullRequestProvider.BITBUCKET &&
+        !projectAccess.hasGitAppInstallation
+    ) {
         return unavailableWritebackEligibility(
             'git_app_not_installed',
             strategy,
@@ -1688,6 +1706,22 @@ export class AiAgentAdminService extends BaseService {
                     try {
                         const project =
                             await this.projectModel.get(projectUuid);
+                        if (isBitbucketCloudConnection(project.dbtConnection)) {
+                            const sensitiveProject =
+                                await this.projectModel.getWithSensitiveFields(
+                                    projectUuid,
+                                );
+                            return [
+                                projectUuid,
+                                {
+                                    provider: PullRequestProvider.BITBUCKET,
+                                    hasProjectToken:
+                                        sensitiveProject.dbtConnection.type ===
+                                            DbtProjectType.BITBUCKET &&
+                                        !!sensitiveProject.dbtConnection.personal_access_token?.trim(),
+                                },
+                            ];
+                        }
                         if (
                             project.dbtConnection.type === DbtProjectType.GITHUB
                         ) {
@@ -1749,6 +1783,10 @@ export class AiAgentAdminService extends BaseService {
                 throw new MissingConfigError(
                     'AI writeback requires E2B_API_KEY and ANTHROPIC_API_KEY',
                 );
+            case 'bitbucket_token_missing':
+                throw new ParameterError(
+                    'Configure a Bitbucket Cloud API token in the project connection to open writeback pull requests',
+                );
             case 'git_app_not_installed':
                 throw new ParameterError(
                     `Install the ${eligibility.provider ?? 'Git'} app to open writeback pull requests`,
@@ -1791,7 +1829,7 @@ export class AiAgentAdminService extends BaseService {
                 );
             case 'unsupported_source_control':
                 throw new ParameterError(
-                    'Writeback requires a GitHub or GitLab connected dbt project',
+                    'Writeback requires a GitHub, GitLab or Bitbucket Cloud connected dbt project',
                 );
             case 'unsupported_root_cause':
             default:

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -452,6 +452,7 @@ import {
     buildDashboardSuggestionContext,
     getPinnedSuggestionContextInput,
 } from './suggestionPinnedContext';
+import { getWritebackConnectionSupport } from './writebackConnection';
 
 type ThreadMessageContext = Array<
     Required<Pick<MessageElement, 'text' | 'user' | 'ts'>>
@@ -9699,6 +9700,8 @@ Use your existing tools to inspect them when relevant to the user's question (re
                 });
         }
 
+        const isBitbucketPullRequest =
+            result.prUrl?.startsWith('https://bitbucket.org/') === true;
         let previewDeployConfigured: boolean | null = null;
         try {
             const { enabled: previewDeploySetupEnabled } =
@@ -9706,7 +9709,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
                     user,
                     featureFlagId: FeatureFlags.AiPreviewDeploySetup,
                 });
-            if (previewDeploySetupEnabled) {
+            if (previewDeploySetupEnabled && !isBitbucketPullRequest) {
                 const ciStatus =
                     await this.previewDeploySetupService.getOrScanProjectCiStatus(
                         user,
@@ -9724,7 +9727,12 @@ Use your existing tools to inspect them when relevant to the user's question (re
         }
 
         let previewUrl: string | null = null;
-        if (result.prUrl && !suppressWritebackPreview && !reviewRemediation) {
+        if (
+            result.prUrl &&
+            !isBitbucketPullRequest &&
+            !suppressWritebackPreview &&
+            !reviewRemediation
+        ) {
             const preview =
                 await this.writebackPreviewService.createPreviewForPullRequest({
                     user,
@@ -11291,15 +11299,10 @@ Use your existing tools to inspect them when relevant to the user's question (re
                 `Disabling editDbtProject for Slack prompt ${prompt.promptUuid} because aiRequireOAuth is off.`,
             );
         }
-        // Writeback opens a pull request and only supports GitHub and GitLab
-        // dbt connections (see AiWritebackService.getGitProvider, which throws
-        // for any other type). Without this guard the agent would expose the
-        // writeback section + editDbtProject tool — and offer to open PRs — on
-        // projects where editDbtProject can only fail.
-        const writebackSupportedConnection =
-            promptProject.dbtConnection.type === DbtProjectType.GITHUB ||
-            promptProject.dbtConnection.type === DbtProjectType.GITLAB;
-        if (aiWritebackEnabled && !writebackSupportedConnection) {
+        const writebackConnectionSupport = getWritebackConnectionSupport(
+            promptProject.dbtConnection,
+        );
+        if (aiWritebackEnabled && !writebackConnectionSupport.editDbtProject) {
             aiWritebackEnabled = false;
         }
 
@@ -11321,7 +11324,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
             );
             codingAgentEnabled = false;
         }
-        if (codingAgentEnabled && !writebackSupportedConnection) {
+        if (codingAgentEnabled && !writebackConnectionSupport.editRepo) {
             codingAgentEnabled = false;
         }
 
@@ -11360,6 +11363,7 @@ Use your existing tools to inspect them when relevant to the user's question (re
 
         const projectContextEnabled =
             aiWritebackEnabled &&
+            writebackConnectionSupport.editRepo &&
             (await this.aiOrganizationSettingsService.isAiAgentReviewsEnabled(
                 user,
             ));
@@ -11376,7 +11380,9 @@ Use your existing tools to inspect them when relevant to the user's question (re
                 featureFlagId: FeatureFlags.AiPreviewDeploySetup,
             });
         const aiPreviewDeploySetupEnabled =
-            aiWritebackEnabled && aiPreviewDeploySetupFlag;
+            aiWritebackEnabled &&
+            writebackConnectionSupport.editRepo &&
+            aiPreviewDeploySetupFlag;
 
         // exploreRepo/discoverRepos read repo source and the view:SourceCode
         // check evaluates against the resolved user. On Slack without

--- a/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/runEditDbtProjectPipeline.test.ts
@@ -184,6 +184,7 @@ const buildService = (overrides: {
         hasToolResult,
         createRemediationEvent,
         createPreviewForPullRequest,
+        previewDeploySetupService,
     };
 };
 
@@ -347,6 +348,37 @@ describe('AiAgentService.runEditDbtProjectPipeline', () => {
             expect.objectContaining({
                 remediationUuid: 'rem-1',
                 event: expect.objectContaining({ eventType: 'pr_updated' }),
+            }),
+        );
+    });
+
+    it('does not offer or create preview deployment for a Bitbucket pull request', async () => {
+        const {
+            service,
+            updateToolResult,
+            createPreviewForPullRequest,
+            previewDeploySetupService,
+        } = buildService({
+            previewDeploySetupEnabled: true,
+            ciStatus: { hasPreviewDeployWorkflow: false },
+            run: vi.fn().mockResolvedValue({
+                ...WRITEBACK_RESULT,
+                prUrl: 'https://bitbucket.org/workspace/dbt/pull-requests/7',
+            }),
+        });
+        await service.runEditDbtProjectPipeline(PAYLOAD);
+        expect(createPreviewForPullRequest).not.toHaveBeenCalled();
+        expect(
+            previewDeploySetupService.getOrScanProjectCiStatus,
+        ).not.toHaveBeenCalled();
+        expect(updateToolResult).toHaveBeenCalledWith(
+            'prompt-1',
+            'tool-call-1',
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    status: 'success',
+                    previewUrl: null,
+                }),
             }),
         );
     });

--- a/packages/backend/src/ee/services/AiAgentService/writebackConnection.test.ts
+++ b/packages/backend/src/ee/services/AiAgentService/writebackConnection.test.ts
@@ -1,0 +1,45 @@
+import {
+    DbtProjectType,
+    type DbtBitBucketProjectConfig,
+} from '@lightdash/common';
+import { getWritebackConnectionSupport } from './writebackConnection';
+
+const bitbucket: DbtBitBucketProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    repository: 'workspace/dbt',
+    branch: 'main',
+    username: 'user',
+    personal_access_token: 'token',
+    project_sub_path: '/',
+};
+
+describe('writeback connection support', () => {
+    it.each([undefined, '', 'bitbucket.org', ' BITBUCKET.ORG. '])(
+        'offers only dbt editing on Bitbucket Cloud host %s',
+        (host_domain) => {
+            expect(
+                getWritebackConnectionSupport({ ...bitbucket, host_domain }),
+            ).toEqual({ editDbtProject: true, editRepo: false });
+        },
+    );
+    it.each(['bitbucket.internal', 'bitbucket.org.evil.test'])(
+        'offers no writeback for unsupported host %s',
+        (host_domain) => {
+            expect(
+                getWritebackConnectionSupport({ ...bitbucket, host_domain }),
+            ).toEqual({ editDbtProject: false, editRepo: false });
+        },
+    );
+    it.each([DbtProjectType.GITHUB, DbtProjectType.GITLAB] as const)(
+        'preserves both tools for %s',
+        (type) => {
+            expect(
+                getWritebackConnectionSupport({
+                    ...bitbucket,
+                    type,
+                    authorization_method: 'personal_access_token',
+                }),
+            ).toEqual({ editDbtProject: true, editRepo: true });
+        },
+    );
+});

--- a/packages/backend/src/ee/services/AiAgentService/writebackConnection.ts
+++ b/packages/backend/src/ee/services/AiAgentService/writebackConnection.ts
@@ -1,0 +1,19 @@
+import { DbtProjectType, type DbtProjectConfig } from '@lightdash/common';
+
+export const isBitbucketCloudConnection = (
+    connection: DbtProjectConfig,
+): boolean =>
+    connection.type === DbtProjectType.BITBUCKET &&
+    (!connection.host_domain?.trim() ||
+        connection.host_domain.trim().toLowerCase().replace(/\.$/, '') ===
+            'bitbucket.org');
+
+export const getWritebackConnectionSupport = (connection: DbtProjectConfig) => {
+    const editRepo =
+        connection.type === DbtProjectType.GITHUB ||
+        connection.type === DbtProjectType.GITLAB;
+    return {
+        editRepo,
+        editDbtProject: editRepo || isBitbucketCloudConnection(connection),
+    };
+};

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -12,6 +12,7 @@ import {
     RequestMethod,
     SupportedDbtVersions,
     WarehouseTypes,
+    type DbtBitBucketProjectConfig,
     type MemberAbility,
     type SessionUser,
 } from '@lightdash/common';
@@ -54,10 +55,12 @@ import {
 import { DeniedPathError } from './deniedPaths';
 import {
     RepoTooLargeError,
+    WritebackCredentialCleanupError,
     WritebackGitNotConnectedError,
     WritebackRunAbortedError,
     WritebackThreadPrClosedError,
 } from './errors';
+import { BitbucketProvider } from './providers/BitbucketProvider';
 
 // Stub e2b and the GitHub/octokit client so the run() tests drive fakes and the
 // unit tests below never reach the real SDKs.
@@ -76,6 +79,15 @@ vi.mock('../SandboxRuntime', async () => ({
         '../SandboxRuntime',
     )),
     createSandboxManager: vi.fn(),
+}));
+vi.mock('../../../clients/bitbucket/Bitbucket', async () => ({
+    ...(await vi.importActual<
+        typeof import('../../../clients/bitbucket/Bitbucket')
+    >('../../../clients/bitbucket/Bitbucket')),
+    getRepository: vi.fn().mockResolvedValue({
+        full_name: 'acme/bitbucket-analytics',
+        mainbranch: { name: 'main' },
+    }),
 }));
 vi.mock('../../../clients/github/Github', () => ({
     createBranch: vi.fn().mockResolvedValue(undefined),
@@ -105,6 +117,14 @@ const PRIMARY_SOURCE_UUID = 'primary-source-uuid';
 const PR_3 = 'https://github.com/acme/analytics/pull/3';
 const PR_7 = 'https://github.com/acme/analytics/pull/7';
 const PR_9 = 'https://github.com/acme/analytics/pull/9';
+const bitbucketConnection: DbtBitBucketProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'developer',
+    repository: 'acme/bitbucket-analytics',
+    branch: 'release/dbt',
+    project_sub_path: '/',
+    personal_access_token: 'project-bitbucket-token',
+};
 
 // The commit a provider lands this turn (SHA + line stat). open/update return
 // it so the card can pin CI and show the diff stat; no-change turns return nulls.
@@ -412,6 +432,37 @@ describe('AiWritebackService.prepareTurn', () => {
         });
         return prepared.kind === 'run' ? prepared.turn : prepared;
     };
+
+    it.each([undefined, '   '])(
+        'carries the selected project identity into a token-free Bitbucket turn connection with host %s',
+        async (host_domain) => {
+            const service = buildService({
+                featureFlagModel: {
+                    get: vi.fn().mockResolvedValue({ enabled: true }),
+                },
+                projectModel: {
+                    get: vi.fn().mockResolvedValue({
+                        ...githubProject(),
+                        dbtConnection: { ...bitbucketConnection, host_domain },
+                    }),
+                },
+            });
+            const turn = await prepareTurn(service, userWithOrg(true));
+            expect(turn.gitConnection).toMatchObject({
+                provider: PullRequestProvider.BITBUCKET,
+                projectUuid: 'p1',
+                projectDbtSourceUuid: null,
+                repo: 'bitbucket-analytics',
+                branch: 'release/dbt',
+            });
+            expect(JSON.stringify(turn.gitConnection)).not.toContain(
+                'project-bitbucket-token',
+            );
+            expect(turn.gitConnection).not.toHaveProperty(
+                'personal_access_token',
+            );
+        },
+    );
 
     it('rejects when the user cannot manage source code', async () => {
         const service = buildService({
@@ -836,6 +887,49 @@ describe('AiWritebackService dbt source targeting', () => {
             dbtSourceUuid: args.dbtSourceUuid,
             existingRow: args.existingRow ?? null,
         });
+
+    it.each([false, true])(
+        'selects an additional Cloud source, including a resumed binding (%s)',
+        async (resume) => {
+            const source = {
+                ...marketingSource(),
+                dbtConnection: bitbucketConnection,
+            };
+            const result = await resolve(serviceWithSources([source]), {
+                dbtSourceUuid: resume
+                    ? PRIMARY_SOURCE_UUID
+                    : source.projectDbtSourceUuid,
+                existingRow: resume
+                    ? { project_dbt_source_uuid: source.projectDbtSourceUuid }
+                    : null,
+            });
+            expect(result).toMatchObject({
+                kind: 'resolved',
+                candidate: {
+                    sourceUuid: 'src-marketing',
+                    connection: {
+                        type: DbtProjectType.BITBUCKET,
+                        branch: 'release/dbt',
+                    },
+                },
+            });
+        },
+    );
+
+    it('excludes Bitbucket Server sources from AI writeback choices', async () => {
+        const source = {
+            ...marketingSource(),
+            dbtConnection: {
+                ...bitbucketConnection,
+                host_domain: 'bitbucket.acme.com',
+            },
+        };
+        const result = await resolve(serviceWithSources([source]), {});
+        expect(result).toMatchObject({
+            kind: 'resolved',
+            candidate: { sourceUuid: null },
+        });
+    });
 
     it('targets the primary connection when the project has no additional sources', async () => {
         const result = await resolve(serviceWithSources([]), {
@@ -1393,6 +1487,186 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
             html_url: PR_7,
         });
     });
+
+    const bitbucketProjectModel = () => ({
+        get: vi.fn().mockResolvedValue({
+            organizationUuid: ORG,
+            name: 'Bitbucket analytics',
+            dbtConnection: {
+                ...bitbucketConnection,
+                personal_access_token: undefined,
+            },
+            warehouseConnection: null,
+            dbtVersion: SupportedDbtVersions.V1_9,
+        }),
+        getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG }),
+        getWithSensitiveFields: vi
+            .fn()
+            .mockResolvedValue({ dbtConnection: bitbucketConnection }),
+    });
+
+    it('clones the configured Bitbucket branch with the project token and creates no PR without changes', async () => {
+        const sandbox = fakeSandbox(0, false);
+        fakeSandboxProvider.create.mockResolvedValue(sandbox);
+        const result = await runService(
+            sandbox,
+            {},
+            { projectModel: bitbucketProjectModel() },
+        );
+        expect(sandbox.git.clone).toHaveBeenCalledWith(
+            'https://bitbucket.org/acme/bitbucket-analytics.git',
+            expect.objectContaining({
+                branch: 'release/dbt',
+                username: 'x-bitbucket-api-token-auth',
+                password: 'project-bitbucket-token',
+            }),
+        );
+        expect(sandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining(
+                '--disallowedTools "Read(//home/user/repo/.git/**),Grep(//home/user/repo/.git/**),Edit(//home/user/repo/.git/**),Write(//home/user/repo/.git/**)"',
+            ),
+            expect.anything(),
+        );
+        expect(result).toMatchObject({
+            prAction: null,
+            prUrl: null,
+            repository: 'acme/bitbucket-analytics',
+        });
+        expect(createPullRequest).not.toHaveBeenCalled();
+        expect(fakeSandboxProvider.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it('clones an adopted Bitbucket PR branch instead of the configured base', async () => {
+        const sandbox = fakeSandbox(0, false);
+        fakeSandboxProvider.create.mockResolvedValue(sandbox);
+        const prUrl =
+            'https://bitbucket.org/acme/bitbucket-analytics/pull-requests/9';
+        const adopt = vi
+            .spyOn(BitbucketProvider.prototype, 'adoptPullRequest')
+            .mockResolvedValue({
+                prUrl,
+                owner: 'acme',
+                repo: 'bitbucket-analytics',
+                pullNumber: 9,
+                headRef: 'feature/existing-change',
+            });
+        try {
+            const result = await runService(
+                sandbox,
+                { prUrl },
+                { projectModel: bitbucketProjectModel() },
+            );
+            expect(sandbox.git.clone).toHaveBeenCalledWith(
+                'https://bitbucket.org/acme/bitbucket-analytics.git',
+                expect.objectContaining({ branch: 'feature/existing-change' }),
+            );
+            expect(result.prUrl).toBe(prUrl);
+            expect(createPullRequest).not.toHaveBeenCalled();
+        } finally {
+            adopt.mockRestore();
+        }
+    });
+
+    it('destroys a resumed sandbox and removes its workstream if push credentials cannot be cleared', async () => {
+        const sandbox = fakeSandbox(0, true);
+        fakeSandboxProvider.connect.mockResolvedValue(sandbox);
+        const prUrl =
+            'https://bitbucket.org/acme/bitbucket-analytics/pull-requests/9';
+        const existingRow = {
+            ...threadRow(prUrl),
+            project_dbt_source_uuid: null,
+            target_repo: 'acme/bitbucket-analytics',
+        };
+        const deleteByUuid = vi.fn().mockResolvedValue(undefined);
+        const editState = vi
+            .spyOn(BitbucketProvider.prototype, 'getPullRequestEditState')
+            .mockResolvedValue({ editable: true, reason: null });
+        const update = vi
+            .spyOn(BitbucketProvider.prototype, 'updatePullRequest')
+            .mockRejectedValue(new WritebackCredentialCleanupError());
+        try {
+            await expect(
+                runService(
+                    sandbox,
+                    { aiThreadUuid: 'thread-1' },
+                    {
+                        projectModel: bitbucketProjectModel(),
+                        aiWritebackThreadModel: {
+                            findByAiThreadUuid: vi
+                                .fn()
+                                .mockResolvedValue(existingRow),
+                            findActiveWorkstreamByRepo: vi
+                                .fn()
+                                .mockResolvedValue(existingRow),
+                            acquireWorkstreamLock: vi.fn().mockResolvedValue({
+                                release: vi.fn().mockResolvedValue(undefined),
+                            }),
+                            deleteByUuid,
+                        },
+                        sandboxRegistryModel: {
+                            findBySandboxUuid: vi.fn().mockResolvedValue({
+                                providerSandboxId: 'sbx-1',
+                            }),
+                            markRunning: vi.fn().mockResolvedValue(undefined),
+                            deleteBySandboxUuid: vi
+                                .fn()
+                                .mockResolvedValue(undefined),
+                        },
+                    },
+                ),
+            ).rejects.toBeInstanceOf(WritebackCredentialCleanupError);
+            expect(update).toHaveBeenCalledTimes(1);
+            expect(deleteByUuid).toHaveBeenCalledWith('w-1');
+            expect(fakeSandboxProvider.destroy).toHaveBeenCalledWith('sbx-1');
+            expect(fakeSandboxProvider.persist).not.toHaveBeenCalled();
+            expect(sandbox.git.clone).not.toHaveBeenCalled();
+        } finally {
+            editState.mockRestore();
+            update.mockRestore();
+        }
+    });
+
+    it.each(['clone', 'cleanup'])(
+        'stops before running the agent and destroys the sandbox on Bitbucket %s failure',
+        async (failure) => {
+            const sandbox = fakeSandbox(0, false);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+            if (failure === 'clone') {
+                sandbox.git.clone.mockRejectedValue(
+                    new Error('secret project-bitbucket-token'),
+                );
+            } else {
+                sandbox.commands.run.mockRejectedValue(
+                    new Error('secret project-bitbucket-token'),
+                );
+            }
+            const result = runService(
+                sandbox,
+                {},
+                {
+                    projectModel: bitbucketProjectModel(),
+                    sandboxRegistryModel: {
+                        create: vi.fn().mockResolvedValue('sbx-uuid'),
+                        findBySandboxUuid: vi
+                            .fn()
+                            .mockResolvedValue({ providerSandboxId: 'sbx-1' }),
+                        deleteBySandboxUuid: vi
+                            .fn()
+                            .mockResolvedValue(undefined),
+                    },
+                },
+            );
+            await expect(result).rejects.toThrow(
+                failure === 'clone'
+                    ? 'Could not clone the Bitbucket repository'
+                    : 'Could not remove Bitbucket clone credentials',
+            );
+            await expect(result).rejects.not.toThrow('project-bitbucket-token');
+            expect(sandbox.files.write).not.toHaveBeenCalled();
+            expect(fakeSandboxProvider.destroy).toHaveBeenCalledTimes(1);
+            expect(createPullRequest).not.toHaveBeenCalled();
+        },
+    );
 
     it('opens a PR and kills the sandbox for a one-shot run with changes', async () => {
         const sandbox = fakeSandbox(0, true);
@@ -3160,6 +3434,71 @@ describe('AiWritebackService.closePullRequest (workstream provider)', () => {
             }),
         ).rejects.toThrow(ForbiddenError);
         expect(providerClose).not.toHaveBeenCalled();
+    });
+
+    it('closes a Bitbucket PR using its additional source token and never routes to GitHub', async () => {
+        const prUrl =
+            'https://bitbucket.org/acme/bitbucket-analytics/pull-requests/7';
+        const source = {
+            projectUuid: 'p1',
+            projectDbtSourceUuid: 'bb-source',
+            name: 'Bitbucket',
+            isPrimary: false,
+            precedence: 1,
+            dbtConnection: bitbucketConnection,
+        };
+        const service = buildService({
+            projectModel: {
+                get: vi.fn().mockResolvedValue(githubProject()),
+                getSummary: vi
+                    .fn()
+                    .mockResolvedValue({ organizationUuid: ORG }),
+            },
+            projectDbtSourcesModel: {
+                getSources: vi.fn().mockResolvedValue([source]),
+                getSource: vi.fn().mockResolvedValue(source),
+            },
+            aiWritebackThreadModel: {
+                findByAiThreadUuidAndPrUrl: vi.fn().mockResolvedValue({
+                    project_dbt_source_uuid: 'bb-source',
+                }),
+            },
+            pullRequestsModel: {
+                findByAiThreadUuidAndUrl: vi.fn().mockResolvedValue(
+                    recordedPr({
+                        provider: PullRequestProvider.BITBUCKET,
+                        repo: 'bitbucket-analytics',
+                        prUrl,
+                        prNumber: 7,
+                    }),
+                ),
+            },
+        });
+        const close = vi
+            .spyOn(service['bitbucketProvider'], 'closePullRequest')
+            .mockResolvedValue({ state: 'closed' });
+        const githubClose = vi.spyOn(
+            service['githubProvider'],
+            'closePullRequest',
+        );
+        const result = await service.closePullRequest({
+            user: userWithManage(),
+            projectUuid: 'p1',
+            aiThreadUuid: 'thread-1',
+            prUrl,
+        });
+        expect(result).toEqual({ state: 'closed' });
+        expect(close).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prUrl,
+                installation: expect.objectContaining({
+                    provider: PullRequestProvider.BITBUCKET,
+                    token: 'project-bitbucket-token',
+                    repo: 'bitbucket-analytics',
+                }),
+            }),
+        );
+        expect(githubClose).not.toHaveBeenCalled();
     });
 
     it('routes a recorded GitLab MR to the GitLab provider', async () => {

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -15,6 +15,7 @@ import {
     PullRequestSource,
     RequestMethod,
     SupportedDbtVersions,
+    UnexpectedServerError,
     WarehouseTypes,
     type AiWritebackDbtSourceOption,
     type AiWritebackPipelineJobPayload,
@@ -68,6 +69,7 @@ import type {
 } from '../../models/AiWritebackThreadModel';
 import type { SandboxRegistryModel } from '../../models/SandboxRegistryModel';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
+import { getWritebackConnectionSupport } from '../AiAgentService/writebackConnection';
 import {
     anthropicClaudeCodeAllowedHosts,
     buildAnthropicClaudeCodeEnv,
@@ -116,10 +118,12 @@ import {
 import { DeniedPathError } from './deniedPaths';
 import {
     RepoTooLargeError,
+    WritebackCredentialCleanupError,
     WritebackGitNotConnectedError,
     WritebackRunAbortedError,
     WritebackThreadPrClosedError,
 } from './errors';
+import { BitbucketProvider } from './providers/BitbucketProvider';
 import { GithubProvider } from './providers/GithubProvider';
 import { GitlabProvider } from './providers/GitlabProvider';
 import type { GitProvider } from './providers/GitProvider';
@@ -495,6 +499,8 @@ export class AiWritebackService extends BaseService {
 
     private readonly gitlabProvider: GitlabProvider;
 
+    private readonly bitbucketProvider: BitbucketProvider;
+
     private readonly githubAppService: GithubAppService;
 
     private readonly ciService: CiService;
@@ -546,6 +552,11 @@ export class AiWritebackService extends BaseService {
         this.githubProvider = new GithubProvider({
             githubAppInstallationsModel,
             githubAppService,
+            logger: this.logger,
+        });
+        this.bitbucketProvider = new BitbucketProvider({
+            projectModel,
+            projectDbtSourcesModel,
             logger: this.logger,
         });
         this.gitlabProvider = new GitlabProvider({
@@ -610,6 +621,53 @@ export class AiWritebackService extends BaseService {
         const project = await this.projectModel.get(projectUuid);
         this.assertCanManageSourceCode(user, project, projectUuid);
 
+        if (recorded.provider === PullRequestProvider.BITBUCKET) {
+            const workstream =
+                await this.aiWritebackThreadModel.findByAiThreadUuidAndPrUrl(
+                    aiThreadUuid,
+                    prUrl,
+                );
+            if (!workstream) {
+                throw new ForbiddenError(
+                    'Cannot resolve the Bitbucket source for this conversation',
+                );
+            }
+            const candidates = await this.listDbtTargetCandidates(
+                projectUuid,
+                project,
+            );
+            const source = candidates.find(
+                (candidate) =>
+                    candidate.sourceUuid === workstream.project_dbt_source_uuid,
+            );
+            if (
+                !source ||
+                source.connection.type !== DbtProjectType.BITBUCKET
+            ) {
+                throw new ForbiddenError(
+                    'The Bitbucket source for this conversation is no longer configured',
+                );
+            }
+            const connection = this.bitbucketProvider.resolveConnection(
+                source.connection,
+                {
+                    projectUuid,
+                    projectDbtSourceUuid: source.sourceUuid,
+                },
+            );
+            const installation =
+                await this.bitbucketProvider.resolveInstallation(
+                    project.organizationUuid,
+                    { user, connection },
+                );
+            return this.bitbucketProvider.closePullRequest({
+                prUrl: recorded.prUrl,
+                owner: recorded.owner,
+                repo: recorded.repo,
+                pullNumber: recorded.prNumber,
+                installation,
+            });
+        }
         const provider =
             recorded.provider === PullRequestProvider.GITLAB
                 ? this.gitlabProvider
@@ -794,9 +852,12 @@ export class AiWritebackService extends BaseService {
         if (connectionType === DbtProjectType.GITLAB) {
             return this.gitlabProvider;
         }
+        if (connectionType === DbtProjectType.BITBUCKET) {
+            return this.bitbucketProvider;
+        }
         throw new WritebackGitNotConnectedError(
             null,
-            `AI writeback requires a GitHub or GitLab dbt connection, but this project uses "${connectionType}"`,
+            `AI writeback requires a GitHub, GitLab or Bitbucket Cloud dbt connection, but this project uses "${connectionType}"`,
         );
     }
 
@@ -1443,6 +1504,7 @@ export class AiWritebackService extends BaseService {
                     ),
                     'github.com',
                     'gitlab.com',
+                    'bitbucket.org',
                 ],
             },
         };
@@ -2294,11 +2356,19 @@ export class AiWritebackService extends BaseService {
                     cloneInstallation,
                 ),
                 existingRow: turn.existingRow,
-                adoptBranch: adoptedPr?.headRef ?? null,
+                adoptBranch:
+                    adoptedPr?.headRef ??
+                    (turn.gitConnection.provider ===
+                    PullRequestProvider.BITBUCKET
+                        ? turn.gitConnection.branch || null
+                        : null),
                 setStage,
                 templateRef: config.resolveTemplateRef(),
                 cloneExtraOptions: config.cloneExtraOptions,
                 onAfterClone,
+                strictCredentialCleanup:
+                    turn.gitConnection.provider ===
+                    PullRequestProvider.BITBUCKET,
             }));
 
             setStage('agent');
@@ -2450,6 +2520,14 @@ export class AiWritebackService extends BaseService {
                 dbtSourceUuid: turn.projectDbtSourceUuid,
             };
         } catch (error) {
+            if (error instanceof WritebackCredentialCleanupError) {
+                pauseOnExit = false;
+                if (turn.existingRow) {
+                    await this.aiWritebackThreadModel.deleteByUuid(
+                        turn.existingRow.ai_writeback_thread_uuid,
+                    );
+                }
+            }
             // A deliberate abort of an already-terminal run is not a failure:
             // keep it out of Sentry, error metrics, and failure analytics.
             if (error instanceof WritebackRunAbortedError) {
@@ -2690,6 +2768,10 @@ export class AiWritebackService extends BaseService {
             provider = this.getGitProvider(dbtTarget.candidate.connection.type);
             gitConnection = provider.resolveConnection(
                 dbtTarget.candidate.connection,
+                {
+                    projectUuid,
+                    projectDbtSourceUuid: dbtTarget.candidate.sourceUuid,
+                },
             );
             projectDbtSourceUuid = dbtTarget.candidate.sourceUuid;
             warehouseType = project.warehouseConnection?.type ?? null;
@@ -2823,7 +2905,7 @@ export class AiWritebackService extends BaseService {
             this.projectDbtSourcesModel.getSources(projectUuid),
         ]);
         const primary: DbtTargetCandidate | null =
-            AiWritebackService.isWritebackTargetable(project.dbtConnection.type)
+            AiWritebackService.isWritebackTargetable(project.dbtConnection)
                 ? {
                       sourceUuid: null,
                       optionUuid: identity.dbtSourceUuid,
@@ -2834,9 +2916,7 @@ export class AiWritebackService extends BaseService {
                 : null;
         const extra = additional.flatMap<DbtTargetCandidate>((dbtSource) =>
             dbtSource.dbtConnection &&
-            AiWritebackService.isWritebackTargetable(
-                dbtSource.dbtConnection.type,
-            )
+            AiWritebackService.isWritebackTargetable(dbtSource.dbtConnection)
                 ? [
                       {
                           sourceUuid: dbtSource.projectDbtSourceUuid,
@@ -2907,7 +2987,7 @@ export class AiWritebackService extends BaseService {
         if (candidates.length === 0) {
             throw new WritebackGitNotConnectedError(
                 null,
-                `AI writeback requires a GitHub or GitLab dbt source, but this project ("${project.dbtConnection.type}") has none`,
+                `AI writeback requires a GitHub, GitLab or Bitbucket Cloud dbt source, but this project ("${project.dbtConnection.type}") has none`,
             );
         }
 
@@ -2974,9 +3054,10 @@ export class AiWritebackService extends BaseService {
         };
     }
 
-    private static isWritebackTargetable(type: DbtProjectType): boolean {
-        // Mirrors getGitProvider: only GitHub and GitLab can have a PR opened.
-        return type === DbtProjectType.GITHUB || type === DbtProjectType.GITLAB;
+    private static isWritebackTargetable(
+        connection: DbtProjectConfig,
+    ): boolean {
+        return getWritebackConnectionSupport(connection).editDbtProject;
     }
 
     /** Git identity safe to surface (repo/branch/subpath); nulls for non-git. */
@@ -3433,6 +3514,7 @@ export class AiWritebackService extends BaseService {
         templateRef,
         cloneExtraOptions,
         onAfterClone,
+        strictCredentialCleanup = false,
     }: {
         organizationUuid: string;
         projectUuid: string;
@@ -3444,6 +3526,7 @@ export class AiWritebackService extends BaseService {
         cloneExtraOptions: Record<string, unknown>;
         /** Run after a fresh clone + .git scrub (e.g. revoke the scoped token). */
         onAfterClone?: () => Promise<void>;
+        strictCredentialCleanup?: boolean;
     }): Promise<{ sandbox: SandboxHandle; sandboxUuid: string }> {
         setStage('sandbox');
 
@@ -3489,15 +3572,25 @@ export class AiWritebackService extends BaseService {
         // tip to branch off) and `timeoutMs` overrides the E2B SDK's 60s
         // default, which a slow clone was exceeding with `deadline_exceeded`.
         const cloneStartedAt = Date.now();
-        await sandbox.git.clone(cloneTarget.url, {
-            path: CWD,
-            username: cloneTarget.username,
-            password: cloneTarget.password,
-            depth: 1,
-            timeoutMs: GIT_TIMEOUT_MS,
-            ...cloneExtraOptions,
-            ...(adoptBranch ? { branch: adoptBranch } : {}),
-        });
+        try {
+            await sandbox.git.clone(cloneTarget.url, {
+                path: CWD,
+                username: cloneTarget.username,
+                password: cloneTarget.password,
+                depth: 1,
+                timeoutMs: GIT_TIMEOUT_MS,
+                ...cloneExtraOptions,
+                ...(adoptBranch ? { branch: adoptBranch } : {}),
+            });
+        } catch (error) {
+            if (strictCredentialCleanup) {
+                await this.getSandboxManager().destroy({ sandboxUuid });
+                throw new ParameterError(
+                    'Could not clone the Bitbucket repository. Check the project API token, repository access and configured branch.',
+                );
+            }
+            throw error;
+        }
         this.logger.info(
             `AiWriteback: repo cloned (sandboxId=${sandbox.sandboxId}, ${
                 Date.now() - cloneStartedAt
@@ -3509,17 +3602,31 @@ export class AiWritebackService extends BaseService {
         // over the working tree — can't lift the token out of `.git/config` and
         // exfiltrate it via the PR (R4). The host commits via the API / explicit
         // push creds, so a credential-free remote URL is all the sandbox needs.
-        try {
-            await sandbox.commands.run(
-                `git -C ${CWD} remote set-url origin ${cloneTarget.url} && ` +
-                    `git -C ${CWD} config --remove-section credential 2>/dev/null; true`,
-            );
-        } catch (error) {
-            this.logger.warn(
-                `AiWriteback: failed to scrub clone credentials from .git (sandboxId=${sandbox.sandboxId}): ${getErrorMessage(
-                    error,
-                )}`,
-            );
+        if (strictCredentialCleanup) {
+            try {
+                await sandbox.commands.run(
+                    `git -C ${CWD} remote set-url origin ${quoteShellArgument(cloneTarget.url)} && ` +
+                        `if git -C ${CWD} config --local --get-regexp '^credential\\.' >/dev/null; then git -C ${CWD} config --local --remove-section credential; fi`,
+                );
+            } catch {
+                await this.getSandboxManager().destroy({ sandboxUuid });
+                throw new UnexpectedServerError(
+                    'Could not remove Bitbucket clone credentials from the sandbox',
+                );
+            }
+        } else {
+            try {
+                await sandbox.commands.run(
+                    `git -C ${CWD} remote set-url origin ${cloneTarget.url} && ` +
+                        `git -C ${CWD} config --remove-section credential 2>/dev/null; true`,
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `AiWriteback: failed to scrub clone credentials from .git (sandboxId=${sandbox.sandboxId}): ${getErrorMessage(
+                        error,
+                    )}`,
+                );
+            }
         }
 
         // Revoke the scoped clone token now the checkout exists (general agent).
@@ -4184,6 +4291,13 @@ export class AiWritebackService extends BaseService {
                     systemPrompt,
                     repoContext,
                     allowedTools: ALLOWED_TOOLS,
+                    disallowedTools:
+                        turn.gitConnection.provider ===
+                        PullRequestProvider.BITBUCKET
+                            ? ['Read', 'Grep', 'Edit', 'Write']
+                                  .map((tool) => `${tool}(/${CWD}/.git/**)`)
+                                  .join(',')
+                            : undefined,
                     addDirs: ['/tmp', SKILLS_DIR, CLAUDE_SKILLS_DIR],
                     model: CLAUDE_MODEL,
                 };

--- a/packages/backend/src/ee/services/AiWritebackService/errors.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/errors.ts
@@ -2,25 +2,16 @@ import {
     ForbiddenError,
     ParameterError,
     PullRequestProvider,
+    UnexpectedGitError,
 } from '@lightdash/common';
 
-/**
- * Thrown when a writeback cannot proceed because the project has no usable Git
- * connection — either the organization has not installed the GitHub/GitLab app,
- * or the project's dbt connection is not a GitHub/GitLab type. The `editDbtProject`
- * tool catches this specifically (via `instanceof`) and tags its result metadata
- * with a provider-specific `errorCode`, so the chat UI can render an actionable
- * "install the app" state instead of a generic failure.
- *
- * `provider` is the git host the project expects (GitHub/GitLab) when that is
- * known, or null when the project's dbt connection is not a Git type at all.
- */
+/** A missing Git app or project token needs provider-specific setup guidance. */
 export class WritebackGitNotConnectedError extends ForbiddenError {
     readonly provider: PullRequestProvider | null;
 
     constructor(
         provider: PullRequestProvider | null = null,
-        message = 'This project is not connected to a GitHub or GitLab repository',
+        message = 'This project is not connected to a supported Git repository',
     ) {
         super(message);
         this.provider = provider;
@@ -75,5 +66,12 @@ export class WritebackRunAbortedError extends Error {
         );
         this.name = 'WritebackRunAbortedError';
         this.runStatus = runStatus;
+    }
+}
+
+/** A sandbox with unremoved Git credentials must never be resumed. */
+export class WritebackCredentialCleanupError extends UnexpectedGitError {
+    constructor() {
+        super('Could not clear Bitbucket sandbox credentials');
     }
 }

--- a/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.test.ts
@@ -1,0 +1,629 @@
+import { Ability } from '@casl/ability';
+import {
+    DbtProjectType,
+    ForbiddenError,
+    ParameterError,
+    PullRequestProvider,
+    PullRequestState,
+    type DbtBitBucketProjectConfig,
+    type PossibleAbilities,
+    type SessionUser,
+} from '@lightdash/common';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as BitbucketClient from '../../../../clients/bitbucket/Bitbucket';
+import type { ProjectDbtSourcesModel } from '../../../../models/ProjectDbtSourcesModel';
+import type { ProjectModel } from '../../../../models/ProjectModel/ProjectModel';
+import type { SandboxHandle } from '../../SandboxRuntime';
+import { CWD } from '../constants';
+import { DeniedPathError } from '../deniedPaths';
+import {
+    WritebackCredentialCleanupError,
+    WritebackGitNotConnectedError,
+} from '../errors';
+import type { BitbucketConnection, BitbucketInstallation } from '../types';
+import { quoteShellArgument } from '../utils';
+import { BitbucketProvider } from './BitbucketProvider';
+
+const config: DbtBitBucketProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'developer',
+    repository: 'workspace/analytics',
+    personal_access_token: 'project-token',
+    branch: 'main',
+    project_sub_path: '.',
+};
+const connection: BitbucketConnection = {
+    provider: PullRequestProvider.BITBUCKET,
+    owner: 'workspace',
+    repo: 'analytics',
+    projectSubPath: '.',
+    branch: 'main',
+    username: 'developer',
+    projectUuid: 'project',
+    projectDbtSourceUuid: null,
+};
+const installation: BitbucketInstallation = {
+    provider: PullRequestProvider.BITBUCKET,
+    owner: 'workspace',
+    repo: 'analytics',
+    token: 'project-token',
+    commitAuthor: { name: 'Lightdash', email: 'support@lightdash.com' },
+};
+const prUrl = 'https://bitbucket.org/workspace/analytics/pull-requests/42';
+const pullRequest: BitbucketClient.BitbucketPullRequest = {
+    number: 42,
+    title: 'Add metric',
+    html_url: prUrl,
+    state: PullRequestState.OPEN,
+    head: 'feature/metric',
+    base: 'main',
+    sourceRepository: 'workspace/analytics',
+    destinationRepository: 'workspace/analytics',
+};
+const user = {
+    userUuid: 'user',
+    organizationUuid: 'organization',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+            },
+        },
+    ]),
+} as SessionUser;
+
+const setup = () => {
+    vi.spyOn(BitbucketClient, 'getRepository').mockResolvedValue({
+        full_name: 'workspace/analytics',
+        mainbranch: { name: 'main' },
+    });
+    const projectModel = {
+        getSummary: vi
+            .fn()
+            .mockResolvedValue({ organizationUuid: 'organization' }),
+        getWithSensitiveFields: vi
+            .fn()
+            .mockResolvedValue({ dbtConnection: config }),
+    };
+    const projectDbtSourcesModel = {
+        getSource: vi.fn().mockResolvedValue({
+            projectUuid: 'project',
+            dbtConnection: config,
+        }),
+    };
+    const provider = new BitbucketProvider({
+        projectModel: projectModel as unknown as ProjectModel,
+        projectDbtSourcesModel:
+            projectDbtSourcesModel as unknown as ProjectDbtSourcesModel,
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as never,
+    });
+    return { provider, projectModel, projectDbtSourcesModel };
+};
+const sandboxFixture = () => ({
+    sandboxId: 'sandbox',
+    git: {
+        status: vi.fn().mockResolvedValue({ currentBranch: 'main' }),
+        createBranch: vi.fn().mockResolvedValue(undefined),
+        add: vi.fn().mockResolvedValue(undefined),
+        commit: vi.fn().mockResolvedValue(undefined),
+        push: vi.fn().mockResolvedValue(undefined),
+    },
+    commands: {
+        run: vi.fn(async (command: string) => {
+            if (command.includes('rev-parse')) {
+                return { exitCode: 0, stdout: 'commit-sha\n' };
+            }
+            if (command.includes('--numstat')) {
+                return { exitCode: 0, stdout: '2\t1\tmodels/orders.yml\n' };
+            }
+            return { exitCode: 0, stdout: '' };
+        }),
+    },
+});
+const writeArgs = (sandbox: ReturnType<typeof sandboxFixture>) => ({
+    connection,
+    installation,
+    user,
+    sandbox: sandbox as unknown as SandboxHandle,
+    title: 'Add metric',
+    description: 'Adds revenue.',
+    setStage: vi.fn(),
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('Bitbucket project authentication', () => {
+    it('resolves sanitized connection identity without carrying a token', () => {
+        const { provider } = setup();
+        expect(
+            provider.resolveConnection(
+                { ...config, personal_access_token: '' },
+                {
+                    projectUuid: 'project',
+                    projectDbtSourceUuid: null,
+                },
+            ),
+        ).toEqual(connection);
+    });
+
+    it.each([
+        ['/', '.'],
+        ['/dbt/', 'dbt'],
+    ])('normalizes dbt subpath %s to %s', (project_sub_path, expected) => {
+        expect(
+            setup().provider.resolveConnection(
+                { ...config, project_sub_path },
+                {
+                    projectUuid: 'project',
+                    projectDbtSourceUuid: null,
+                },
+            ).projectSubPath,
+        ).toBe(expected);
+    });
+
+    it('allows a custom role limited to feature-branch SourceCode management', async () => {
+        const limitedUser = {
+            ...user,
+            ability: new Ability<PossibleAbilities>([
+                {
+                    action: 'manage',
+                    subject: 'SourceCode',
+                    conditions: {
+                        organizationUuid: 'organization',
+                        projectUuid: 'project',
+                        isProtectedBranch: false,
+                    },
+                },
+            ]),
+        };
+        await expect(
+            setup().provider.resolveInstallation('organization', {
+                user: limitedUser,
+                connection,
+            }),
+        ).resolves.toMatchObject({ token: 'project-token' });
+    });
+
+    it.each(['bitbucket.example.com', 'bitbucket.org.evil.test'])(
+        'rejects unsupported host %s before resolving credentials',
+        (host_domain) => {
+            expect(() =>
+                setup().provider.resolveConnection(
+                    { ...config, host_domain },
+                    {
+                        projectUuid: 'project',
+                        projectDbtSourceUuid: null,
+                    },
+                ),
+            ).toThrow(ParameterError);
+        },
+    );
+
+    it('resolves the current token for the authorized project', async () => {
+        const { provider } = setup();
+        expect(
+            await provider.resolveInstallation('organization', {
+                user,
+                connection,
+            }),
+        ).toMatchObject({
+            provider: PullRequestProvider.BITBUCKET,
+            token: 'project-token',
+            owner: 'workspace',
+            repo: 'analytics',
+        });
+    });
+
+    it('reports provider-denied token access as a Bitbucket configuration error', async () => {
+        const { provider } = setup();
+        vi.mocked(BitbucketClient.getRepository).mockRejectedValue(
+            new ForbiddenError('Private provider details'),
+        );
+        await expect(
+            provider.resolveInstallation('organization', { user, connection }),
+        ).rejects.toMatchObject({
+            provider: PullRequestProvider.BITBUCKET,
+            message:
+                'The Bitbucket API token is invalid, expired or lacks repository access. Update the token in the project connection.',
+        });
+    });
+
+    it('denies another organization before loading secrets', async () => {
+        const { provider, projectModel } = setup();
+        projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'other-organization',
+        });
+        await expect(
+            provider.resolveInstallation('organization', { user, connection }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+    });
+
+    it('requires manage SourceCode before loading secrets', async () => {
+        const { provider, projectModel } = setup();
+        await expect(
+            provider.resolveInstallation('organization', {
+                user: { ...user, ability: new Ability<PossibleAbilities>([]) },
+                connection,
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        { repository: 'workspace/other' },
+        { username: 'other-user' },
+        { host_domain: 'other.example.com' },
+    ])('rejects changed connection identity %j', async (change) => {
+        const { provider, projectModel } = setup();
+        projectModel.getWithSensitiveFields.mockResolvedValue({
+            dbtConnection: { ...config, ...change },
+        });
+        await expect(
+            provider.resolveInstallation('organization', { user, connection }),
+        ).rejects.toThrow();
+    });
+
+    it('reports a missing project token as a Bitbucket configuration error', async () => {
+        const { provider, projectModel } = setup();
+        projectModel.getWithSensitiveFields.mockResolvedValue({
+            dbtConnection: { ...config, personal_access_token: '' },
+        });
+        await expect(
+            provider.resolveInstallation('organization', { user, connection }),
+        ).rejects.toBeInstanceOf(WritebackGitNotConnectedError);
+    });
+
+    it('resolves an additional source and rejects a source from another project', async () => {
+        const { provider, projectModel, projectDbtSourcesModel } = setup();
+        const options = {
+            user,
+            connection: { ...connection, projectDbtSourceUuid: 'source' },
+        };
+        await expect(
+            provider.resolveInstallation('organization', options),
+        ).resolves.toMatchObject({ token: 'project-token' });
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+        projectDbtSourcesModel.getSource.mockResolvedValue({
+            projectUuid: 'other-project',
+            dbtConnection: config,
+        });
+        await expect(
+            provider.resolveInstallation('organization', options),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+
+    it('builds a credential-free clone URL and rejects another repository installation', () => {
+        const { provider } = setup();
+        expect(provider.getCloneTarget(connection, installation)).toEqual({
+            url: 'https://bitbucket.org/workspace/analytics.git',
+            username: 'x-bitbucket-api-token-auth',
+            password: 'project-token',
+        });
+        expect(() =>
+            provider.getCloneTarget(connection, {
+                ...installation,
+                repo: 'other',
+            }),
+        ).toThrow(ForbiddenError);
+    });
+});
+
+describe('Bitbucket PR lifecycle', () => {
+    it.each([
+        'https://evil.test/workspace/analytics/pull-requests/42',
+        'http://bitbucket.org/workspace/analytics/pull-requests/42',
+        'https://bitbucket.org/other/analytics/pull-requests/42',
+        'https://user:token@bitbucket.org/workspace/analytics/pull-requests/42',
+        'https://bitbucket.org/workspace/analytics/pull-requests/0',
+    ])('rejects invalid or unrelated URL %s before API calls', async (url) => {
+        const get = vi.spyOn(BitbucketClient, 'getPullRequest');
+        await expect(
+            setup().provider.adoptPullRequest({
+                prUrl: url,
+                connection,
+                installation,
+            }),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it('adopts a same-repository open PR', async () => {
+        vi.spyOn(BitbucketClient, 'getPullRequest').mockResolvedValue(
+            pullRequest,
+        );
+        await expect(
+            setup().provider.adoptPullRequest({
+                prUrl,
+                connection,
+                installation,
+            }),
+        ).resolves.toEqual({
+            prUrl,
+            owner: 'workspace',
+            repo: 'analytics',
+            pullNumber: 42,
+            headRef: 'feature/metric',
+        });
+    });
+
+    it.each([
+        { sourceRepository: 'fork/analytics' },
+        { destinationRepository: 'other/analytics' },
+        { sourceRepository: null },
+        { destinationRepository: undefined },
+    ])('rejects fork or missing repository identity %j', async (change) => {
+        vi.spyOn(BitbucketClient, 'getPullRequest').mockResolvedValue({
+            ...pullRequest,
+            ...change,
+        });
+        await expect(
+            setup().provider.adoptPullRequest({
+                prUrl,
+                connection,
+                installation,
+            }),
+        ).rejects.toThrow(/fork/);
+    });
+
+    it.each([PullRequestState.MERGED, PullRequestState.CLOSED])(
+        'reports %s as uneditable and refuses adoption',
+        async (state) => {
+            vi.spyOn(BitbucketClient, 'getPullRequest').mockResolvedValue({
+                ...pullRequest,
+                state,
+            });
+            const { provider } = setup();
+            await expect(
+                provider.getPullRequestEditState({
+                    prUrl,
+                    connection,
+                    installation,
+                }),
+            ).resolves.toEqual({ editable: false, reason: state });
+            await expect(
+                provider.adoptPullRequest({ prUrl, connection, installation }),
+            ).rejects.toThrow(state);
+        },
+    );
+
+    it('pushes a fresh branch, returns commit stats and credits the user', async () => {
+        const create = vi
+            .spyOn(BitbucketClient, 'createPullRequest')
+            .mockResolvedValue(pullRequest);
+        const sandbox = sandboxFixture();
+        await expect(
+            setup().provider.openPullRequest(writeArgs(sandbox)),
+        ).resolves.toEqual({
+            prUrl,
+            commitSha: 'commit-sha',
+            additions: 2,
+            deletions: 1,
+        });
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                base: 'main',
+                head: expect.stringMatching(/^lightdash-ai-writeback\//),
+            }),
+        );
+        expect(sandbox.git.push).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                remote: 'origin',
+                username: 'x-bitbucket-api-token-auth',
+                password: 'project-token',
+            }),
+        );
+        expect(sandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining(
+                "remote set-url origin 'https://bitbucket.org/workspace/analytics.git'",
+            ),
+        );
+        expect(sandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining('--unset-all remote.origin.pushurl'),
+        );
+        expect(sandbox.git.commit).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.stringContaining(
+                'Co-authored-by: Jane Doe <jane@example.com>',
+            ),
+            expect.anything(),
+        );
+        expect(sandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining('--remove-section credential'),
+        );
+    });
+
+    it.each(['bitbucket-pipelines.yml', '.github/workflows/deploy.yml'])(
+        'refuses denied path %s before committing or pushing',
+        async (path) => {
+            const sandbox = sandboxFixture();
+            sandbox.commands.run.mockImplementation(async (command) => ({
+                exitCode: 0,
+                stdout: command.includes('--name-status')
+                    ? `A\u0000${path}\u0000`
+                    : '',
+            }));
+            const create = vi.spyOn(BitbucketClient, 'createPullRequest');
+            await expect(
+                setup().provider.openPullRequest(writeArgs(sandbox)),
+            ).rejects.toBeInstanceOf(DeniedPathError);
+            expect(sandbox.git.commit).not.toHaveBeenCalled();
+            expect(sandbox.git.push).not.toHaveBeenCalled();
+            expect(create).not.toHaveBeenCalled();
+        },
+    );
+
+    it('replaces a tampered Git push URL and disables hooks before authenticated push', async () => {
+        const directory = mkdtempSync(join(tmpdir(), 'bitbucket-provider-'));
+        try {
+            const git = (...args: string[]) =>
+                execFileSync('git', ['-C', directory, ...args], {
+                    encoding: 'utf8',
+                }).trim();
+            git('init', '-q');
+            git('remote', 'add', 'origin', 'https://evil.test/repo.git');
+            git(
+                'config',
+                '--local',
+                'remote.origin.pushurl',
+                'https://evil.test/push.git',
+            );
+            git('config', '--local', 'core.hooksPath', '/tmp/unsafe-hooks');
+            git('config', '--local', 'credential.helper', 'unsafe-helper');
+            const sandbox = sandboxFixture();
+            sandbox.commands.run.mockImplementation(async (command) => {
+                if (
+                    command.includes(' config ') ||
+                    command.includes(' remote set-url ')
+                ) {
+                    execFileSync('sh', [
+                        '-c',
+                        command.replaceAll(CWD, quoteShellArgument(directory)),
+                    ]);
+                }
+                return {
+                    exitCode: 0,
+                    stdout: command.includes('rev-parse') ? 'commit-sha' : '',
+                };
+            });
+            sandbox.git.push.mockImplementation(async () => {
+                expect(git('remote', 'get-url', '--push', 'origin')).toBe(
+                    'https://bitbucket.org/workspace/analytics.git',
+                );
+                expect(git('config', '--local', 'core.hooksPath')).toBe(
+                    '/dev/null',
+                );
+                expect(() =>
+                    git('config', '--local', '--get-all', 'credential.helper'),
+                ).toThrow();
+            });
+            vi.spyOn(BitbucketClient, 'createPullRequest').mockResolvedValue(
+                pullRequest,
+            );
+            await setup().provider.openPullRequest(writeArgs(sandbox));
+            expect(sandbox.git.push).toHaveBeenCalledTimes(1);
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    });
+
+    it('cleans up credentials and sanitizes a failed push', async () => {
+        const sandbox = sandboxFixture();
+        sandbox.git.push.mockRejectedValue(new Error('project-token'));
+        await expect(
+            setup().provider.openPullRequest(writeArgs(sandbox)),
+        ).rejects.toThrow('Could not push the Bitbucket writeback branch');
+        expect(sandbox.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining('--remove-section credential'),
+        );
+    });
+
+    it('fails safely when the sandbox cannot remove persisted credentials', async () => {
+        const sandbox = sandboxFixture();
+        sandbox.commands.run.mockImplementation(async (command) => ({
+            exitCode: command.includes('--remove-section credential') ? 1 : 0,
+            stdout: '',
+        }));
+        const create = vi.spyOn(BitbucketClient, 'createPullRequest');
+        await expect(
+            setup().provider.openPullRequest(writeArgs(sandbox)),
+        ).rejects.toBeInstanceOf(WritebackCredentialCleanupError);
+        expect(create).not.toHaveBeenCalled();
+    });
+
+    it('refuses to update a PR that merged before the resumed turn', async () => {
+        vi.spyOn(BitbucketClient, 'getPullRequest').mockResolvedValue({
+            ...pullRequest,
+            state: PullRequestState.MERGED,
+        });
+        const sandbox = sandboxFixture();
+        await expect(
+            setup().provider.updatePullRequest({
+                ...writeArgs(sandbox),
+                prUrl,
+            }),
+        ).rejects.toThrow(/merged/);
+        expect(sandbox.git.commit).not.toHaveBeenCalled();
+        expect(sandbox.git.push).not.toHaveBeenCalled();
+    });
+
+    it('updates only the live PR branch and refreshes metadata', async () => {
+        vi.spyOn(BitbucketClient, 'getPullRequest').mockResolvedValue(
+            pullRequest,
+        );
+        const update = vi
+            .spyOn(BitbucketClient, 'updatePullRequest')
+            .mockResolvedValue(pullRequest);
+        const sandbox = sandboxFixture();
+        sandbox.git.status.mockResolvedValue({
+            currentBranch: pullRequest.head,
+        });
+        await expect(
+            setup().provider.updatePullRequest({
+                ...writeArgs(sandbox),
+                prUrl,
+            }),
+        ).resolves.toMatchObject({ commitSha: 'commit-sha' });
+        expect(update).toHaveBeenCalledWith(
+            expect.objectContaining({ pullNumber: 42, title: 'Add metric' }),
+        );
+        sandbox.git.status.mockResolvedValue({ currentBranch: 'main' });
+        sandbox.git.push.mockClear();
+        await expect(
+            setup().provider.updatePullRequest({
+                ...writeArgs(sandbox),
+                prUrl,
+            }),
+        ).rejects.toThrow(/not on/);
+        expect(sandbox.git.push).not.toHaveBeenCalled();
+    });
+
+    it('declines an open PR, treats already closed as idempotent and refuses merged PRs', async () => {
+        const get = vi
+            .spyOn(BitbucketClient, 'getPullRequest')
+            .mockResolvedValue(pullRequest);
+        const decline = vi
+            .spyOn(BitbucketClient, 'declinePullRequest')
+            .mockResolvedValue({
+                ...pullRequest,
+                state: PullRequestState.CLOSED,
+            });
+        const { provider } = setup();
+        const args = {
+            prUrl,
+            owner: 'workspace',
+            repo: 'analytics',
+            pullNumber: 42,
+            installation,
+        };
+        await expect(provider.closePullRequest(args)).resolves.toEqual({
+            state: 'closed',
+        });
+        get.mockResolvedValue({
+            ...pullRequest,
+            state: PullRequestState.CLOSED,
+        });
+        await expect(provider.closePullRequest(args)).resolves.toEqual({
+            state: 'closed',
+        });
+        expect(decline).toHaveBeenCalledTimes(1);
+        get.mockResolvedValue({
+            ...pullRequest,
+            state: PullRequestState.MERGED,
+        });
+        await expect(provider.closePullRequest(args)).rejects.toThrow(/merged/);
+        await expect(
+            provider.closePullRequest({ ...args, owner: 'other' }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+    });
+});

--- a/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.ts
@@ -1,0 +1,496 @@
+/* eslint-disable class-methods-use-this */
+import { subject } from '@casl/ability';
+import {
+    DbtProjectType,
+    ForbiddenError,
+    ParameterError,
+    PullRequestProvider,
+    PullRequestState,
+    UnexpectedGitError,
+    type ClosePullRequestResult,
+    type DbtProjectConfig,
+    type SessionUser,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import type { Logger } from 'winston';
+import * as BitbucketClient from '../../../../clients/bitbucket/Bitbucket';
+import type { ProjectDbtSourcesModel } from '../../../../models/ProjectDbtSourcesModel';
+import type { ProjectModel } from '../../../../models/ProjectModel/ProjectModel';
+import { BaseService } from '../../../../services/BaseService';
+import { COMMIT_AUTHOR_EMAIL, COMMIT_AUTHOR_NAME, CWD } from '../constants';
+import {
+    WritebackCredentialCleanupError,
+    WritebackGitNotConnectedError,
+} from '../errors';
+import type {
+    AdoptedPullRequest,
+    BitbucketConnection,
+    BitbucketInstallation,
+    CloneTarget,
+    GitConnection,
+    GitInstallation,
+} from '../types';
+import {
+    buildUserCoAuthorTrailer,
+    normalizeProjectSubPath,
+    quoteShellArgument,
+} from '../utils';
+import type {
+    AdoptPullRequestArgs,
+    ClosePullRequestArgs,
+    GitProvider,
+    LandedCommit,
+    OpenPullRequestArgs,
+    UpdatePullRequestArgs,
+} from './GitProvider';
+import {
+    assertStagedPathsAllowed,
+    collectDiffStat,
+    commitLocal,
+    resolveDbtProjectPaths,
+    stageChanges,
+} from './sandboxGit';
+
+const asConnection = (connection: GitConnection): BitbucketConnection => {
+    if (connection.provider !== PullRequestProvider.BITBUCKET) {
+        throw new ParameterError('Expected a Bitbucket connection');
+    }
+    return connection;
+};
+
+const asInstallation = (
+    installation: GitInstallation,
+): BitbucketInstallation => {
+    if (installation.provider !== PullRequestProvider.BITBUCKET) {
+        throw new ParameterError('Expected Bitbucket credentials');
+    }
+    return installation;
+};
+
+const assertRepository = (
+    repository: { owner: string; repo: string },
+    installation: BitbucketInstallation,
+): void => {
+    if (
+        repository.owner !== installation.owner ||
+        repository.repo !== installation.repo
+    ) {
+        throw new ForbiddenError(
+            'Bitbucket credentials do not match the selected repository',
+        );
+    }
+};
+
+const parsePullRequest = (
+    prUrl: string,
+    repository: { owner: string; repo: string },
+): number => {
+    let url: URL;
+    try {
+        url = new URL(prUrl);
+    } catch {
+        throw new ParameterError('Invalid Bitbucket pull request URL');
+    }
+    const prefix = `/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.repo)}/pull-requests/`;
+    const suffix = url.pathname.startsWith(prefix)
+        ? url.pathname.slice(prefix.length)
+        : '';
+    if (
+        url.protocol !== 'https:' ||
+        url.host !== 'bitbucket.org' ||
+        url.username ||
+        url.password ||
+        url.search ||
+        url.hash ||
+        !/^[1-9][0-9]*\/?$/.test(suffix)
+    ) {
+        throw new ParameterError(
+            'Only Bitbucket Cloud pull requests in the selected repository can be edited',
+        );
+    }
+    const number = Number(suffix.replace(/\/$/, ''));
+    if (!Number.isSafeInteger(number)) {
+        throw new ParameterError('Invalid Bitbucket pull request number');
+    }
+    return number;
+};
+
+const assertPullRequestRepository = (
+    pullRequest: BitbucketClient.BitbucketPullRequest,
+    installation: BitbucketInstallation,
+): void => {
+    const repository =
+        `${installation.owner}/${installation.repo}`.toLowerCase();
+    if (
+        pullRequest.sourceRepository?.toLowerCase() !== repository ||
+        pullRequest.destinationRepository?.toLowerCase() !== repository
+    ) {
+        throw new ParameterError(
+            'Cannot edit a fork pull request or a pull request with unknown repositories',
+        );
+    }
+};
+
+const assertOpen = (
+    pullRequest: BitbucketClient.BitbucketPullRequest,
+): void => {
+    if (pullRequest.state !== PullRequestState.OPEN) {
+        throw new ParameterError(
+            `This Bitbucket pull request is ${pullRequest.state}. Open a new pull request instead.`,
+        );
+    }
+};
+
+export class BitbucketProvider extends BaseService implements GitProvider {
+    readonly provider = PullRequestProvider.BITBUCKET;
+
+    private readonly projectModel: ProjectModel;
+
+    private readonly projectDbtSourcesModel: ProjectDbtSourcesModel;
+
+    constructor(dependencies: {
+        projectModel: ProjectModel;
+        projectDbtSourcesModel: ProjectDbtSourcesModel;
+        logger: Logger;
+    }) {
+        super({ logger: dependencies.logger });
+        this.projectModel = dependencies.projectModel;
+        this.projectDbtSourcesModel = dependencies.projectDbtSourcesModel;
+    }
+
+    resolveConnection(
+        dbtConnection: DbtProjectConfig,
+        context?: { projectUuid: string; projectDbtSourceUuid: string | null },
+    ): BitbucketConnection {
+        if (!context || dbtConnection.type !== DbtProjectType.BITBUCKET) {
+            throw new ParameterError(
+                'Bitbucket writeback requires a project dbt connection',
+            );
+        }
+        return {
+            provider: PullRequestProvider.BITBUCKET,
+            ...BitbucketClient.resolveBitbucketRepository(dbtConnection),
+            ...context,
+            username: dbtConnection.username,
+            projectSubPath: normalizeProjectSubPath(
+                dbtConnection.project_sub_path,
+            ),
+            branch: dbtConnection.branch,
+        };
+    }
+
+    async resolveInstallation(
+        organizationUuid: string,
+        options?: { user?: SessionUser; connection?: GitConnection },
+    ): Promise<BitbucketInstallation> {
+        if (!options?.user || !options.connection) {
+            throw new ForbiddenError(
+                'Bitbucket writeback requires a user and a project connection',
+            );
+        }
+        const connection = asConnection(options.connection);
+        const project = await this.projectModel.getSummary(
+            connection.projectUuid,
+        );
+        if (
+            project.organizationUuid !== organizationUuid ||
+            options.user.organizationUuid !== organizationUuid ||
+            this.createAuditedAbility(options.user).cannot(
+                'manage',
+                subject('SourceCode', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid: connection.projectUuid,
+                    isProtectedBranch: false,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+        const current = await this.getCurrentConnection(connection);
+        if (
+            current.type !== DbtProjectType.BITBUCKET ||
+            current.username !== connection.username
+        ) {
+            throw new ForbiddenError(
+                'The Bitbucket connection changed. Start a new writeback.',
+            );
+        }
+        if (!current.personal_access_token?.trim()) {
+            throw new WritebackGitNotConnectedError(
+                PullRequestProvider.BITBUCKET,
+                'Configure an API token for the selected Bitbucket dbt source',
+            );
+        }
+        const credentials =
+            BitbucketClient.resolveBitbucketCredentials(current);
+        const installation: BitbucketInstallation = {
+            ...credentials,
+            provider: PullRequestProvider.BITBUCKET,
+            commitAuthor: {
+                name: COMMIT_AUTHOR_NAME,
+                email: COMMIT_AUTHOR_EMAIL,
+            },
+        };
+        assertRepository(connection, installation);
+        try {
+            await BitbucketClient.getRepository(credentials);
+        } catch (error) {
+            if (error instanceof ForbiddenError) {
+                throw new WritebackGitNotConnectedError(
+                    PullRequestProvider.BITBUCKET,
+                    'The Bitbucket API token is invalid, expired or lacks repository access. Update the token in the project connection.',
+                );
+            }
+            throw error;
+        }
+        return installation;
+    }
+
+    private async getCurrentConnection(
+        connection: BitbucketConnection,
+    ): Promise<DbtProjectConfig> {
+        if (connection.projectDbtSourceUuid) {
+            const source = await this.projectDbtSourcesModel.getSource(
+                connection.projectDbtSourceUuid,
+            );
+            if (source.projectUuid !== connection.projectUuid) {
+                throw new ForbiddenError(
+                    'The dbt source does not belong to this project',
+                );
+            }
+            if (!source.dbtConnection || source.hasCredentialError) {
+                throw new ParameterError(
+                    'The selected dbt source has no usable Bitbucket credentials',
+                );
+            }
+            return source.dbtConnection;
+        }
+        return (
+            await this.projectModel.getWithSensitiveFields(
+                connection.projectUuid,
+            )
+        ).dbtConnection;
+    }
+
+    getCloneTarget(
+        connection: GitConnection,
+        installation: GitInstallation,
+    ): CloneTarget {
+        const target = asConnection(connection);
+        const credentials = asInstallation(installation);
+        assertRepository(target, credentials);
+        return {
+            url: `https://bitbucket.org/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}.git`,
+            username: 'x-bitbucket-api-token-auth',
+            password: credentials.token,
+        };
+    }
+
+    private async readPullRequest(
+        args: AdoptPullRequestArgs,
+    ): Promise<BitbucketClient.BitbucketPullRequest> {
+        const connection = asConnection(args.connection);
+        const installation = asInstallation(args.installation);
+        assertRepository(connection, installation);
+        const pullNumber = parsePullRequest(args.prUrl, connection);
+        const pullRequest = await BitbucketClient.getPullRequest({
+            ...installation,
+            pullNumber,
+        });
+        assertPullRequestRepository(pullRequest, installation);
+        return pullRequest;
+    }
+
+    async getPullRequestEditState(
+        args: AdoptPullRequestArgs,
+    ): Promise<{ editable: boolean; reason: 'merged' | 'closed' | null }> {
+        const pullRequest = await this.readPullRequest(args);
+        if (pullRequest.state === PullRequestState.MERGED) {
+            return { editable: false, reason: 'merged' };
+        }
+        if (pullRequest.state === PullRequestState.CLOSED) {
+            return { editable: false, reason: 'closed' };
+        }
+        return { editable: true, reason: null };
+    }
+
+    async adoptPullRequest(
+        args: AdoptPullRequestArgs,
+    ): Promise<AdoptedPullRequest> {
+        const pullRequest = await this.readPullRequest(args);
+        assertOpen(pullRequest);
+        const connection = asConnection(args.connection);
+        return {
+            prUrl: pullRequest.html_url,
+            owner: connection.owner,
+            repo: connection.repo,
+            pullNumber: pullRequest.number,
+            headRef: pullRequest.head,
+        };
+    }
+
+    async openPullRequest(
+        args: OpenPullRequestArgs,
+    ): Promise<{ prUrl: string } & LandedCommit> {
+        const connection = asConnection(args.connection);
+        assertRepository(connection, asInstallation(args.installation));
+        const base = (await args.sandbox.git.status(CWD)).currentBranch;
+        if (!base || (connection.branch && base !== connection.branch)) {
+            throw new ParameterError(
+                'The sandbox is not on the configured Bitbucket base branch',
+            );
+        }
+        const branch = `lightdash-ai-writeback/${randomUUID()}`;
+        await args.sandbox.git.createBranch(CWD, branch);
+        const landed = await this.landChanges(args, branch);
+        args.setStage('pull_request');
+        const pullRequest = await BitbucketClient.createPullRequest({
+            ...asInstallation(args.installation),
+            title: args.title,
+            body: args.description,
+            head: branch,
+            base,
+        });
+        return { prUrl: pullRequest.html_url, ...landed };
+    }
+
+    async updatePullRequest(
+        args: UpdatePullRequestArgs,
+    ): Promise<LandedCommit> {
+        const pullRequest = await this.readPullRequest(args);
+        assertOpen(pullRequest);
+        const branch = (await args.sandbox.git.status(CWD)).currentBranch;
+        if (
+            !branch ||
+            branch !== pullRequest.head ||
+            branch === pullRequest.base
+        ) {
+            throw new ParameterError(
+                'The sandbox is not on the Bitbucket pull request branch',
+            );
+        }
+        const landed = await this.landChanges(args, branch);
+        args.setStage('pull_request');
+        await BitbucketClient.updatePullRequest({
+            ...asInstallation(args.installation),
+            pullNumber: pullRequest.number,
+            title: args.title,
+            body: args.description,
+        });
+        return landed;
+    }
+
+    async closePullRequest(
+        args: ClosePullRequestArgs,
+    ): Promise<ClosePullRequestResult> {
+        const installation = asInstallation(args.installation);
+        assertRepository(args, installation);
+        const pullNumber = parsePullRequest(args.prUrl, installation);
+        if (pullNumber !== args.pullNumber) {
+            throw new ParameterError(
+                'Bitbucket pull request identifiers do not match',
+            );
+        }
+        const pullRequest = await BitbucketClient.getPullRequest({
+            ...installation,
+            pullNumber,
+        });
+        assertPullRequestRepository(pullRequest, installation);
+        if (pullRequest.state === PullRequestState.MERGED) {
+            throw new ParameterError(
+                'This Bitbucket pull request is already merged',
+            );
+        }
+        if (pullRequest.state === PullRequestState.CLOSED) {
+            return { state: 'closed' };
+        }
+        const closed = await BitbucketClient.declinePullRequest({
+            ...installation,
+            pullNumber,
+        });
+        return {
+            state: closed.state === PullRequestState.CLOSED ? 'closed' : 'open',
+        };
+    }
+
+    private async landChanges(
+        args: OpenPullRequestArgs,
+        branch: string,
+    ): Promise<LandedCommit> {
+        const connection = asConnection(args.connection);
+        const installation = asInstallation(args.installation);
+        assertRepository(connection, installation);
+        args.setStage('commit');
+        await this.clearPushCredentials(args);
+        const hooks = await args.sandbox.commands.run(
+            `git -C ${CWD} config --local core.hooksPath /dev/null`,
+        );
+        if (hooks.exitCode !== 0) {
+            throw new UnexpectedGitError(
+                'Could not disable Bitbucket sandbox Git hooks',
+            );
+        }
+        const paths = await resolveDbtProjectPaths(
+            args.sandbox,
+            connection.projectSubPath,
+            this.logger,
+        );
+        await stageChanges(args.sandbox, paths, this.logger);
+        await assertStagedPathsAllowed(args.sandbox);
+        const diffStat = await collectDiffStat(args.sandbox);
+        const trailer = buildUserCoAuthorTrailer(args.user);
+        await commitLocal(
+            args.sandbox,
+            trailer ? `${args.title}\n\n${trailer}` : args.title,
+            installation.commitAuthor,
+        );
+        args.setStage('push');
+        try {
+            const remote = quoteShellArgument(
+                this.getCloneTarget(connection, installation).url,
+            );
+            const reset = await args.sandbox.commands.run(
+                `git -C ${CWD} remote set-url origin ${remote} && ` +
+                    `if git -C ${CWD} config --local --get-all remote.origin.pushurl >/dev/null; then git -C ${CWD} config --local --unset-all remote.origin.pushurl; fi`,
+            );
+            if (reset.exitCode !== 0) {
+                throw new Error('Could not reset the Bitbucket remote');
+            }
+            await args.sandbox.git.push(CWD, {
+                remote: 'origin',
+                branch,
+                username: 'x-bitbucket-api-token-auth',
+                password: installation.token,
+            });
+        } catch {
+            throw new UnexpectedGitError(
+                'Could not push the Bitbucket writeback branch. Check repository access and branch restrictions.',
+            );
+        } finally {
+            await this.clearPushCredentials(args);
+        }
+        const result = await args.sandbox.commands.run(
+            `git -C ${CWD} rev-parse HEAD`,
+        );
+        return { commitSha: result.stdout.trim(), ...diffStat };
+    }
+
+    private async clearPushCredentials(
+        args: OpenPullRequestArgs,
+    ): Promise<void> {
+        // SDKs may persist authentication in .git even when pushing fails.
+        try {
+            const remote = quoteShellArgument(
+                this.getCloneTarget(args.connection, args.installation).url,
+            );
+            const result = await args.sandbox.commands.run(
+                `git -C ${CWD} remote set-url origin ${remote} && if git -C ${CWD} config --local --get-regexp '^credential\\.' >/dev/null; then git -C ${CWD} config --local --remove-section credential; fi`,
+            );
+            if (result.exitCode !== 0) {
+                throw new Error('Credential cleanup failed');
+            }
+        } catch {
+            throw new WritebackCredentialCleanupError();
+        }
+    }
+}

--- a/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/GitProvider.ts
@@ -70,7 +70,10 @@ export interface GitProvider {
     /** Tag recorded on the `pull_requests` row. */
     readonly provider: PullRequestProvider;
 
-    resolveConnection(dbtConnection: DbtProjectConfig): GitConnection;
+    resolveConnection(
+        dbtConnection: DbtProjectConfig,
+        context?: { projectUuid: string; projectDbtSourceUuid: string | null },
+    ): GitConnection;
     /**
      * Resolve auth for the run's git host. When `options.user` and
      * `options.connection` are supplied and the user has linked their personal

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -54,7 +54,21 @@ export type GitlabConnection = {
  * The dbt repo a writeback run targets. Discriminated by `provider` so the
  * service can read the shared fields while each provider narrows for its own.
  */
-export type GitConnection = GithubConnection | GitlabConnection;
+export type BitbucketConnection = {
+    provider: PullRequestProvider.BITBUCKET;
+    owner: string;
+    repo: string;
+    projectSubPath: string;
+    branch: string;
+    projectUuid: string;
+    projectDbtSourceUuid: string | null;
+    username: string;
+};
+
+export type GitConnection =
+    | GithubConnection
+    | GitlabConnection
+    | BitbucketConnection;
 
 export type AdoptedPullRequest = {
     prUrl: string;
@@ -97,7 +111,18 @@ export type GitlabInstallation = {
 };
 
 /** Resolved auth for the run's git host. Discriminated by `provider`. */
-export type GitInstallation = GithubInstallation | GitlabInstallation;
+export type BitbucketInstallation = {
+    provider: PullRequestProvider.BITBUCKET;
+    token: string;
+    owner: string;
+    repo: string;
+    commitAuthor: GitCommitAuthor;
+};
+
+export type GitInstallation =
+    | GithubInstallation
+    | GitlabInstallation
+    | BitbucketInstallation;
 
 /** HTTPS clone target; credentials are supplied out-of-band, never in the URL. */
 export type CloneTarget = {

--- a/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.test.ts
@@ -138,6 +138,28 @@ describe('parseGitlabConnection', () => {
 });
 
 describe('buildCloneTarget', () => {
+    it('keeps the Bitbucket API token out of the clone URL', () => {
+        expect(
+            buildCloneTarget(
+                {
+                    provider: PullRequestProvider.BITBUCKET,
+                    owner: 'acme',
+                    repo: 'analytics',
+                    projectUuid: 'project',
+                    projectDbtSourceUuid: 'source',
+                    username: 'developer',
+                    projectSubPath: '.',
+                    branch: 'release/dbt',
+                },
+                'project-token',
+            ),
+        ).toEqual({
+            url: 'https://bitbucket.org/acme/analytics.git',
+            username: 'x-bitbucket-api-token-auth',
+            password: 'project-token',
+        });
+    });
+
     it('builds a GitHub x-access-token target', () => {
         expect(
             buildCloneTarget(parseGithubConnection(githubConfig()), 'tok'),

--- a/packages/backend/src/ee/services/AiWritebackService/utils.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/utils.ts
@@ -60,7 +60,7 @@ const splitOwnerRepo = (
  * Normalise the stored sub-path (leading slash, `/` for root) to a path
  * relative to the repo root so it can be passed to `--project-dir`.
  */
-const normalizeProjectSubPath = (projectSubPath: string): string => {
+export const normalizeProjectSubPath = (projectSubPath: string): string => {
     const relative = projectSubPath
         .trim()
         .replace(/^\/+/, '')
@@ -118,6 +118,12 @@ export const buildCloneTarget = (
             return {
                 url: `https://github.com/${connection.owner}/${connection.repo}.git`,
                 username: 'x-access-token',
+                password: token,
+            };
+        case PullRequestProvider.BITBUCKET:
+            return {
+                url: `https://bitbucket.org/${encodeURIComponent(connection.owner)}/${encodeURIComponent(connection.repo)}.git`,
+                username: 'x-bitbucket-api-token-auth',
                 password: token,
             };
         case PullRequestProvider.GITLAB:

--- a/packages/backend/src/ee/services/ai/utils/classifyWritebackError.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/classifyWritebackError.test.ts
@@ -1,0 +1,14 @@
+import { PullRequestProvider } from '@lightdash/common';
+import { WritebackGitNotConnectedError } from '../../AiWritebackService/errors';
+import { classifyWritebackError } from './classifyWritebackError';
+
+it.each([
+    [PullRequestProvider.BITBUCKET, 'bitbucket_token_missing'],
+    [PullRequestProvider.GITHUB, 'github_not_installed'],
+    [PullRequestProvider.GITLAB, 'gitlab_not_installed'],
+    [null, 'unsupported_source_control'],
+])('gives setup guidance for %s', (provider, expected) => {
+    expect(
+        classifyWritebackError(new WritebackGitNotConnectedError(provider)),
+    ).toBe(expected);
+});

--- a/packages/backend/src/ee/services/ai/utils/classifyWritebackError.ts
+++ b/packages/backend/src/ee/services/ai/utils/classifyWritebackError.ts
@@ -10,6 +10,7 @@ import {
 export type WritebackErrorCode =
     | 'github_not_installed'
     | 'gitlab_not_installed'
+    | 'bitbucket_token_missing'
     | 'unsupported_source_control'
     | 'pull_request_not_open'
     | 'git_write_permission'
@@ -31,6 +32,9 @@ export const classifyWritebackError = (error: unknown): WritebackErrorCode => {
         }
         if (error.provider === PullRequestProvider.GITLAB) {
             return 'gitlab_not_installed';
+        }
+        if (error.provider === PullRequestProvider.BITBUCKET) {
+            return 'bitbucket_token_missing';
         }
         return 'unsupported_source_control';
     }

--- a/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
+++ b/packages/common/src/ee/AiAgent/aiAgentReviewClassifierTypes.ts
@@ -402,6 +402,7 @@ export type AiAgentReviewItemWritebackBlockedReason =
     | 'insufficient_source_code_access'
     | 'unsupported_source_control'
     | 'git_app_not_installed'
+    | 'bitbucket_token_missing'
     | 'missing_writeback_config'
     | 'pull_request_open'
     | 'source_thread_writeback_exists'

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolEditDbtProjectArgs.ts
@@ -103,6 +103,7 @@ export const toolEditDbtProjectOutputSchema = z.object({
                 .enum([
                     'github_not_installed',
                     'gitlab_not_installed',
+                    'bitbucket_token_missing',
                     'unsupported_source_control',
                     'pull_request_not_open',
                     'git_write_permission',

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/reviewItemDetails.ts
@@ -77,7 +77,9 @@ export const writebackBlockedReasonLabels: Record<
     project_context_disabled: 'Project context is not enabled',
     insufficient_source_code_access:
         'You do not have permission to modify source code',
-    unsupported_source_control: 'Project is not connected to GitHub or GitLab',
+    unsupported_source_control:
+        'Project is not connected to GitHub, GitLab or Bitbucket Cloud',
+    bitbucket_token_missing: 'Configure the project Bitbucket API token',
     git_app_not_installed: 'Git app is not installed',
     missing_writeback_config: 'Writeback runtime is not configured',
     pull_request_open: 'A pull request is already open',
@@ -96,9 +98,10 @@ export const writebackBlockedReasonDescriptions: Partial<
     Record<AiAgentReviewItemWritebackBlockedReason, string>
 > = {
     unsupported_source_control:
-        'Connect this project to GitHub or GitLab so Lightdash can open a pull request that fixes issues like this for you.',
+        'Connect this project to GitHub, GitLab or Bitbucket Cloud so Lightdash can open a pull request that fixes issues like this for you.',
     reviews_disabled:
         'Turn on Issues for your organization to let agents file and fix issues automatically.',
+    bitbucket_token_missing: 'Configure the project Bitbucket API token',
     git_app_not_installed:
         'Install the Lightdash app on your repository so it can open pull requests.',
     project_context_disabled:

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.test.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.test.tsx
@@ -1,0 +1,88 @@
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../../../testing/testUtils';
+import { usePullRequestCiChecks } from '../../../hooks/usePullRequestCiChecks';
+import { AiEditDbtProjectToolCall } from './AiEditDbtProjectToolCall';
+
+vi.mock('../../../hooks/usePullRequestCiChecks', () => ({
+    usePullRequestCiChecks: vi.fn().mockReturnValue({ data: null }),
+}));
+vi.mock('../../../hooks/useClosePullRequest', () => ({
+    useClosePullRequest: () => ({ mutate: vi.fn(), isLoading: false }),
+}));
+vi.mock('../../../hooks/useMergePullRequest', () => ({
+    useMergePullRequest: () => ({ mutate: vi.fn(), isLoading: false }),
+}));
+vi.mock('../../../hooks/useProjectAiAgents', () => ({
+    useProjectAiAgent: () => ({ data: undefined }),
+    useCreateAgentThreadMessageMutation: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('./WritebackDiffModal', () => ({ WritebackDiffModal: () => null }));
+
+describe('Bitbucket dbt writeback card', () => {
+    afterEach(() => vi.clearAllMocks());
+
+    it('links to Bitbucket without polling CI or offering unsupported actions', async () => {
+        const prUrl = 'https://bitbucket.org/workspace/jaffle/pull-requests/7';
+        renderWithProviders(
+            <MemoryRouter>
+                <AiEditDbtProjectToolCall
+                    projectUuid="project"
+                    isPreviewDeploySetup={false}
+                    metadata={{
+                        status: 'success',
+                        prUrl,
+                        previewUrl: 'https://preview.example.com',
+                    }}
+                />
+            </MemoryRouter>,
+        );
+        expect(usePullRequestCiChecks).toHaveBeenCalledWith(
+            'project',
+            null,
+            null,
+        );
+        expect(screen.getByText('workspace/jaffle')).toBeVisible();
+        expect(
+            screen.queryByRole('button', { name: 'Merge PR' }),
+        ).not.toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'View' }));
+        await waitFor(() =>
+            expect(
+                screen.getByRole('menuitem', { name: 'Pull request' }),
+            ).toHaveAttribute('href', prUrl),
+        );
+        expect(
+            screen.queryByRole('menuitem', { name: 'Preview' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('menuitem', { name: 'Diff' }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('directs a missing token to project settings without an app installation action', () => {
+        renderWithProviders(
+            <MemoryRouter>
+                <AiEditDbtProjectToolCall
+                    projectUuid="project"
+                    isPreviewDeploySetup={false}
+                    metadata={{
+                        status: 'error',
+                        errorCode: 'bitbucket_token_missing',
+                    }}
+                />
+            </MemoryRouter>,
+        );
+        expect(screen.getByText('Configure Bitbucket API token')).toBeVisible();
+        expect(
+            screen.getByRole('link', { name: 'Edit project connection' }),
+        ).toHaveAttribute(
+            'href',
+            '/generalSettings/projectManagement/project/settings',
+        );
+        expect(
+            screen.queryByRole('link', { name: 'Install GitHub App' }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/AiEditDbtProjectToolCall.tsx
@@ -37,7 +37,11 @@ import { usePullRequestCiChecks } from '../../../hooks/usePullRequestCiChecks';
 import { POST_MERGE_MIGRATION_PROMPT } from '../../../postMergeMigrationPrompt';
 import styles from './AiEditDbtProjectToolCall.module.css';
 import { isMergeable } from './pullRequestActions';
-import { INSTALL_ACTIONS, summarisePrUrl } from './pullRequestCardUtils';
+import {
+    INSTALL_ACTIONS,
+    summarisePrUrl,
+    isBitbucketPullRequest,
+} from './pullRequestCardUtils';
 import { PullRequestCiChecks } from './PullRequestCiChecks';
 import { WritebackDiffModal } from './WritebackDiffModal';
 
@@ -135,14 +139,16 @@ export const PullRequestViewMenu: FC<{
                     >
                         Pull request
                     </Menu.Item>
-                    <Menu.Item
-                        leftSection={
-                            <MantineIcon icon={IconFileDiff} size={14} />
-                        }
-                        onClick={() => setDiffOpened(true)}
-                    >
-                        Diff
-                    </Menu.Item>
+                    {!isBitbucketPullRequest(prUrl) && (
+                        <Menu.Item
+                            leftSection={
+                                <MantineIcon icon={IconFileDiff} size={14} />
+                            }
+                            onClick={() => setDiffOpened(true)}
+                        >
+                            Diff
+                        </Menu.Item>
+                    )}
                 </Menu.Dropdown>
             </Menu>
             <WritebackDiffModal
@@ -321,11 +327,12 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
     // Hooks must run before the early returns below; the query is disabled until
     // there's a PR URL, so the error/no-PR branches don't fetch anything.
     const prUrl = metadata.status === 'success' ? metadata.prUrl : null;
+    const isBitbucket = isBitbucketPullRequest(prUrl);
     const ciCommitSha =
         metadata.status === 'success' ? (metadata.commitSha ?? null) : null;
     const { data: ciChecks } = usePullRequestCiChecks(
         projectUuid,
-        prUrl,
+        isBitbucket ? null : prUrl,
         ciCommitSha,
     );
     const { mutate: merge, isLoading: isMerging } =
@@ -356,9 +363,10 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                 />
             );
         }
-        // The project's dbt connection isn't GitHub/GitLab, so there's no app to
-        // install — point the user at the connection settings to switch it.
-        if (metadata.errorCode === 'unsupported_source_control') {
+        if (
+            metadata.errorCode === 'unsupported_source_control' ||
+            metadata.errorCode === 'bitbucket_token_missing'
+        ) {
             return (
                 <Paper p="sm" radius="md">
                     <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -373,13 +381,16 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                         <Stack gap="xs">
                             <Stack gap={2}>
                                 <Text size="xs" fw={500}>
-                                    Source control not supported
+                                    {metadata.errorCode ===
+                                    'bitbucket_token_missing'
+                                        ? 'Configure Bitbucket API token'
+                                        : 'Source control not supported'}
                                 </Text>
                                 <Text size="xs" c="dimmed">
-                                    AI writeback needs this project's dbt
-                                    connection to use GitHub or GitLab. Update
-                                    the connection to open pull requests from
-                                    chat.
+                                    {metadata.errorCode ===
+                                    'bitbucket_token_missing'
+                                        ? 'Update the API token in this project connection. It needs repository and pull request read/write permissions in Bitbucket Cloud.'
+                                        : 'AI writeback needs a GitHub, GitLab or Bitbucket Cloud dbt connection. Update the connection to open pull requests from chat.'}
                                 </Text>
                             </Stack>
                             <Group gap={0}>
@@ -452,8 +463,7 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
             );
         }
         // The thread's pull request was already merged or closed, so further
-        // edits can't be added here. Not a failure — guide the user to a new
-        // thread rather than show a red error.
+        // edits require a new pull request in the same thread.
         if (metadata.errorCode === 'pull_request_not_open') {
             return (
                 <Paper p="sm" radius="md">
@@ -476,7 +486,8 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                             <Text size="xs" c="dimmed">
                                 Its pull request has already been merged or
                                 closed, so further changes can't be added here.
-                                Start a new thread to request more changes.
+                                Ask to open a new pull request for further
+                                changes.
                             </Text>
                         </Stack>
                     </Group>
@@ -658,49 +669,53 @@ export const AiEditDbtProjectToolCall: FC<Props> = ({
                             projectUuid={projectUuid}
                             prUrl={metadata.prUrl}
                             previewUrl={
-                                isPreviewDeploySetup
+                                isPreviewDeploySetup || isBitbucket
                                     ? null
                                     : (metadata.previewUrl ?? null)
                             }
                             commitSha={metadata.commitSha ?? null}
                         />
-                        <PullRequestActionButtons
-                            ciChecks={ciChecks ?? null}
-                            isMerging={isMerging}
-                            isClosing={isClosing}
-                            onMerge={() =>
-                                merge(
-                                    {
-                                        prUrl: resolvedPrUrl,
-                                        sha: metadata.commitSha ?? null,
-                                    },
-                                    // Once merged, ask the agent to assess and
-                                    // repoint affected saved content. Injected as
-                                    // a hidden turn (filtered from the chat by
-                                    // AgentChatDisplay) so only the agent's
-                                    // proactive reply shows. Only when the agent
-                                    // can edit content — otherwise it can't act
-                                    // on the request.
-                                    canMigrateContent
-                                        ? {
-                                              onSuccess: () =>
-                                                  sendThreadMessage({
-                                                      prompt: POST_MERGE_MIGRATION_PROMPT,
-                                                      hidden: true,
-                                                  }),
-                                          }
-                                        : undefined,
-                                )
-                            }
-                            onClose={() => close({ prUrl: resolvedPrUrl })}
-                        />
+                        {!isBitbucket && (
+                            <PullRequestActionButtons
+                                ciChecks={ciChecks ?? null}
+                                isMerging={isMerging}
+                                isClosing={isClosing}
+                                onMerge={() =>
+                                    merge(
+                                        {
+                                            prUrl: resolvedPrUrl,
+                                            sha: metadata.commitSha ?? null,
+                                        },
+                                        // Once merged, ask the agent to assess and
+                                        // repoint affected saved content. Injected as
+                                        // a hidden turn (filtered from the chat by
+                                        // AgentChatDisplay) so only the agent's
+                                        // proactive reply shows. Only when the agent
+                                        // can edit content — otherwise it can't act
+                                        // on the request.
+                                        canMigrateContent
+                                            ? {
+                                                  onSuccess: () =>
+                                                      sendThreadMessage({
+                                                          prompt: POST_MERGE_MIGRATION_PROMPT,
+                                                          hidden: true,
+                                                      }),
+                                              }
+                                            : undefined,
+                                    )
+                                }
+                                onClose={() => close({ prUrl: resolvedPrUrl })}
+                            />
+                        )}
                     </Box>
                 </Box>
-                <PullRequestCiChecks
-                    prUrl={metadata.prUrl}
-                    ciChecks={ciChecks ?? null}
-                    hasMergeAction
-                />
+                {!isBitbucket && (
+                    <PullRequestCiChecks
+                        prUrl={metadata.prUrl}
+                        ciChecks={ciChecks ?? null}
+                        hasMergeAction
+                    />
+                )}
             </Stack>
         </Paper>
     );

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.test.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { isBitbucketPullRequest, summarisePrUrl } from './pullRequestCardUtils';
+
+describe('Bitbucket pull request cards', () => {
+    it('shows the workspace and repository from the pull request URL', () => {
+        expect(
+            summarisePrUrl(
+                'https://bitbucket.org/workspace/jaffle/pull-requests/12',
+            ),
+        ).toBe('workspace/jaffle');
+    });
+    it.each([
+        ['https://bitbucket.org/workspace/jaffle/pull-requests/12', true],
+        [
+            'https://bitbucket.org.evil.test/workspace/jaffle/pull-requests/12',
+            false,
+        ],
+        ['https://github.com/workspace/jaffle/pull/12', false],
+        [null, false],
+        ['invalid URL', false],
+    ])('recognizes the Bitbucket card %s', (url, expected) => {
+        expect(isBitbucketPullRequest(url)).toBe(expected);
+    });
+});

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/pullRequestCardUtils.ts
@@ -9,18 +9,18 @@ import {
 // without tripping react-refresh's only-export-components rule.
 
 /**
- * Parses "https://github.com/lightdash/jaffle/pull/29" into "lightdash/jaffle"
- * so the user can verify which repo the PR landed in at a glance. Best-effort —
- * any non-GitHub host or malformed path falls back to the raw hostname.
+ * Summarizes supported pull request URLs as workspace/repository; other hosts
+ * fall back to the hostname.
  */
 export const summarisePrUrl = (prUrl: string): string | null => {
     try {
         const url = new URL(prUrl);
         const segments = url.pathname.split('/').filter(Boolean);
         if (
-            url.hostname === 'github.com' &&
             segments.length >= 4 &&
-            segments[2] === 'pull'
+            ((url.hostname === 'github.com' && segments[2] === 'pull') ||
+                (url.hostname === 'bitbucket.org' &&
+                    segments[2] === 'pull-requests'))
         ) {
             const [owner, repo] = segments;
             return `${owner}/${repo}`;
@@ -51,4 +51,17 @@ export const INSTALL_ACTIONS: Record<
         installUrl: '/api/v1/gitlab/install',
         cta: 'Connect GitLab',
     },
+};
+
+export const isBitbucketPullRequest = (
+    prUrl: string | null | undefined,
+): boolean => {
+    if (!prUrl) {
+        return false;
+    }
+    try {
+        return new URL(prUrl).hostname === 'bitbucket.org';
+    } catch {
+        return false;
+    }
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1996

## Summary

Enables AI agents to create and update Bitbucket Cloud pull requests for dbt edits. This is the AI writeback part of [SPK-1994](https://linear.app/lightdash/issue/SPK-1994), based on current main after the foundation [#28925](https://github.com/lightdash/lightdash/pull/28925) and credential binding fix [#28926](https://github.com/lightdash/lightdash/pull/28926) merged.

## Changes

- Resolves the selected primary or additional dbt source's project token after authorization, preserving repository, branch and dbt subfolder identity across conversation turns.
- Creates, updates, adopts and declines same-repository PRs. Rejects foreign repositories, forks and closed PR updates; existing tool guidance opens a fresh PR in the same thread.
- Keeps tokens outside agent context, scrubs sandbox credentials, and destroys a sandbox if credential cleanup fails. Retains denied-path checks and dbt validation.
- Shows Bitbucket token configuration guidance and PR links. Bitbucket cards hide unsupported CI, preview and merge actions.

## Connection flow

```text
Selected dbt source → project authorization → current project token
                   → sandbox dbt edit + validation → Bitbucket PR
Follow-up          → same source + open PR         → update same PR
Closed PR          → fresh-PR tool guidance        → new PR
```

## Test plan

- [x] 447 backend tests and 8 rendered frontend/helper tests pass.
- [x] Backend, frontend and common type checks; focused lint; API generation pass.
- [x] Real E2B sandbox and Bitbucket Cloud: edit a metric in a nested dbt folder, compile all 61 explores, create a PR, update the same PR, externally decline it, reject a follow-up, and open a fresh PR.
- [x] A no-change follow-up leaves the remote commit unchanged. Disposable PRs, branches, sandboxes and local fixtures cleaned up; repository main remains unchanged.
- [x] Permission/source binding, invalid tokens, fork/foreign-repository rejection, denied paths, Git configuration tampering and credential-cleanup failures covered by focused tests.

Live verification used E2B. Other sandbox runtimes were not exercised.
