### PR TITLE
feat(explorer): support Bitbucket custom field writeback

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.bitbucket.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.bitbucket.test.ts
@@ -1,0 +1,478 @@
+import { Ability } from '@casl/ability';
+import {
+    BinType,
+    ConflictError,
+    CustomDimensionType,
+    DbtProjectType,
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    PullRequestProvider,
+    PullRequestSource,
+    PullRequestState,
+    SupportedDbtVersions,
+    type DbtBitBucketProjectConfig,
+    type PossibleAbilities,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
+import * as BitbucketClient from '../../clients/bitbucket/Bitbucket';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { PullRequestsModel } from '../../models/PullRequestsModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { GithubAppService } from '../GithubAppService/GithubAppService';
+import { user } from '../ProjectService/ProjectService.mock';
+import { GitIntegrationService } from './GitIntegrationService';
+import {
+    CUSTOM_DIMENSION,
+    CUSTOM_METRIC,
+    EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
+    EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
+    SCHEMA_YML,
+} from './GitIntegrationService.mock';
+
+vi.mock('../../clients/bitbucket/Bitbucket', async () => ({
+    ...(await vi.importActual<
+        typeof import('../../clients/bitbucket/Bitbucket')
+    >('../../clients/bitbucket/Bitbucket')),
+    getBranch: vi.fn(),
+    createBranch: vi.fn(),
+    getFileContent: vi.fn(),
+    commitFiles: vi.fn(),
+    createPullRequest: vi.fn(),
+}));
+
+const config: DbtBitBucketProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'developer',
+    personal_access_token: 'project-token',
+    repository: 'workspace/analytics',
+    branch: 'release/dbt',
+    project_sub_path: '/semantic/',
+};
+const writebackUser = {
+    ...user,
+    organizationUuid: 'organization',
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'manage',
+            subject: 'CustomFields',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+            },
+        },
+        {
+            action: 'manage',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+                isProtectedBranch: false,
+            },
+        },
+        {
+            action: 'view',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+            },
+        },
+    ]),
+};
+const prUrl = 'https://bitbucket.org/workspace/analytics/pull-requests/17';
+const setup = () => {
+    const project = {
+        organizationUuid: 'organization',
+        projectUuid: 'project',
+        name: 'Analytics',
+        dbtVersion: SupportedDbtVersions.V1_9,
+        dbtConnection: { ...config, personal_access_token: '' },
+    };
+    const projectModel = {
+        get: vi.fn().mockResolvedValue(project),
+        getSummary: vi
+            .fn()
+            .mockResolvedValue({ organizationUuid: 'organization' }),
+        getWithSensitiveFields: vi
+            .fn()
+            .mockResolvedValue({ ...project, dbtConnection: config }),
+        getExploreFromCache: vi
+            .fn()
+            .mockResolvedValue({ ymlPath: 'models/schema.yml' }),
+        getWarehouseCredentialsForProject: vi.fn().mockResolvedValue({}),
+        getWarehouseClientFromCredentials: vi
+            .fn()
+            .mockReturnValue(warehouseClientMock),
+    };
+    const sources = { getSources: vi.fn().mockResolvedValue([]) };
+    const pullRequests = { create: vi.fn().mockResolvedValue(undefined) };
+    const service = new GitIntegrationService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        savedChartModel: {} as SavedChartModel,
+        projectModel: projectModel as unknown as ProjectModel,
+        projectDbtSourcesModel: sources as unknown as ProjectDbtSourcesModel,
+        spaceModel: {} as SpaceModel,
+        githubAppInstallationsModel: {} as GithubAppInstallationsModel,
+        githubAppService: {} as GithubAppService,
+        pullRequestsModel: pullRequests as unknown as PullRequestsModel,
+    });
+    return { service, projectModel, sources, pullRequests };
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(BitbucketClient.getBranch).mockResolvedValue({
+        name: config.branch,
+        target: { hash: 'base-sha' },
+    });
+    vi.mocked(BitbucketClient.createBranch).mockResolvedValue({
+        name: 'new-branch',
+        target: { hash: 'base-sha' },
+    });
+    vi.mocked(BitbucketClient.getFileContent).mockResolvedValue({
+        content: SCHEMA_YML,
+        sha: 'base-sha',
+    });
+    vi.mocked(BitbucketClient.commitFiles).mockResolvedValue(undefined);
+    vi.mocked(BitbucketClient.createPullRequest).mockResolvedValue({
+        number: 17,
+        title: 'Adds custom fields',
+        html_url: prUrl,
+        state: PullRequestState.OPEN,
+        head: 'new-branch',
+        base: config.branch,
+    });
+});
+
+describe('Bitbucket Explorer writeback', () => {
+    it.each([
+        ['.', 'models/schema.yml'],
+        ['/', 'models/schema.yml'],
+        ['./dbt', 'dbt/models/schema.yml'],
+        ['/./dbt/', 'dbt/models/schema.yml'],
+        ['dbt/./project', 'dbt/project/models/schema.yml'],
+    ])(
+        'normalizes project path %s to %s',
+        async (projectSubPath, expectedPath) => {
+            const { service, projectModel } = setup();
+            const project = await projectModel.get();
+            projectModel.get.mockResolvedValue({
+                ...project,
+                dbtConnection: {
+                    ...project.dbtConnection,
+                    project_sub_path: projectSubPath,
+                },
+            });
+            await service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            });
+            expect(BitbucketClient.getFileContent).toHaveBeenCalledWith(
+                expect.objectContaining({ fileName: expectedPath }),
+            );
+            expect(BitbucketClient.commitFiles).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    changes: [
+                        {
+                            action: 'upsert',
+                            path: expectedPath,
+                            content: EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
+                        },
+                    ],
+                }),
+            );
+        },
+    );
+
+    it('writes a metric without losing existing YAML and records a Bitbucket PR', async () => {
+        const { service, pullRequests } = setup();
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).resolves.toEqual({ prTitle: 'Adds custom fields', prUrl });
+        expect(BitbucketClient.getBranch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                owner: 'workspace',
+                repo: 'analytics',
+                branch: 'release/dbt',
+                token: 'project-token',
+            }),
+        );
+        const { branch } = vi.mocked(BitbucketClient.createBranch).mock
+            .calls[0][0];
+        expect(branch).not.toBe(config.branch);
+        expect(BitbucketClient.createBranch).toHaveBeenCalledWith(
+            expect.objectContaining({ sha: 'base-sha' }),
+        );
+        expect(BitbucketClient.commitFiles).toHaveBeenCalledWith(
+            expect.objectContaining({
+                branch,
+                expectedParent: 'base-sha',
+                changes: [
+                    {
+                        action: 'upsert',
+                        path: 'semantic/models/schema.yml',
+                        content: EXPECTED_SCHEMA_YML_WITH_CUSTOM_METRIC,
+                    },
+                ],
+            }),
+        );
+        expect(BitbucketClient.createPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ head: branch, base: config.branch }),
+        );
+        expect(pullRequests.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: PullRequestProvider.BITBUCKET,
+                source: PullRequestSource.CUSTOM_METRIC,
+                projectUuid: 'project',
+                owner: 'workspace',
+                repo: 'analytics',
+                prNumber: 17,
+            }),
+        );
+    });
+
+    it('preserves both model changes when bulk metrics share a YAML file', async () => {
+        const { service } = setup();
+        let content = SCHEMA_YML;
+        let sha = 'base-sha';
+        vi.mocked(BitbucketClient.getFileContent).mockImplementation(
+            async () => ({ content, sha }),
+        );
+        vi.mocked(BitbucketClient.commitFiles).mockImplementation(
+            async (args) => {
+                expect(args.expectedParent).toBe(sha);
+                const change = args.changes[0];
+                if (change.action !== 'upsert') {
+                    throw new Error('Expected YAML update');
+                }
+                content = change.content;
+                sha = 'updated-sha';
+            },
+        );
+        await service.createPullRequest(writebackUser, 'project', "'", {
+            type: 'customMetrics',
+            fields: [
+                CUSTOM_METRIC,
+                { ...CUSTOM_METRIC, name: 'second_metric', table: 'table_b' },
+            ],
+        });
+        expect(content).toContain('new_metric:');
+        expect(content).toContain('second_metric:');
+        expect(content).toContain('# comment at the top');
+        expect(content).toContain('metric_a:');
+        expect(BitbucketClient.createPullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes supported custom SQL dimensions through the existing YAML editor', async () => {
+        const { service, pullRequests } = setup();
+        await service.createPullRequest(writebackUser, 'project', "'", {
+            type: 'customDimensions',
+            fields: [CUSTOM_DIMENSION],
+        });
+        expect(BitbucketClient.commitFiles).toHaveBeenCalledWith(
+            expect.objectContaining({
+                changes: [
+                    {
+                        action: 'upsert',
+                        path: 'semantic/models/schema.yml',
+                        content: EXPECTED_SCHEMA_YML_WITH_CUSTOM_DIMENSION,
+                    },
+                ],
+            }),
+        );
+        expect(pullRequests.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                source: PullRequestSource.CUSTOM_DIMENSION,
+            }),
+        );
+    });
+
+    it('previews dimensions from the configured base without writing a branch', async () => {
+        const { service } = setup();
+        const result = await service.previewCustomDimensions(
+            fromSession(writebackUser, 'session-cookie'),
+            'project',
+            [CUSTOM_DIMENSION],
+            "'",
+        );
+        expect(result.yaml).toContain('amount_size:');
+        expect(result.yaml).toContain('${table_a.dim_a}');
+        expect(BitbucketClient.getFileContent).toHaveBeenCalledWith(
+            expect.objectContaining({
+                branch: config.branch,
+                fileName: 'semantic/models/schema.yml',
+            }),
+        );
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+        expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+    });
+
+    it('requires source-code management before reading the token', async () => {
+        const { service, projectModel } = setup();
+        const customFieldsOnly = {
+            ...writebackUser,
+            ability: new Ability<PossibleAbilities>([
+                {
+                    action: 'manage',
+                    subject: 'CustomFields',
+                    conditions: {
+                        organizationUuid: 'organization',
+                        projectUuid: 'project',
+                    },
+                },
+            ]),
+        };
+        await expect(
+            service.createPullRequest(customFieldsOnly, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+    });
+
+    it('authorizes against the actual project organization before reading secrets', async () => {
+        const { service, projectModel } = setup();
+        projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'another-organization',
+        });
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+    });
+
+    it('refuses ambiguous additional Bitbucket sources before calling Git', async () => {
+        const { service, sources } = setup();
+        sources.getSources.mockResolvedValue([
+            {
+                name: 'Additional Bitbucket',
+                projectDbtSourceUuid: 'additional',
+                dbtConnection: config,
+            },
+        ]);
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).rejects.toThrow(/multiple git-backed dbt sources/);
+        expect(BitbucketClient.getBranch).not.toHaveBeenCalled();
+        expect(BitbucketClient.getFileContent).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        [undefined, 'missing baseDimensionName'],
+        ['missing_column', 'Column missing_column not found'],
+    ])(
+        'requires an existing base dimension for metrics: %s',
+        async (baseDimensionName, message) => {
+            const { service } = setup();
+            await expect(
+                service.createPullRequest(writebackUser, 'project', "'", {
+                    type: 'customMetrics',
+                    fields: [{ ...CUSTOM_METRIC, baseDimensionName }],
+                }),
+            ).rejects.toThrow(message);
+            expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+            expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+        },
+    );
+
+    it('preserves fixed-number bin restrictions', async () => {
+        const { service } = setup();
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customDimensions',
+                fields: [
+                    {
+                        id: 'bins',
+                        name: 'Bins',
+                        table: 'table_a',
+                        type: CustomDimensionType.BIN,
+                        dimensionId: 'table_a_dim_a',
+                        binType: BinType.FIXED_NUMBER,
+                        binNumber: 5,
+                    },
+                ],
+            }),
+        ).rejects.toThrow(/Fixed-number bins cannot be written back/);
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        new ForbiddenError('Invalid or expired token'),
+        new ForbiddenError('Insufficient token scopes'),
+        new NotFoundError('Missing branch'),
+    ])(
+        'propagates provider failure before creating a branch: %s',
+        async (error) => {
+            const { service } = setup();
+            vi.mocked(BitbucketClient.getBranch).mockRejectedValueOnce(error);
+            await expect(
+                service.createPullRequest(writebackUser, 'project', "'", {
+                    type: 'customMetrics',
+                    fields: [CUSTOM_METRIC],
+                }),
+            ).rejects.toBeInstanceOf(error.constructor);
+            expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+            expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+        },
+    );
+
+    it('does not publish a PR for missing YAML', async () => {
+        const { service } = setup();
+        vi.mocked(BitbucketClient.getFileContent).mockRejectedValueOnce(
+            new NotFoundError('Missing file'),
+        );
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).rejects.toBeInstanceOf(NotFoundError);
+        expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+        expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        new ConflictError('Branch advanced'),
+        new ForbiddenError('Token lacks write scope'),
+    ])('does not publish a PR when committing fails: %s', async (error) => {
+        const { service } = setup();
+        vi.mocked(BitbucketClient.commitFiles).mockRejectedValueOnce(error);
+        await expect(
+            service.createPullRequest(writebackUser, 'project', "'", {
+                type: 'customMetrics',
+                fields: [CUSTOM_METRIC],
+            }),
+        ).rejects.toBeInstanceOf(error.constructor);
+        expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it('keeps generic SQL and source-editor credential paths unsupported', async () => {
+        const { service } = setup();
+        await expect(
+            service.getGitCredentials(writebackUser, 'project'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        await expect(service.getProjectRepo('project')).rejects.toBeInstanceOf(
+            ParameterError,
+        );
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -85,6 +85,10 @@ type GitProps = {
     dbtVersion?: SupportedDbtVersions;
 };
 
+type ExploreGitProps =
+    | GitProps
+    | (Omit<GitProps, 'type'> & { type: DbtProjectType.BITBUCKET });
+
 // Keep backward compatibility
 type GithubProps = GitProps;
 
@@ -147,15 +151,19 @@ export class GitIntegrationService extends BaseService {
         prUrl: string;
         source: PullRequestSource;
     }): Promise<void> {
+        const legacyProvider =
+            type === DbtProjectType.GITHUB
+                ? PullRequestProvider.GITHUB
+                : PullRequestProvider.GITLAB;
         try {
             await this.pullRequestsModel.create({
                 organizationUuid: user.organizationUuid!,
                 projectUuid,
                 createdByUserUuid: user.userUuid,
                 provider:
-                    type === DbtProjectType.GITHUB
-                        ? PullRequestProvider.GITHUB
-                        : PullRequestProvider.GITLAB,
+                    type === DbtProjectType.BITBUCKET
+                        ? PullRequestProvider.BITBUCKET
+                        : legacyProvider,
                 source,
                 owner,
                 repo,
@@ -200,7 +208,7 @@ export class GitIntegrationService extends BaseService {
         };
     }
 
-    static async createBranch(gitProps: GitProps) {
+    static async createBranch(gitProps: ExploreGitProps) {
         const {
             owner,
             repo,
@@ -212,20 +220,30 @@ export class GitIntegrationService extends BaseService {
             installationId,
         } = gitProps;
 
-        const getLastCommit =
-            type === DbtProjectType.GITHUB
-                ? GithubClient.getLastCommit
-                : GitlabClient.getLastCommit;
         let commitSha: string;
         try {
-            ({ sha: commitSha } = await getLastCommit({
-                owner,
-                repo,
-                branch: mainBranch,
-                installationId,
-                token,
-                hostDomain,
-            }));
+            if (type === DbtProjectType.BITBUCKET) {
+                const baseBranch = await BitbucketClient.getBranch({
+                    owner,
+                    repo,
+                    token,
+                    branch: mainBranch,
+                });
+                commitSha = baseBranch.target.hash;
+            } else {
+                const getLastCommit =
+                    type === DbtProjectType.GITHUB
+                        ? GithubClient.getLastCommit
+                        : GitlabClient.getLastCommit;
+                ({ sha: commitSha } = await getLastCommit({
+                    owner,
+                    repo,
+                    branch: mainBranch,
+                    installationId,
+                    token,
+                    hostDomain,
+                }));
+            }
         } catch (error) {
             // `mainBranch` is the branch from the project's dbt connection
             // settings. Both Git clients report a missing (or invisible)
@@ -243,20 +261,29 @@ export class GitIntegrationService extends BaseService {
             `Creating branch ${branch} from ${mainBranch} (commit: ${commitSha}) in ${owner}/${repo}`,
         );
 
-        const createBranch =
-            type === DbtProjectType.GITHUB
-                ? GithubClient.createBranch
-                : GitlabClient.createBranch;
-
-        await createBranch({
-            branch,
-            owner,
-            repo,
-            sha: commitSha,
-            installationId,
-            token,
-            hostDomain,
-        });
+        if (type === DbtProjectType.BITBUCKET) {
+            await BitbucketClient.createBranch({
+                owner,
+                repo,
+                token,
+                branch,
+                sha: commitSha,
+            });
+        } else {
+            const createBranch =
+                type === DbtProjectType.GITHUB
+                    ? GithubClient.createBranch
+                    : GitlabClient.createBranch;
+            await createBranch({
+                branch,
+                owner,
+                repo,
+                sha: commitSha,
+                installationId,
+                token,
+                hostDomain,
+            });
+        }
 
         Logger.debug(
             `Successfully created branch ${branch} in ${owner}/${repo}`,
@@ -333,7 +360,7 @@ Affected charts:
         installationId?: string;
         token: string;
         branch: string;
-        type: DbtProjectType.GITHUB | DbtProjectType.GITLAB;
+        type: ExploreGitProps['type'];
         hostDomain?: string;
     }) {
         const explore = await this.projectModel.getExploreFromCache(
@@ -350,10 +377,11 @@ Affected charts:
             `${path}/${explore.ymlPath}`,
         );
 
-        const getFileContent =
-            type === DbtProjectType.GITHUB
-                ? GithubClient.getFileContent
-                : GitlabClient.getFileContent;
+        const getFileContent = {
+            [DbtProjectType.GITHUB]: GithubClient.getFileContent,
+            [DbtProjectType.GITLAB]: GitlabClient.getFileContent,
+            [DbtProjectType.BITBUCKET]: BitbucketClient.getFileContent,
+        }[type];
         const { content: fileContent, sha: fileSha } = await getFileContent({
             fileName,
             owner,
@@ -385,7 +413,7 @@ Affected charts:
     }
 
     async updateFile(
-        args: GitProps &
+        args: ExploreGitProps &
             (
                 | {
                       fieldType: 'customDimensions';
@@ -474,22 +502,40 @@ Affected charts:
 
             const message = `Updated file ${fileName} with ${fieldsForTable?.length} custom ${fieldsType} from table ${table}`;
 
-            const updateFile =
-                gitType === DbtProjectType.GITHUB
-                    ? GithubClient.updateFile
-                    : GitlabClient.updateFile;
-            await updateFile({
-                owner,
-                repo,
-                fileName,
-                content: updatedYml,
-                fileSha,
-                branch,
-                installationId,
-                token,
-                hostDomain,
-                message,
-            });
+            if (gitType === DbtProjectType.BITBUCKET) {
+                await BitbucketClient.commitFiles({
+                    owner,
+                    repo,
+                    token,
+                    branch,
+                    expectedParent: fileSha,
+                    message,
+                    changes: [
+                        {
+                            path: fileName,
+                            content: updatedYml,
+                            action: 'upsert',
+                        },
+                    ],
+                });
+            } else {
+                const updateFile =
+                    gitType === DbtProjectType.GITHUB
+                        ? GithubClient.updateFile
+                        : GitlabClient.updateFile;
+                await updateFile({
+                    owner,
+                    repo,
+                    fileName,
+                    content: updatedYml,
+                    fileSha,
+                    branch,
+                    installationId,
+                    token,
+                    hostDomain,
+                    message,
+                });
+            }
             Logger.debug(
                 `Successfully updated file ${fileName} in ${owner}/${repo} (branch: ${branch})`,
             );
@@ -534,7 +580,8 @@ Affected charts:
         ).filter(
             (source) =>
                 source.dbtConnection?.type === DbtProjectType.GITHUB ||
-                source.dbtConnection?.type === DbtProjectType.GITLAB,
+                source.dbtConnection?.type === DbtProjectType.GITLAB ||
+                source.dbtConnection?.type === DbtProjectType.BITBUCKET,
         );
 
         if (additionalGitBackedSources.length === 0) {
@@ -645,6 +692,76 @@ Affected charts:
         return gitProps;
     }
 
+    private async getExploreGitProps(
+        user: SessionUser,
+        projectUuid: string,
+        quoteChar: `"` | `'`,
+    ): Promise<ExploreGitProps> {
+        const project = await this.projectModel.get(projectUuid);
+        const connection = project.dbtConnection;
+        if (
+            connection.type === DbtProjectType.GITHUB ||
+            connection.type === DbtProjectType.GITLAB
+        ) {
+            return this.getGitProps(user, projectUuid, quoteChar);
+        }
+        if (connection.type !== DbtProjectType.BITBUCKET) {
+            throw new ParameterError(
+                `invalid dbt connection type ${connection.type} for project ${project.name}`,
+            );
+        }
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            user.organizationUuid !== organizationUuid ||
+            this.createAuditedAbility(user).cannot(
+                'manage',
+                subject('SourceCode', {
+                    organizationUuid,
+                    projectUuid,
+                    isProtectedBranch: false,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You need permission to manage source code to write back to Bitbucket',
+            );
+        }
+        const repository =
+            BitbucketClient.resolveBitbucketRepository(connection);
+        const credentials = await this.getBitbucketCredentials(
+            user,
+            projectUuid,
+        );
+        if (
+            repository.owner !== credentials.owner ||
+            repository.repo !== credentials.repo
+        ) {
+            throw new ParameterError(
+                'The Bitbucket repository changed. Reload the project before writing back.',
+            );
+        }
+        const relativePath = connection.project_sub_path
+            .trim()
+            .replace(/^\/+|\/+$/g, '');
+        const path = relativePath
+            .split('/')
+            .filter((segment) => segment !== '.')
+            .join('/');
+        const userName = `${snakeCaseName(user.firstName[0] || '')}${snakeCaseName(user.lastName)}`;
+        return {
+            ...credentials,
+            branch: `lightdash-${userName}-${nanoid(4)}`,
+            mainBranch: connection.branch,
+            path,
+            quoteChar,
+            dbtVersion:
+                project.dbtVersion === DbtVersionOptionLatest.LATEST
+                    ? getLatestSupportDbtVersion()
+                    : project.dbtVersion,
+        };
+    }
+
     private static assertCustomDimensionsSupported(
         customDimensions: CustomDimension[],
     ): void {
@@ -690,7 +807,7 @@ Affected charts:
         await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
 
         const user = toSessionUser(account);
-        const gitProps = await this.getGitProps(
+        const gitProps = await this.getExploreGitProps(
             user,
             projectUuid,
             yamlQuoteChar,
@@ -776,7 +893,11 @@ Affected charts:
             GitIntegrationService.assertCustomDimensionsSupported(args.fields);
         }
         await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
-        const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
+        const gitProps = await this.getExploreGitProps(
+            user,
+            projectUuid,
+            quoteChar,
+        );
 
         await GitIntegrationService.createBranch(gitProps);
         if (args.type === 'customMetrics') {
@@ -812,10 +933,11 @@ Affected charts:
             context: QueryExecutionContext.EXPLORE,
         };
         try {
-            const createPullRequest =
-                gitProps.type === DbtProjectType.GITHUB
-                    ? GithubClient.createPullRequest
-                    : GitlabClient.createPullRequest;
+            const createPullRequest = {
+                [DbtProjectType.GITHUB]: GithubClient.createPullRequest,
+                [DbtProjectType.GITLAB]: GitlabClient.createPullRequest,
+                [DbtProjectType.BITBUCKET]: BitbucketClient.createPullRequest,
+            }[gitProps.type];
             const pullRequest: {
                 html_url: string;
                 title: string;
@@ -833,9 +955,9 @@ ${replacementGuidance}`,
 
             Logger.debug(
                 `Successfully created ${
-                    gitProps.type === DbtProjectType.GITHUB
-                        ? 'pull request'
-                        : 'merge request'
+                    gitProps.type === DbtProjectType.GITLAB
+                        ? 'merge request'
+                        : 'pull request'
                 } #${pullRequest.number} in ${gitProps.owner}/${gitProps.repo}`,
             );
 

--- a/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/hooks.ts
@@ -138,3 +138,22 @@ export const useIsGitProject = (projectUuid: string) => {
         project?.dbtConnection.type as DbtProjectType,
     );
 };
+
+export const useSupportsCustomFieldWriteBack = (projectUuid: string) => {
+    const { data: project } = useProject(projectUuid);
+    const connection = project?.dbtConnection;
+    if (!connection) {
+        return false;
+    }
+    if (connection.type === DbtProjectType.BITBUCKET) {
+        const host = connection.host_domain
+            ?.trim()
+            .toLowerCase()
+            .replace(/\.$/, '');
+        return !host || host === 'bitbucket.org';
+    }
+    return (
+        connection.type === DbtProjectType.GITHUB ||
+        connection.type === DbtProjectType.GITLAB
+    );
+};

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.test.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.test.tsx
@@ -1,0 +1,221 @@
+import {
+    DbtProjectType,
+    MetricType,
+    CustomDimensionType,
+    DimensionType,
+    BinType,
+    type CustomDimension,
+    type AdditionalMetric,
+} from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { screen, waitFor, fireEvent, renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import {
+    createExplorerStore,
+    explorerActions,
+} from '../../../features/explorer/store';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { useIsGitProject, useSupportsCustomFieldWriteBack } from './hooks';
+import { SingleItemModalContent, WriteBackModal } from './index';
+
+const project = vi.hoisted(() => ({
+    type: 'github',
+    host_domain: undefined as string | undefined,
+}));
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: () => ({ data: { dbtConnection: project } }),
+}));
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastSuccess: vi.fn(), showToastApiError: vi.fn() }),
+}));
+vi.mock('../../../hooks/useProjectUuid', () => ({
+    useProjectUuid: () => 'project',
+}));
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../../common/CodeBlock/CodeBlock', () => ({
+    default: ({ code }: { code: string }) => <pre>{code}</pre>,
+}));
+
+const metric: AdditionalMetric = {
+    name: 'total_amount',
+    label: 'Total amount',
+    table: 'orders',
+    type: MetricType.SUM,
+    sql: '${TABLE}.amount',
+    baseDimensionName: 'amount',
+};
+const renderModal = (item: AdditionalMetric | CustomDimension = metric) =>
+    renderWithProviders(
+        <QueryClientProvider
+            client={
+                new QueryClient({
+                    defaultOptions: { queries: { retry: false } },
+                })
+            }
+        >
+            <SingleItemModalContent
+                handleClose={vi.fn()}
+                projectUuid="project"
+                item={item}
+            />
+        </QueryClientProvider>,
+    );
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    project.type = DbtProjectType.GITHUB;
+    project.host_domain = undefined;
+});
+
+describe('custom field writeback modal', () => {
+    it('allows a metric submission without requesting a dimension preview', () => {
+        renderModal();
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeEnabled();
+        expect(lightdashApi).not.toHaveBeenCalled();
+        expect(
+            screen.queryByText('Generating warehouse-aware preview...'),
+        ).not.toBeInTheDocument();
+    });
+
+    it.each([
+        [DbtProjectType.GITHUB, undefined, true],
+        [DbtProjectType.GITLAB, undefined, true],
+        [DbtProjectType.BITBUCKET, undefined, true],
+        [DbtProjectType.BITBUCKET, ' BITBUCKET.ORG. ', true],
+        [DbtProjectType.BITBUCKET, 'bitbucket.internal', false],
+        [DbtProjectType.BITBUCKET, 'bitbucket.org.evil.test', false],
+        [DbtProjectType.DBT, undefined, false],
+    ] as const)('allows %s on host %s: %s', (type, host, supported) => {
+        project.type = type;
+        project.host_domain = host;
+        renderModal();
+        const button = screen.getByRole('button', {
+            name: 'Open Pull Request',
+        });
+        if (supported) {
+            expect(button).toBeEnabled();
+        } else {
+            expect(button).toBeDisabled();
+        }
+    });
+
+    it('does not enable Source Editor or ContentAsCode through the generic Git hook', () => {
+        project.type = DbtProjectType.BITBUCKET;
+        const { result } = renderHook(() => ({
+            customFields: useSupportsCustomFieldWriteBack('project'),
+            genericGit: useIsGitProject('project'),
+        }));
+        expect(result.current).toEqual({
+            customFields: true,
+            genericGit: false,
+        });
+    });
+
+    it('submits a Bitbucket metric and displays the returned pull request link', async () => {
+        project.type = DbtProjectType.BITBUCKET;
+        const prUrl = 'https://bitbucket.org/workspace/jaffle/pull-requests/7';
+        vi.mocked(lightdashApi).mockResolvedValue({
+            prUrl,
+            prTitle: 'Add metric',
+        });
+        vi.spyOn(window, 'open').mockImplementation(() => null);
+        renderModal();
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        );
+        await waitFor(() =>
+            expect(screen.getByRole('link', { name: '#7' })).toHaveAttribute(
+                'href',
+                prUrl,
+            ),
+        );
+        expect(lightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/projects/project/git-integration/pull-requests/custom-metrics',
+                method: 'POST',
+                body: JSON.stringify({ customMetrics: [metric] }),
+            }),
+        );
+        vi.restoreAllMocks();
+    });
+
+    it('waits for the warehouse-aware dimension preview before permitting submission', async () => {
+        project.type = DbtProjectType.BITBUCKET;
+        const dimension: CustomDimension = {
+            id: 'amount',
+            name: 'Amount',
+            table: 'orders',
+            type: CustomDimensionType.SQL,
+            dimensionType: DimensionType.NUMBER,
+            sql: '${orders.amount}',
+        };
+        vi.mocked(lightdashApi).mockResolvedValue({
+            yaml: 'amount: test-preview',
+        });
+        renderModal(dimension);
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeDisabled();
+        await waitFor(() =>
+            expect(
+                screen.getByRole('button', { name: 'Open Pull Request' }),
+            ).toBeEnabled(),
+        );
+        expect(lightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                url: '/projects/project/git-integration/pull-requests/custom-dimensions/preview',
+                body: JSON.stringify({ customDimensions: [dimension] }),
+            }),
+        );
+        expect(screen.getByText('amount: test-preview')).toBeVisible();
+    });
+
+    it('enables a bulk metric submission after selecting metrics without a dimension preview', () => {
+        project.type = DbtProjectType.BITBUCKET;
+        const store = createExplorerStore();
+        store.dispatch(
+            explorerActions.toggleWriteBackModal({
+                items: [
+                    metric,
+                    { ...metric, name: 'other', label: 'Other amount' },
+                ],
+            }),
+        );
+        renderWithProviders(
+            <QueryClientProvider client={new QueryClient()}>
+                <Provider store={store}>
+                    <WriteBackModal />
+                </Provider>
+            </QueryClientProvider>,
+        );
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeDisabled();
+        fireEvent.click(screen.getByText('Total amount'));
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeEnabled();
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+
+    it('keeps unsupported fixed-number bins disabled without requesting a preview', () => {
+        project.type = DbtProjectType.BITBUCKET;
+        renderModal({
+            id: 'amount_bin',
+            name: 'Amount bin',
+            table: 'orders',
+            type: CustomDimensionType.BIN,
+            binType: BinType.FIXED_NUMBER,
+            binNumber: 5,
+            dimensionId: 'orders_amount',
+        });
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeDisabled();
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -35,7 +35,7 @@ import { PolymorphicGroupButton } from '../../common/PolymorphicGroupButton';
 import { CreatedPullRequestModalContent } from './CreatedPullRequestModalContent';
 import {
     useCustomDimensionsWriteBackPreview,
-    useIsGitProject,
+    useSupportsCustomFieldWriteBack,
     useWriteBackCustomDimensions,
     useWriteBackCustomMetrics,
 } from './hooks';
@@ -43,7 +43,7 @@ import { convertToDbt, getItemId, getItemLabel, match } from './utils';
 import { BIN_ORDERING_WRITE_BACK_WARNING } from './writeBackSupport';
 
 const prDisabledMessage =
-    'Pull requests can only be opened for Git connected projects (GitHub/GitLab)';
+    'Pull requests can only be opened for GitHub, GitLab or Bitbucket Cloud connected projects';
 const texts = {
     customDimension: {
         name: 'custom dimension',
@@ -108,7 +108,8 @@ export const SingleItemModalContent = ({
     );
 
     const [showDiff, setShowDiff] = useState(true);
-    const isGitProject = useIsGitProject(projectUuid);
+    const supportsCustomFieldWriteBack =
+        useSupportsCustomFieldWriteBack(projectUuid);
     const writeBackError = isCustomDimension(item)
         ? getCustomDimensionWriteBackError(item)
         : null;
@@ -148,12 +149,12 @@ export const SingleItemModalContent = ({
         );
     }
 
-    const disableErrorTooltip = isGitProject && !previewError;
+    const disableErrorTooltip = supportsCustomFieldWriteBack && !previewError;
 
     const errorTooltipLabel = previewError || prDisabledMessage;
 
     const buttonDisabled =
-        isLoading || previewQuery.isLoading || !disableErrorTooltip;
+        isLoading || previewQuery.isInitialLoading || !disableErrorTooltip;
 
     const itemLabel = getItemLabel(item);
 
@@ -219,7 +220,7 @@ export const SingleItemModalContent = ({
                         <CodeBlock
                             code={
                                 previewError ||
-                                (previewQuery.isLoading
+                                (previewQuery.isInitialLoading
                                     ? 'Generating warehouse-aware preview...'
                                     : previewCode)
                             }
@@ -271,7 +272,8 @@ const MultipleItemsModalContent = ({
         () => writeBackCustomMetricsIsLoading,
     );
 
-    const isGitProject = useIsGitProject(projectUuid);
+    const supportsCustomFieldWriteBack =
+        useSupportsCustomFieldWriteBack(projectUuid);
 
     const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
@@ -321,17 +323,19 @@ const MultipleItemsModalContent = ({
     }
 
     const disableErrorTooltip =
-        isGitProject && selectedItemIds.length > 0 && !previewError;
+        supportsCustomFieldWriteBack &&
+        selectedItemIds.length > 0 &&
+        !previewError;
 
     const errorTooltipLabel = previewError
         ? previewError
-        : !isGitProject
+        : !supportsCustomFieldWriteBack
           ? prDisabledMessage
           : `Select ${texts[type].baseName}s to open a pull request`;
 
     const buttonDisabled =
         isLoading ||
-        previewQuery.isLoading ||
+        previewQuery.isInitialLoading ||
         !disableErrorTooltip ||
         selectedItemIds.length === 0;
     return (
@@ -452,7 +456,7 @@ const MultipleItemsModalContent = ({
                         <CodeBlock
                             code={
                                 previewError ||
-                                (previewQuery.isLoading
+                                (previewQuery.isInitialLoading
                                     ? 'Generating warehouse-aware preview...'
                                     : previewCode)
                             }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1997

## Summary

Enables Explorer custom metrics and dimensions to write back to Bitbucket Cloud as part of [SPK-1994](https://linear.app/lightdash/issue/SPK-1994).

Stacks on [#28932](https://github.com/lightdash/lightdash/pull/28932), which adds AI Bitbucket writeback. This PR adds the Explorer workflow using the existing Bitbucket client and dbt YAML transformations.

## Changes

- Resolves the configured repository, base branch and dbt subfolder for Explorer writeback using the project token. Requires source-code management permission before accessing credentials or writing.
- Supports single/bulk custom metrics and supported custom dimensions, including YAML preview and correct PR provider recording. Preserves existing transformation and saved-content replacement rules.
- Rejects ambiguous additional Git-backed sources, including Bitbucket sources.
- Adds an Explorer-specific capability check. Generic source-editor and SQL workflows keep their existing provider gates.
- Fixes metric submission being disabled by an inactive dimension-preview query. Active dimension previews still block submission while loading.

## Writeback flow

```text
Explorer custom field → permissions + source ownership check
                      → configured branch + project token
                      → existing YAML transformation
                      → change branch + Bitbucket PR
```

## Test plan

- [x] 38 backend tests and 23 frontend tests pass, including existing provider behavior and the reproduced disabled-metric regression.
- [x] Backend/frontend type checks and focused lint pass.
- [x] Browser: open the metric writeback modal, submit, and verify its real Bitbucket PR link and YAML change.
- [x] Live API: single metric, bulk metrics, dimension preview and dimension writeback create the expected YAML on the configured nested path and base branch.
- [x] Live invalid-token and anonymous requests fail without creating a PR. Restricted-token write denial, branch conflicts and ambiguous sources are covered at the client boundary.
- [x] All four test PRs declined, branches and local fixtures removed, repository main unchanged.
