### PR TITLE
fix(spaces): keep space picker search responsive with many spaces

### DIFF
--- a/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceSelector.tsx
@@ -6,7 +6,7 @@ import {
 } from '@lightdash/common';
 import { Paper, Stack, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { useMemo, useState } from 'react';
+import { useDeferredValue, useMemo, useState } from 'react';
 import useApp from '../../../providers/App/useApp';
 import AdminContentViewFilter from '../ResourceView/AdminContentViewFilter';
 import Tree from '../Tree/Tree';
@@ -81,10 +81,12 @@ const SpaceSelector = ({
 
     const [searchQuery, setSearchQuery] = useState('');
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 200);
+    // Deferred so a large tree re-render never blocks the next keystroke.
+    const deferredSearchQuery = useDeferredValue(debouncedSearchQuery);
 
     const fuzzyFilteredSpaces = useFuzzyTreeSearch(
         filteredSpaces,
-        debouncedSearchQuery,
+        deferredSearchQuery,
     );
 
     return (

--- a/packages/frontend/src/components/common/Tree/Tree.module.css
+++ b/packages/frontend/src/components/common/Tree/Tree.module.css
@@ -1,5 +1,8 @@
 .node {
     position: relative;
+    /* Off-screen rows skip style and layout work; a row is 32px tall. */
+    content-visibility: auto;
+    contain-intrinsic-size: auto 32px;
 
     &::before {
         position: absolute;

--- a/packages/frontend/src/components/common/Tree/Tree.test.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.test.tsx
@@ -1,0 +1,60 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import Tree from './Tree';
+import { type NestableItem } from './types';
+
+const data: NestableItem[] = [
+    { uuid: 'a', name: 'Alpha', path: 'a' },
+    { uuid: 'b', name: 'Beta', path: 'a.b' },
+    { uuid: 'c', name: 'Gamma', path: 'a.b.c' },
+    { uuid: 'd', name: 'Delta', path: 'd' },
+    { uuid: 'e', name: 'Epsilon', path: 'd.e' },
+];
+
+const renderTree = (isExpanded: boolean, value: string | null) =>
+    renderWithProviders(
+        <Tree
+            topLevelLabel="Spaces"
+            isExpanded={isExpanded}
+            data={data}
+            type="single"
+            value={value}
+            onChange={vi.fn()}
+        />,
+    );
+
+describe('Tree', () => {
+    it('only opens the selected item ancestors by default', () => {
+        renderTree(false, 'c');
+
+        expect(screen.getByText('Gamma')).toBeInTheDocument();
+        expect(screen.queryByText('Epsilon')).not.toBeInTheDocument();
+    });
+
+    it('opens every node while expanded', () => {
+        renderTree(true, 'c');
+
+        expect(screen.getByText('Gamma')).toBeInTheDocument();
+        expect(screen.getByText('Epsilon')).toBeInTheDocument();
+    });
+
+    it('collapses back to the selected item ancestors when no longer expanded', () => {
+        const { rerender } = renderTree(true, 'c');
+        expect(screen.getByText('Epsilon')).toBeInTheDocument();
+
+        rerender(
+            <Tree
+                topLevelLabel="Spaces"
+                isExpanded={false}
+                data={data}
+                type="single"
+                value="c"
+                onChange={vi.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Gamma')).toBeInTheDocument();
+        expect(screen.queryByText('Epsilon')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/Tree/Tree.tsx
+++ b/packages/frontend/src/components/common/Tree/Tree.tsx
@@ -155,6 +155,11 @@ const Tree: React.FC<Props> = (props) => {
     useEffect(() => {
         if (isExpanded) {
             tree.expandAllNodes();
+        } else {
+            // Mantine keeps expanded keys across data changes, so collapse
+            // explicitly and reopen only the selected items' ancestors.
+            tree.collapseAllNodes();
+            items.forEach(expandAllParentPaths);
         }
         // WARNING: does not need to be re-run every time tree ref changes
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/frontend/src/components/common/Tree/useFuzzyTreeSearch.test.ts
+++ b/packages/frontend/src/components/common/Tree/useFuzzyTreeSearch.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { type NestableItem } from './types';
+import useFuzzyTreeSearch from './useFuzzyTreeSearch';
+
+const items: NestableItem[] = [
+    { uuid: '1', name: 'Finance', path: 'finance' },
+    { uuid: '2', name: 'Reports', path: 'finance.reports' },
+    { uuid: '3', name: 'Marketing weekly', path: 'finance.reports.weekly' },
+    { uuid: '4', name: 'Archive', path: 'finance.archive' },
+    { uuid: '5', name: 'Marketing', path: 'marketing' },
+    { uuid: '6', name: 'Drafts', path: 'marketing.drafts' },
+    // Path shares a string prefix with "marketing" but is not its descendant
+    { uuid: '7', name: 'Marketing ops', path: 'marketingops' },
+    { uuid: '8', name: 'Old', path: 'marketingops.old', restricted: true },
+];
+
+const search = (query: string) =>
+    renderHook(() => useFuzzyTreeSearch(items, query)).result.current;
+
+describe('useFuzzyTreeSearch', () => {
+    it('returns undefined when there is no query', () => {
+        expect(search('')).toBeUndefined();
+    });
+
+    it('keeps matches and their ancestors, in the original order', () => {
+        const result = search('marketing');
+
+        expect(
+            result?.map((item) => [item.path, item._fuzzyFilteredBy]),
+        ).toEqual([
+            ['finance', 'parent'],
+            ['finance.reports', 'parent'],
+            ['finance.reports.weekly', 'match'],
+            ['marketing', 'match'],
+            ['marketingops', 'match'],
+        ]);
+    });
+
+    it('does not treat a string-prefix sibling as an ancestor', () => {
+        const result = search('Old');
+
+        expect(result?.map((item) => item.path)).toEqual([
+            'marketingops',
+            'marketingops.old',
+        ]);
+    });
+
+    it('preserves item fields and adds highlight matches', () => {
+        const result = search('Old');
+        const match = result?.find((item) => item.path === 'marketingops.old');
+
+        expect(match).toMatchObject({
+            uuid: '8',
+            restricted: true,
+            _fuzzyFilteredBy: 'match',
+        });
+        expect(
+            match && '_fuzzyMatches' in match && match._fuzzyMatches,
+        ).toEqual(['Old']);
+    });
+
+    it('drops spaces that neither match nor lead to a match', () => {
+        const result = search('Drafts');
+
+        expect(result?.map((item) => item.path)).toEqual([
+            'marketing',
+            'marketing.drafts',
+        ]);
+    });
+});

--- a/packages/frontend/src/components/common/Tree/useFuzzyTreeSearch.ts
+++ b/packages/frontend/src/components/common/Tree/useFuzzyTreeSearch.ts
@@ -8,44 +8,59 @@ export type FuzzyFilteredItem<T> = T & {
     _fuzzyFilteredBy: 'match' | 'parent';
 };
 
+// Module-level constants keep the Fuse index memoized across renders.
+const FUZZY_SEARCH_KEYS = ['name'];
+const FUZZY_SEARCH_OPTIONS = {
+    threshold: 0.3,
+    shouldSort: false,
+    includeMatches: true,
+};
+
+/** Every proper ancestor path of the given ltree-style paths. */
+const getAncestorPaths = (paths: string[]) => {
+    const ancestors = new Set<string>();
+    for (const path of paths) {
+        const segments = path.split('.');
+        for (let depth = segments.length - 1; depth > 0; depth -= 1) {
+            const ancestorPath = segments.slice(0, depth).join('.');
+            // Once an ancestor is known, everything above it is too.
+            if (ancestors.has(ancestorPath)) break;
+            ancestors.add(ancestorPath);
+        }
+    }
+    return ancestors;
+};
+
 function useFuzzyTreeSearch<T extends NestableItem>(items: T[], query: string) {
-    const matchedItems = useFuzzySearch(items, ['name'], query, {
-        threshold: 0.3,
-        shouldSort: false,
-        includeMatches: true,
-    });
+    const matchedItems = useFuzzySearch(
+        items,
+        FUZZY_SEARCH_KEYS,
+        query,
+        FUZZY_SEARCH_OPTIONS,
+    );
 
     const filteredItems = useMemo(() => {
         if (!matchedItems) return;
 
-        return items
-            .map<
-                | FuzzyFilteredItem<T>
-                | FuzzyFilteredItem<FuzzyMatches<T>>
-                | undefined
-            >((item) => {
-                const matchedItem = matchedItems.find(
-                    (m) => m.path === item.path,
-                );
-                const isParentMatch = matchedItems.some((m) =>
-                    m.path.startsWith(item.path),
-                );
+        const matchedByPath = new Map(
+            matchedItems.map((matchedItem) => [matchedItem.path, matchedItem]),
+        );
+        const ancestorPaths = getAncestorPaths(
+            matchedItems.map((matchedItem) => matchedItem.path),
+        );
 
-                if (matchedItem) {
-                    return {
-                        ...matchedItem,
-                        _fuzzyFilteredBy: 'match',
-                    };
-                } else if (isParentMatch) {
-                    return {
-                        ...item,
-                        _fuzzyFilteredBy: 'parent',
-                    };
-                } else {
-                    return undefined;
-                }
-            })
-            .filter((item) => item !== undefined);
+        return items.flatMap<
+            FuzzyFilteredItem<T> | FuzzyFilteredItem<FuzzyMatches<T>>
+        >((item) => {
+            const matchedItem = matchedByPath.get(item.path);
+            if (matchedItem) {
+                return [{ ...matchedItem, _fuzzyFilteredBy: 'match' }];
+            }
+            if (ancestorPaths.has(item.path)) {
+                return [{ ...item, _fuzzyFilteredBy: 'parent' }];
+            }
+            return [];
+        });
     }, [matchedItems, items]);
 
     return filteredItems;


### PR DESCRIPTION
## Problem

Typing in the space search box of the move and transfer modals lags on projects with many nested spaces. The picker filters the whole space list client-side on every keystroke, and the ancestor check scanned the full match list for every space, so a short query cost spaces × matches. After a search, the tree also stayed fully expanded, so clearing the box and browsing manually was slow too.

## Changes

- `useFuzzyTreeSearch`: ancestors are derived from the matched paths (a set walk) instead of a `find` + `some(startsWith)` per space. This also stops a sibling with a shared string prefix (`a.bc` for `a.b`) from being treated as an ancestor.
- Fuse options are module constants so the search index is memoized across renders.
- `Tree`: collapses back to the selected item's ancestors when the search is cleared.
- `SpaceSelector`: the filtered render is deferred so typing never blocks on the tree.
- Tree rows use `content-visibility: auto` so off-screen rows skip style and layout.
- Tests for the hook and for the collapse behaviour.

## Measurements

Production builds before and after, same local backend and data, seeded nested spaces. Main-thread long-task time per keystroke while typing `m`, `ma`, `mar`, then clearing.

| Spaces | Keystroke | Before | After |
|---|---|---|---|
| 3,028 | `m` (647 rows) | 220–330 ms | 100 ms |
| 3,028 | `ma` (167 rows) | 240–270 ms | 165 ms |
| 3,028 | `mar` onwards | 55–125 ms | 0 ms |
| 3,028 | clear | 125 ms, 528 rows left open | 0 ms, 9 rows |
| 10,028 | `m` (2,005 rows) | 750–1,520 ms | 240–300 ms |
| 10,028 | `ma` (332 rows) | 775–960 ms | 380–550 ms |
| 10,028 | `mar` onwards | 170–290 ms | 0–55 ms |
| 10,028 | clear | 375 ms, 1,048 rows left open | 55 ms, 10 rows |

What remains is the React unmount and commit when a very large result narrows to a smaller one.

Closes: #28927
