### PR TITLE
feat(sql-runner): add Bitbucket Cloud model writeback

### DIFF
--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.sqlRunner.test.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.sqlRunner.test.ts
@@ -1,0 +1,516 @@
+import { Ability } from '@casl/ability';
+import {
+    AlreadyExistsError,
+    ConflictError,
+    DbtProjectType,
+    DimensionType,
+    ForbiddenError,
+    NotFoundError,
+    ParameterError,
+    PullRequestProvider,
+    PullRequestSource,
+    PullRequestState,
+    SupportedDbtVersions,
+    UnexpectedGitError,
+    type DbtProjectConfig,
+    type PossibleAbilities,
+    type VizColumn,
+} from '@lightdash/common';
+import { load } from 'js-yaml';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import * as BitbucketClient from '../../clients/bitbucket/Bitbucket';
+import * as GithubClient from '../../clients/github/Github';
+import * as GitlabClient from '../../clients/gitlab/Gitlab';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { GithubAppInstallationsModel } from '../../models/GithubAppInstallations/GithubAppInstallationsModel';
+import { ProjectDbtSourcesModel } from '../../models/ProjectDbtSourcesModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { PullRequestsModel } from '../../models/PullRequestsModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import { GithubAppService } from '../GithubAppService/GithubAppService';
+import { user } from '../ProjectService/ProjectService.mock';
+import { GitIntegrationService } from './GitIntegrationService';
+
+vi.mock('../../clients/bitbucket/Bitbucket', async () => ({
+    ...(await vi.importActual<
+        typeof import('../../clients/bitbucket/Bitbucket')
+    >('../../clients/bitbucket/Bitbucket')),
+    getBranch: vi.fn(),
+    createBranch: vi.fn(),
+    getFileContent: vi.fn(),
+    commitFiles: vi.fn(),
+    createPullRequest: vi.fn(),
+}));
+const legacyClients = vi.hoisted(() => {
+    const createClient = () => ({
+        getLastCommit: vi.fn(),
+        createBranch: vi.fn(),
+        checkFileDoesNotExist: vi.fn(),
+        createFile: vi.fn(),
+        createPullRequest: vi.fn(),
+        getOrRefreshToken: vi.fn(),
+    });
+    return { github: createClient(), gitlab: createClient() };
+});
+vi.mock('../../clients/github/Github', () => legacyClients.github);
+vi.mock('../../clients/gitlab/Gitlab', () => legacyClients.gitlab);
+
+const connection: DbtProjectConfig = {
+    type: DbtProjectType.BITBUCKET,
+    username: 'developer',
+    personal_access_token: 'project-token',
+    repository: 'workspace/analytics',
+    branch: 'release/dbt',
+    project_sub_path: './semantic/',
+};
+const sql = 'select 1 as amount, current_date as order_date';
+const columns: VizColumn[] = [
+    { reference: 'amount', type: DimensionType.NUMBER },
+    { reference: 'order_date', type: DimensionType.DATE },
+];
+const expectedPaths = [
+    'semantic/models/lightdash/daily_revenue.sql',
+    'semantic/models/lightdash/daily_revenue.yml',
+];
+const writebackUser = {
+    ...user,
+    organizationUuid: 'organization',
+    ability: new Ability<PossibleAbilities>([
+        {
+            action: 'view',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+            },
+        },
+        {
+            action: 'manage',
+            subject: 'SourceCode',
+            conditions: {
+                organizationUuid: 'organization',
+                projectUuid: 'project',
+                isProtectedBranch: false,
+            },
+        },
+    ]),
+};
+const prUrl = 'https://bitbucket.org/workspace/analytics/pull-requests/21';
+
+const setup = (dbtConnection: DbtProjectConfig = connection) => {
+    const project = {
+        projectUuid: 'project',
+        organizationUuid: 'organization',
+        name: 'Analytics',
+        dbtVersion: SupportedDbtVersions.V1_9,
+        dbtConnection,
+    };
+    const projectModel = {
+        get: vi.fn().mockResolvedValue({
+            ...project,
+            dbtConnection: { ...dbtConnection, personal_access_token: '' },
+        }),
+        getSummary: vi
+            .fn()
+            .mockResolvedValue({ organizationUuid: 'organization' }),
+        getWithSensitiveFields: vi.fn().mockResolvedValue(project),
+    };
+    const pullRequests = { create: vi.fn().mockResolvedValue(undefined) };
+    const service = new GitIntegrationService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        projectDbtSourcesModel: {} as ProjectDbtSourcesModel,
+        pullRequestsModel: pullRequests as unknown as PullRequestsModel,
+        savedChartModel: {} as SavedChartModel,
+        spaceModel: {} as SpaceModel,
+        githubAppInstallationsModel: {
+            getInstallationId: vi.fn().mockResolvedValue('installation'),
+            getAuth: vi.fn().mockResolvedValue({
+                token: 'project-token',
+                refreshToken: 'refresh',
+            }),
+        } as unknown as GithubAppInstallationsModel,
+        githubAppService: {
+            getValidUserToken: vi.fn().mockResolvedValue(undefined),
+        } as unknown as GithubAppService,
+    });
+    const create = () =>
+        service.createPullRequestFromSql(
+            writebackUser,
+            'project',
+            'Daily Revenue',
+            sql,
+            columns,
+        );
+    return { service, create, projectModel, pullRequests };
+};
+
+beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(BitbucketClient.getBranch).mockImplementation(
+        async ({ branch }) => ({
+            name: branch,
+            target: {
+                hash:
+                    branch === connection.branch
+                        ? 'base-sha'
+                        : 'captured-parent',
+            },
+        }),
+    );
+    vi.mocked(BitbucketClient.createBranch).mockResolvedValue({
+        name: 'feature',
+        target: { hash: 'base-sha' },
+    });
+    vi.mocked(BitbucketClient.getFileContent).mockRejectedValue(
+        new NotFoundError('No file'),
+    );
+    vi.mocked(BitbucketClient.commitFiles).mockResolvedValue(undefined);
+    vi.mocked(BitbucketClient.createPullRequest).mockResolvedValue({
+        number: 21,
+        title: 'Create model',
+        html_url: prUrl,
+        state: PullRequestState.OPEN,
+        head: 'feature',
+        base: connection.branch,
+    });
+    for (const client of Object.values(legacyClients)) {
+        client.getLastCommit.mockResolvedValue({
+            sha: 'legacy-base',
+        });
+        client.createBranch.mockResolvedValue(undefined);
+        client.checkFileDoesNotExist.mockResolvedValue(undefined);
+        client.createFile.mockResolvedValue(undefined);
+        client.createPullRequest.mockResolvedValue({
+            number: 21,
+            title: 'Create model',
+            html_url: 'https://example.com/pr/21',
+        });
+    }
+    vi.mocked(GithubClient.getOrRefreshToken).mockResolvedValue({
+        token: 'project-token',
+        refreshToken: 'refresh',
+    });
+});
+
+describe('Bitbucket SQL Runner writeback', () => {
+    it('creates SQL and YAML atomically from the captured feature-branch parent', async () => {
+        const { create, pullRequests } = setup();
+        await expect(create()).resolves.toEqual({
+            prTitle: 'Create model',
+            prUrl,
+        });
+        const { branch } = vi.mocked(BitbucketClient.createBranch).mock
+            .calls[0][0];
+        expect(BitbucketClient.createBranch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                owner: 'workspace',
+                repo: 'analytics',
+                token: 'project-token',
+                sha: 'base-sha',
+            }),
+        );
+        expect(branch).not.toBe(connection.branch);
+        expect(
+            vi
+                .mocked(BitbucketClient.getFileContent)
+                .mock.calls.map(([args]) => args.fileName)
+                .sort(),
+        ).toEqual(expectedPaths);
+        expect(BitbucketClient.commitFiles).toHaveBeenCalledTimes(1);
+        const [commit] = vi.mocked(BitbucketClient.commitFiles).mock.calls[0];
+        expect(commit).toMatchObject({
+            branch,
+            expectedParent: 'captured-parent',
+            owner: 'workspace',
+            repo: 'analytics',
+            token: 'project-token',
+        });
+        expect(commit.changes.map((change) => change.path)).toEqual(
+            expectedPaths,
+        );
+        const [sqlChange, yamlChange] = commit.changes;
+        if (sqlChange.action !== 'upsert' || yamlChange.action !== 'upsert') {
+            throw new Error('Expected two new model files');
+        }
+        expect(sqlChange.content).toContain("tags=['created-by-lightdash']");
+        expect(sqlChange.content).toContain(sql);
+        expect(load(yamlChange.content)).toMatchObject({
+            version: 2,
+            models: [
+                {
+                    name: 'daily_revenue',
+                    columns: [
+                        {
+                            name: 'amount',
+                            meta: { dimension: { type: 'number' } },
+                        },
+                        {
+                            name: 'order_date',
+                            meta: { dimension: { type: 'date' } },
+                        },
+                    ],
+                },
+            ],
+        });
+        expect(BitbucketClient.createPullRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ head: branch, base: 'release/dbt' }),
+        );
+        expect(pullRequests.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: PullRequestProvider.BITBUCKET,
+                source: PullRequestSource.SQL_RUNNER,
+                prUrl,
+                projectUuid: 'project',
+            }),
+        );
+    });
+
+    it('rejects a branch change during collision checks instead of accepting the newer parent', async () => {
+        const { create } = setup();
+        let currentParent = 'captured-parent';
+        vi.mocked(BitbucketClient.getBranch).mockImplementation(
+            async ({ branch }) => ({
+                name: branch,
+                target: {
+                    hash:
+                        branch === connection.branch
+                            ? 'base-sha'
+                            : currentParent,
+                },
+            }),
+        );
+        vi.mocked(BitbucketClient.getFileContent).mockImplementation(
+            async () => {
+                currentParent = 'concurrent-parent';
+                throw new NotFoundError('No file');
+            },
+        );
+        vi.mocked(BitbucketClient.commitFiles).mockImplementation(
+            async ({ expectedParent }) => {
+                if (expectedParent !== currentParent) {
+                    throw new ConflictError(
+                        'Branch changed during file checks',
+                    );
+                }
+            },
+        );
+        await expect(create()).rejects.toBeInstanceOf(ConflictError);
+        expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it.each(expectedPaths)(
+        'does not overwrite existing %s or publish a PR',
+        async (existingPath) => {
+            const { create, pullRequests } = setup();
+            vi.mocked(BitbucketClient.getFileContent).mockImplementation(
+                async ({ fileName }) => {
+                    if (fileName === existingPath) {
+                        return {
+                            content: 'existing content',
+                            sha: 'captured-parent',
+                        };
+                    }
+                    throw new NotFoundError('No file');
+                },
+            );
+            await expect(create()).rejects.toBeInstanceOf(AlreadyExistsError);
+            expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+            expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+            expect(pullRequests.create).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each([
+        new ForbiddenError('Invalid token'),
+        new UnexpectedGitError('API unavailable'),
+    ])(
+        'does not treat a failed collision check as an absent file: %s',
+        async (error) => {
+            const { create } = setup();
+            vi.mocked(BitbucketClient.getFileContent).mockRejectedValueOnce(
+                error,
+            );
+            await expect(create()).rejects.toBe(error);
+            expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+            expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each([
+        new ConflictError('Concurrent update'),
+        new ForbiddenError('Missing write scope'),
+    ])(
+        'does not publish or record a PR when the atomic commit fails: %s',
+        async (error) => {
+            const { create, pullRequests } = setup();
+            vi.mocked(BitbucketClient.commitFiles).mockRejectedValueOnce(error);
+            await expect(create()).rejects.toBe(error);
+            expect(BitbucketClient.createPullRequest).not.toHaveBeenCalled();
+            expect(pullRequests.create).not.toHaveBeenCalled();
+        },
+    );
+
+    it('does not record a PR that Bitbucket refused to create', async () => {
+        const { create, pullRequests } = setup();
+        vi.mocked(BitbucketClient.createPullRequest).mockRejectedValueOnce(
+            new ForbiddenError('Missing PR scope'),
+        );
+        await expect(create()).rejects.toBeInstanceOf(ForbiddenError);
+        expect(BitbucketClient.commitFiles).toHaveBeenCalledTimes(1);
+        expect(pullRequests.create).not.toHaveBeenCalled();
+    });
+
+    it.each(['create', 'preview'] as const)(
+        'requires manage SourceCode before loading credentials for %s',
+        async (action) => {
+            const { service, projectModel } = setup();
+            const reader = {
+                ...writebackUser,
+                ability: new Ability<PossibleAbilities>([
+                    {
+                        action: 'view',
+                        subject: 'SourceCode',
+                        conditions: {
+                            projectUuid: 'project',
+                            organizationUuid: 'organization',
+                        },
+                    },
+                ]),
+            };
+            await expect(
+                action === 'create'
+                    ? service.createPullRequestFromSql(
+                          reader,
+                          'project',
+                          'Daily Revenue',
+                          sql,
+                          columns,
+                      )
+                    : service.writeBackPreview(
+                          reader,
+                          'project',
+                          'Daily Revenue',
+                      ),
+            ).rejects.toBeInstanceOf(ForbiddenError);
+            expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+            expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+        },
+    );
+
+    it('checks the resource organization before loading project credentials', async () => {
+        const { create, projectModel } = setup();
+        projectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'other-organization',
+        });
+        await expect(create()).rejects.toBeInstanceOf(ForbiddenError);
+        expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+    });
+
+    it('previews the Bitbucket URL and normalized paths without writing files', async () => {
+        const { service } = setup();
+        await expect(
+            service.writeBackPreview(writebackUser, 'project', 'Daily Revenue'),
+        ).resolves.toEqual({
+            url: 'https://bitbucket.org/workspace/analytics',
+            owner: 'workspace',
+            repo: 'analytics',
+            path: 'semantic/models/lightdash',
+            files: expectedPaths,
+        });
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+        expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+    });
+
+    it('rejects self-hosted Bitbucket and leaves generic source editing disabled', async () => {
+        const { create } = setup({
+            ...connection,
+            host_domain: 'bitbucket.internal',
+        });
+        await expect(create()).rejects.toBeInstanceOf(ParameterError);
+        const { service } = setup();
+        await expect(
+            service.getGitCredentials(writebackUser, 'project'),
+        ).rejects.toBeInstanceOf(ParameterError);
+        expect(BitbucketClient.createBranch).not.toHaveBeenCalled();
+    });
+});
+
+describe.each([DbtProjectType.GITHUB, DbtProjectType.GITLAB] as const)(
+    '%s SQL Runner regression',
+    (type) => {
+        const legacyConnection: DbtProjectConfig = {
+            ...connection,
+            type,
+            authorization_method: 'personal_access_token',
+            project_sub_path: 'dbt',
+            host_domain:
+                type === DbtProjectType.GITLAB ? 'gitlab.internal' : undefined,
+        };
+        const client =
+            type === DbtProjectType.GITHUB ? GithubClient : GitlabClient;
+
+        it('retains separate SQL/YAML writes and the configured PR destination', async () => {
+            const { create, pullRequests } = setup(legacyConnection);
+            await expect(create()).resolves.toMatchObject({
+                prUrl: 'https://example.com/pr/21',
+            });
+            expect(client.checkFileDoesNotExist).toHaveBeenCalledTimes(2);
+            expect(client.createFile).toHaveBeenCalledTimes(2);
+            const files = vi
+                .mocked(client.createFile)
+                .mock.calls.map(([args]) => args);
+            expect(files[0]).toMatchObject({
+                fileName: 'dbt/models/lightdash/daily_revenue.sql',
+                content: expect.stringContaining(sql),
+            });
+            expect(files[1]).toMatchObject({
+                fileName: 'dbt/models/lightdash/daily_revenue.yml',
+            });
+            expect(load(files[1].content)).toMatchObject({
+                version: 2,
+                models: [{ name: 'daily_revenue' }],
+            });
+            expect(client.createPullRequest).toHaveBeenCalledWith(
+                expect.objectContaining({ base: connection.branch }),
+            );
+            expect(pullRequests.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    provider:
+                        type === DbtProjectType.GITHUB
+                            ? PullRequestProvider.GITHUB
+                            : PullRequestProvider.GITLAB,
+                    source: PullRequestSource.SQL_RUNNER,
+                }),
+            );
+            expect(BitbucketClient.commitFiles).not.toHaveBeenCalled();
+        });
+
+        it('previews without loading credentials or calling the Git provider', async () => {
+            const { service, projectModel } = setup(legacyConnection);
+            const result = await service.writeBackPreview(
+                writebackUser,
+                'project',
+                'Daily Revenue',
+            );
+            expect(result).toEqual({
+                url:
+                    type === DbtProjectType.GITHUB
+                        ? 'https://github.com/workspace/analytics'
+                        : 'https://gitlab.internal/workspace/analytics',
+                owner: 'workspace',
+                repo: 'analytics',
+                path: 'dbt/models/lightdash',
+                files: [
+                    'dbt/models/lightdash/daily_revenue.sql',
+                    'dbt/models/lightdash/daily_revenue.yml',
+                ],
+            });
+            expect(projectModel.getWithSensitiveFields).not.toHaveBeenCalled();
+            expect(client.createBranch).not.toHaveBeenCalled();
+            expect(client.checkFileDoesNotExist).not.toHaveBeenCalled();
+        });
+    },
+);

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -2,6 +2,7 @@
 import { subject } from '@casl/ability';
 import {
     AdditionalMetric,
+    AlreadyExistsError,
     ApiCustomDimensionWriteBackPreview,
     ApiGithubDbtWritePreview,
     CustomDimension,
@@ -88,11 +89,11 @@ type GitProps = {
     semanticLayer?: 'dbt' | 'lightdash';
 };
 
-type ExploreGitProps =
+type DbtWritebackGitProps =
     | GitProps
     | (Omit<GitProps, 'type'> & { type: DbtProjectType.BITBUCKET });
 
-type WriteBackFileArgs = ExploreGitProps &
+type WriteBackFileArgs = DbtWritebackGitProps &
     (
         | {
               fieldType: 'customDimensions';
@@ -225,7 +226,7 @@ export class GitIntegrationService extends BaseService {
         };
     }
 
-    static async createBranch(gitProps: ExploreGitProps) {
+    static async createBranch(gitProps: DbtWritebackGitProps) {
         const {
             owner,
             repo,
@@ -377,7 +378,7 @@ Affected charts:
         installationId?: string;
         token: string;
         branch: string;
-        type: ExploreGitProps['type'];
+        type: DbtWritebackGitProps['type'];
         hostDomain?: string;
     }) {
         const project = await this.projectModel.get(projectUuid);
@@ -763,11 +764,11 @@ Affected charts:
         return gitProps;
     }
 
-    private async getExploreGitProps(
+    private async getDbtWritebackGitProps(
         user: SessionUser,
         projectUuid: string,
         quoteChar: `"` | `'`,
-    ): Promise<ExploreGitProps> {
+    ): Promise<DbtWritebackGitProps> {
         const project = await this.projectModel.get(projectUuid);
         const connection = project.dbtConnection;
         if (
@@ -878,7 +879,7 @@ Affected charts:
         await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
 
         const user = toSessionUser(account);
-        const gitProps = await this.getExploreGitProps(
+        const gitProps = await this.getDbtWritebackGitProps(
             user,
             projectUuid,
             yamlQuoteChar,
@@ -969,7 +970,7 @@ Affected charts:
             GitIntegrationService.assertCustomDimensionsSupported(args.fields);
         }
         await this.assertExploreWritebackSourceIsUnambiguous(projectUuid);
-        const gitProps = await this.getExploreGitProps(
+        const gitProps = await this.getDbtWritebackGitProps(
             user,
             projectUuid,
             quoteChar,
@@ -1115,6 +1116,48 @@ ${replacementGuidance}`,
         return GitIntegrationService.removeExtraSlashes(filePath);
     }
 
+    private static buildSqlModelContent(sql: string): string {
+        return `
+{{
+  config(
+    tags=['created-by-lightdash']
+  )
+}}
+
+${sql}
+`;
+    }
+
+    private static buildYamlModelContent({
+        name,
+        columns,
+        quoteChar,
+    }: {
+        name: string;
+        columns: VizColumn[];
+        quoteChar: GitProps['quoteChar'];
+    }): string {
+        return new DbtSchemaEditor(`version: 2`)
+            .addModel({
+                name: snakeCaseName(name),
+                description: `SQL model for ${friendlyName(name)}`,
+                meta: {
+                    label: friendlyName(name),
+                },
+                columns: columns.map((c) => ({
+                    name: c.reference,
+                    meta: {
+                        dimension: {
+                            type: c.type,
+                        },
+                    },
+                })),
+            })
+            .toString({
+                quoteChar,
+            });
+    }
+
     private static async createSqlFile({
         gitProps,
         name,
@@ -1140,15 +1183,7 @@ ${replacementGuidance}`,
             path: fileName,
         });
 
-        const content = `
-{{
-  config(
-    tags=['created-by-lightdash']
-  )
-}}
-  
-${sql}
-`;
+        const content = GitIntegrationService.buildSqlModelContent(sql);
 
         const message = `Created file ${fileName} `;
 
@@ -1189,25 +1224,11 @@ ${sql}
             path: fileName,
         });
 
-        const content = new DbtSchemaEditor(`version: 2`)
-            .addModel({
-                name: snakeCaseName(name),
-                description: `SQL model for ${friendlyName(name)}`,
-                meta: {
-                    label: friendlyName(name),
-                },
-                columns: columns.map((c) => ({
-                    name: c.reference,
-                    meta: {
-                        dimension: {
-                            type: c.type,
-                        },
-                    },
-                })),
-            })
-            .toString({
-                quoteChar: gitProps.quoteChar,
-            });
+        const content = GitIntegrationService.buildYamlModelContent({
+            name,
+            columns,
+            quoteChar: gitProps.quoteChar,
+        });
 
         const message = `Created file ${fileName} `;
 
@@ -1237,6 +1258,71 @@ ${sql}
         }
     }
 
+    private static async createBitbucketSqlModel({
+        gitProps,
+        name,
+        sql,
+        columns,
+    }: {
+        gitProps: Extract<
+            DbtWritebackGitProps,
+            { type: DbtProjectType.BITBUCKET }
+        >;
+        name: string;
+        sql: string;
+        columns: VizColumn[];
+    }): Promise<void> {
+        const changes: BitbucketClient.BitbucketFileChange[] = [
+            {
+                action: 'upsert',
+                path: GitIntegrationService.getFilePath(
+                    gitProps.path,
+                    name,
+                    'sql',
+                ),
+                content: GitIntegrationService.buildSqlModelContent(sql),
+            },
+            {
+                action: 'upsert',
+                path: GitIntegrationService.getFilePath(
+                    gitProps.path,
+                    name,
+                    'yml',
+                ),
+                content: GitIntegrationService.buildYamlModelContent({
+                    name,
+                    columns,
+                    quoteChar: gitProps.quoteChar,
+                }),
+            },
+        ];
+        const parent = await BitbucketClient.getBranch(gitProps);
+        await Promise.all(
+            changes.map(async (change) => {
+                try {
+                    await BitbucketClient.getFileContent({
+                        ...gitProps,
+                        fileName: change.path,
+                    });
+                } catch (error) {
+                    if (error instanceof NotFoundError) {
+                        return;
+                    }
+                    throw error;
+                }
+                throw new AlreadyExistsError(
+                    `File ${change.path} already exists`,
+                );
+            }),
+        );
+        await BitbucketClient.commitFiles({
+            ...gitProps,
+            expectedParent: parent.target.hash,
+            message: `Created SQL and YML model for ${name}`,
+            changes,
+        });
+    }
+
     async createPullRequestFromSql(
         user: SessionUser,
         projectUuid: string,
@@ -1245,25 +1331,38 @@ ${sql}
         columns: VizColumn[],
         quoteChar: `"` | `'` = '"',
     ): Promise<PullRequestCreated> {
-        const gitProps = await this.getGitProps(user, projectUuid, quoteChar);
+        const gitProps = await this.getDbtWritebackGitProps(
+            user,
+            projectUuid,
+            quoteChar,
+        );
         await this.assertSqlModelWritebackSupported(projectUuid);
         await GitIntegrationService.createBranch(gitProps);
 
-        await GitIntegrationService.createSqlFile({
-            gitProps,
-            name,
-            sql,
-        });
-        await GitIntegrationService.createYmlFile({
-            gitProps,
-            name,
-            columns,
-        });
+        if (gitProps.type === DbtProjectType.BITBUCKET) {
+            await GitIntegrationService.createBitbucketSqlModel({
+                gitProps,
+                name,
+                sql,
+                columns,
+            });
+        } else {
+            await GitIntegrationService.createSqlFile({
+                gitProps,
+                name,
+                sql,
+            });
+            await GitIntegrationService.createYmlFile({
+                gitProps,
+                name,
+                columns,
+            });
+        }
         Logger.debug(
             `Creating ${
-                gitProps.type === DbtProjectType.GITHUB
-                    ? 'pull request'
-                    : 'merge request'
+                gitProps.type === DbtProjectType.GITLAB
+                    ? 'merge request'
+                    : 'pull request'
             } from branch ${gitProps.branch} to ${gitProps.mainBranch} in ${
                 gitProps.owner
             }/${gitProps.repo}`,
@@ -1275,10 +1374,11 @@ ${sql}
             context: QueryExecutionContext.SQL_RUNNER,
         };
         try {
-            const createPullRequest =
-                gitProps.type === DbtProjectType.GITHUB
-                    ? GithubClient.createPullRequest
-                    : GitlabClient.createPullRequest;
+            const createPullRequest = {
+                [DbtProjectType.GITHUB]: GithubClient.createPullRequest,
+                [DbtProjectType.GITLAB]: GitlabClient.createPullRequest,
+                [DbtProjectType.BITBUCKET]: BitbucketClient.createPullRequest,
+            }[gitProps.type];
 
             const pullRequest: {
                 html_url: string;
@@ -1297,9 +1397,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
 
             Logger.debug(
                 `Successfully created ${
-                    gitProps.type === DbtProjectType.GITHUB
-                        ? 'pull request'
-                        : 'merge request'
+                    gitProps.type === DbtProjectType.GITLAB
+                        ? 'merge request'
+                        : 'pull request'
                 } #${pullRequest.number} in ${gitProps.owner}/${gitProps.repo}`,
             );
 
@@ -1341,6 +1441,26 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         name: string,
     ): Promise<ApiGithubDbtWritePreview['results']> {
         await this.assertSqlModelWritebackSupported(projectUuid);
+        const project = await this.projectModel.get(projectUuid);
+        if (project.dbtConnection.type === DbtProjectType.BITBUCKET) {
+            const { owner, repo, path } = await this.getDbtWritebackGitProps(
+                user,
+                projectUuid,
+                '"',
+            );
+            return {
+                url: `https://bitbucket.org/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+                owner,
+                repo,
+                path: GitIntegrationService.removeExtraSlashes(
+                    `${path}/models/lightdash`,
+                ),
+                files: [
+                    GitIntegrationService.getFilePath(path, name, 'sql'),
+                    GitIntegrationService.getFilePath(path, name, 'yml'),
+                ],
+            };
+        }
         const { owner, repo, path, type, hostDomain } =
             await this.getProjectRepo(projectUuid);
 

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.test.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.test.tsx
@@ -1,0 +1,161 @@
+import { DbtProjectType } from '@lightdash/common';
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { HeaderCreate } from './HeaderCreate';
+
+const mocks = vi.hoisted(() => ({
+    project: {
+        name: 'Jaffle',
+        dbtConnection: {
+            type: 'bitbucket',
+            host_domain: undefined as string | undefined,
+            semanticLayer: undefined as 'dbt' | 'lightdash' | undefined,
+        },
+    },
+    hasGithub: false,
+    gitEnabled: false,
+    canWrite: true,
+    dispatch: vi.fn(),
+}));
+const state = {
+    sqlRunner: {
+        projectUuid: 'project',
+        name: 'SQL query',
+        sqlColumns: [],
+        selectedChartType: null,
+        modals: {
+            saveChartModal: { isOpen: false },
+            createVirtualViewModal: { isOpen: false },
+            writeBackToDbtModal: { isOpen: false },
+            chartErrorsAlert: { isOpen: false },
+        },
+    },
+};
+vi.mock('../../store/hooks', () => ({
+    useAppDispatch: () => mocks.dispatch,
+    useAppSelector: (selector: (value: typeof state) => unknown) =>
+        selector(state),
+}));
+vi.mock('../../../../hooks/useProject', () => ({
+    useProject: () => ({ data: mocks.project }),
+}));
+vi.mock('../../../../hooks/health/useHealth', () => ({
+    default: () => ({
+        data: {
+            hasGithub: mocks.hasGithub,
+            siteUrl: 'https://app.example.com',
+        },
+    }),
+}));
+vi.mock('../../../../hooks/gitIntegration/useGitIntegration', () => ({
+    useGitIntegration: () => ({ data: { enabled: mocks.gitEnabled } }),
+}));
+vi.mock('../../../../providers/App/useApp', () => ({
+    default: () => ({
+        health: { data: undefined },
+        user: {
+            data: {
+                organizationUuid: 'organization',
+                ability: {
+                    can: (
+                        _action: string,
+                        resource: { __caslSubjectType__: string },
+                    ) =>
+                        resource.__caslSubjectType__ === 'SourceCode' &&
+                        mocks.canWrite,
+                },
+            },
+        },
+    }),
+}));
+vi.mock('../../../../hooks/user/useCreateInAnySpaceAccess', () => ({
+    default: () => false,
+}));
+vi.mock('../../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastSuccess: vi.fn() }),
+}));
+vi.mock('../../hooks/useSqlRunnerShareUrl', () => ({
+    useCreateSqlRunnerShareUrl: () => vi.fn(),
+}));
+vi.mock('../../../../components/DataViz/store/selectors', () => ({
+    cartesianChartSelectors: { getErrors: () => null },
+}));
+vi.mock(
+    '../../../../components/VisualizationConfigs/common/EditableText',
+    () => ({ EditableText: () => null }),
+);
+vi.mock('../../../virtualView', () => ({ CreateVirtualViewModal: () => null }));
+vi.mock('../SaveSqlChartModal', () => ({ SaveSqlChartModal: () => null }));
+vi.mock('../WriteBackToDbtModal', () => ({ WriteBackToDbtModal: () => null }));
+vi.mock('../ChartErrorsAlert', () => ({ ChartErrorsAlert: () => null }));
+
+beforeEach(() => {
+    mocks.project.dbtConnection.type = DbtProjectType.BITBUCKET;
+    mocks.project.dbtConnection.host_domain = undefined;
+    mocks.project.dbtConnection.semanticLayer = undefined;
+    mocks.hasGithub = false;
+    mocks.gitEnabled = false;
+    mocks.canWrite = true;
+    mocks.dispatch.mockClear();
+});
+
+describe('SQL writeback header', () => {
+    it('opens Bitbucket Cloud writeback without GitHub configuration', () => {
+        renderWithProviders(<HeaderCreate />);
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Write back to dbt' }),
+        );
+        expect(mocks.dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ payload: 'writeBackToDbtModal' }),
+        );
+    });
+    it('keeps SQL model creation disabled for native GitHub projects', () => {
+        mocks.project.dbtConnection.type = DbtProjectType.GITHUB;
+        mocks.project.dbtConnection.semanticLayer = 'lightdash';
+        mocks.hasGithub = true;
+        mocks.gitEnabled = true;
+        renderWithProviders(<HeaderCreate />);
+        expect(
+            screen.getByRole('button', { name: 'Write back to dbt' }),
+        ).toBeDisabled();
+        expect(mocks.dispatch).not.toHaveBeenCalled();
+    });
+    it('does not offer writeback without SourceCode permission', () => {
+        mocks.canWrite = false;
+        renderWithProviders(<HeaderCreate />);
+        expect(
+            screen.queryByRole('button', { name: 'Write back to dbt' }),
+        ).not.toBeInTheDocument();
+    });
+    it.each(['bitbucket.internal', 'bitbucket.org.evil.test'])(
+        'keeps unsupported host %s disabled',
+        (host) => {
+            mocks.project.dbtConnection.host_domain = host;
+            renderWithProviders(<HeaderCreate />);
+            expect(
+                screen.getByRole('button', { name: 'Write back to dbt' }),
+            ).toBeDisabled();
+        },
+    );
+    it.each([DbtProjectType.GITHUB, DbtProjectType.GITLAB])(
+        'preserves %s integration requirements',
+        (type) => {
+            mocks.project.dbtConnection.type = type;
+            const { rerender } = renderWithProviders(<HeaderCreate />);
+            expect(
+                screen.getByRole('button', { name: 'Write back to dbt' }),
+            ).toBeDisabled();
+            mocks.hasGithub = true;
+            rerender(<HeaderCreate />);
+            expect(
+                screen.getByRole('button', { name: 'Write back to dbt' }),
+            ).toBeDisabled();
+            mocks.gitEnabled = true;
+            rerender(<HeaderCreate />);
+            expect(
+                screen.getByRole('button', { name: 'Write back to dbt' }),
+            ).toBeEnabled();
+        },
+    );
+});

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -11,7 +11,7 @@ import {
 } from '@mantine/core';
 import { useClipboard } from '@mantine/hooks';
 import {
-    IconBrandGithub,
+    IconGitPullRequest,
     IconChevronDown,
     IconDeviceFloppy,
     IconLink,
@@ -37,6 +37,7 @@ import {
     toggleModal,
     updateName,
 } from '../../store/sqlRunnerSlice';
+import { isBitbucketCloudConnection } from '../../utils/isBitbucketCloudConnection';
 import { ChartErrorsAlert } from '../ChartErrorsAlert';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
@@ -113,6 +114,14 @@ export const HeaderCreate: FC = () => {
                 undefined,
             ];
         }
+        if (project?.dbtConnection.type === DbtProjectType.BITBUCKET) {
+            return isBitbucketCloudConnection(project.dbtConnection)
+                ? [undefined, undefined]
+                : [
+                      'SQL writeback supports Bitbucket Cloud only. Update the project connection.',
+                      `${health?.data?.siteUrl}/generalSettings/projectManagement/${projectUuid}/settings`,
+                  ];
+        }
         const hasGithubEnabled = gitIntegration?.enabled;
         const hasGitProject = [
             DbtProjectType.GITHUB,
@@ -139,8 +148,8 @@ export const HeaderCreate: FC = () => {
                     <Text span fw={600}>
                         {project?.name}
                     </Text>{' '}
-                    is not connected to a GitHub or GitLab repository, click
-                    here to open project settings page
+                    is not connected to a GitHub, GitLab or Bitbucket Cloud
+                    repository, click here to open project settings page
                 </Text>,
                 `${health?.data?.siteUrl}/generalSettings/projectManagement/${projectUuid}/settings`,
             ];
@@ -251,7 +260,7 @@ export const HeaderCreate: FC = () => {
             case 'createVirtualView':
                 return <MantineIcon icon={IconTableAlias} />;
             case 'writeBackToDbt':
-                return <MantineIcon icon={IconBrandGithub} />;
+                return <MantineIcon icon={IconGitPullRequest} />;
         }
     }, []);
 
@@ -276,7 +285,8 @@ export const HeaderCreate: FC = () => {
         !loadedColumns ||
         (ctaAction === 'save' && !canSaveChart) ||
         (ctaAction === 'createVirtualView' && !canCreateVirtualView) ||
-        (ctaAction === 'writeBackToDbt' && !canWriteBackToDbt);
+        (ctaAction === 'writeBackToDbt' &&
+            (!canWriteBackToDbt || writeBackDisabledMessage !== undefined));
 
     const hasAnyAction =
         canSaveChart || canCreateVirtualView || canWriteBackToDbt;

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.test.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.test.tsx
@@ -1,0 +1,179 @@
+import { DbtProjectType } from '@lightdash/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { WriteBackToDbtModal } from './WriteBackToDbtModal';
+
+const mocks = vi.hoisted(() => ({
+    project: {
+        dbtConnection: {
+            type: 'bitbucket',
+            host_domain: undefined as string | undefined,
+        },
+    },
+    hasGithub: false,
+    showToastError: vi.fn(),
+}));
+const state = {
+    sqlRunner: {
+        projectUuid: 'project',
+        sql: 'select 1 as amount',
+        sqlColumns: [{ name: 'amount', type: 'number' }],
+    },
+};
+vi.mock('../store/hooks', () => ({
+    useAppSelector: (selector: (value: typeof state) => unknown) =>
+        selector(state),
+}));
+vi.mock('../../../hooks/useProject', () => ({
+    useProject: () => ({ data: mocks.project }),
+}));
+vi.mock('../../../hooks/health/useHealth', () => ({
+    default: () => ({ data: { hasGithub: mocks.hasGithub } }),
+}));
+vi.mock(
+    '../../../components/common/GithubIntegration/hooks/useGithubIntegration',
+    () => ({ useGithubUserCredential: () => ({ data: undefined }) }),
+);
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastError: mocks.showToastError }),
+}));
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+const onClose = vi.fn();
+const renderModal = () =>
+    renderWithProviders(
+        <QueryClientProvider
+            client={
+                new QueryClient({
+                    defaultOptions: { queries: { retry: false } },
+                })
+            }
+        >
+            <WriteBackToDbtModal opened onClose={onClose} />
+        </QueryClientProvider>,
+    );
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.project.dbtConnection.type = DbtProjectType.BITBUCKET;
+    mocks.project.dbtConnection.host_domain = undefined;
+    mocks.hasGithub = false;
+    vi.mocked(lightdashApi).mockImplementation(async ({ url }) =>
+        url.endsWith('/preview')
+            ? {
+                  repo: 'workspace/jaffle',
+                  url: 'https://bitbucket.org/workspace/jaffle',
+                  files: ['models/new_model.sql', 'models/new_model.yml'],
+              }
+            : {
+                  prUrl: 'https://bitbucket.org/workspace/jaffle/pull-requests/7',
+                  prTitle: 'Add revenue',
+              },
+    );
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('SQL writeback modal', () => {
+    it('previews and submits Bitbucket without a GitHub integration or OAuth prompt', async () => {
+        const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+        renderModal();
+        await waitFor(() =>
+            expect(screen.getByText('new_model.sql')).toBeVisible(),
+        );
+        expect(screen.getByText('new_model.yml')).toBeVisible();
+        expect(
+            screen.queryByText('Connect your GitHub account'),
+        ).not.toBeInTheDocument();
+        fireEvent.click(screen.getByText('workspace/jaffle'));
+        expect(open).toHaveBeenCalledWith(
+            'https://bitbucket.org/workspace/jaffle',
+            '_blank',
+            'noopener,noreferrer',
+        );
+        fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), {
+            target: { value: 'revenue' },
+        });
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        );
+        await waitFor(() => expect(onClose).toHaveBeenCalled());
+        expect(lightdashApi).toHaveBeenCalledWith({
+            url: '/projects/project/sqlRunner/pull-request',
+            method: 'POST',
+            body: JSON.stringify({
+                name: 'revenue',
+                sql: state.sqlRunner.sql,
+                columns: state.sqlRunner.sqlColumns,
+            }),
+        });
+        expect(open).toHaveBeenCalledWith(
+            'https://bitbucket.org/workspace/jaffle/pull-requests/7',
+            '_blank',
+            'noopener,noreferrer',
+        );
+    });
+    it('does not preview or submit for Bitbucket Server', () => {
+        mocks.project.dbtConnection.host_domain = 'bitbucket.internal';
+        renderModal();
+        fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), {
+            target: { value: 'revenue' },
+        });
+        expect(
+            screen.getByRole('button', { name: 'Open Pull Request' }),
+        ).toBeDisabled();
+        expect(lightdashApi).not.toHaveBeenCalled();
+    });
+    it.each(['success', 'failure'])(
+        'keeps the latest preview when an older request ends in %s',
+        async (outcome) => {
+            let settleOldRequest = () => {};
+            const oldRequest = new Promise<{
+                repo: string;
+                url: string;
+                files: string[];
+            }>((resolve, reject) => {
+                settleOldRequest = () => {
+                    if (outcome === 'failure') {
+                        reject({ error: { message: 'Old preview failed' } });
+                    } else {
+                        resolve({
+                            repo: 'old',
+                            url: 'https://bitbucket.org/workspace/jaffle',
+                            files: ['models/old.sql'],
+                        });
+                    }
+                };
+            });
+            vi.mocked(lightdashApi).mockReturnValueOnce(oldRequest);
+            renderModal();
+            fireEvent.change(screen.getByRole('textbox', { name: 'Name' }), {
+                target: { value: 'latest' },
+            });
+            await waitFor(() =>
+                expect(screen.getByText('new_model.sql')).toBeVisible(),
+            );
+            await act(async () => {
+                settleOldRequest();
+                await oldRequest.catch(() => undefined);
+            });
+            expect(screen.getByText('new_model.sql')).toBeVisible();
+            expect(screen.queryByText('old.sql')).not.toBeInTheDocument();
+        },
+    );
+
+    it('shows the provider error when preview fails', async () => {
+        vi.mocked(lightdashApi).mockRejectedValue({
+            error: { message: 'Update the Bitbucket project API token' },
+        });
+        renderModal();
+        await waitFor(() =>
+            expect(mocks.showToastError).toHaveBeenCalledWith({
+                title: 'Failed to preview dbt writeback',
+                subtitle: 'Update the Bitbucket project API token',
+            }),
+        );
+        expect(screen.queryByText('new_model.sql')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -15,7 +15,7 @@ import {
 } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconBrandGithub, IconInfoCircle } from '@tabler/icons-react';
+import { IconGitPullRequest, IconInfoCircle } from '@tabler/icons-react';
 import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
 import { useCallback, useEffect, useState, type FC } from 'react';
 import { z } from 'zod';
@@ -33,6 +33,7 @@ import { useProject } from '../../../hooks/useProject';
 import { useGithubDbtWriteBack } from '../hooks/useGithubDbtWriteBack';
 import { useGithubDbtWritePreview } from '../hooks/useGithubDbtWritePreview';
 import { useAppSelector } from '../store/hooks';
+import { isBitbucketCloudConnection } from '../utils/isBitbucketCloudConnection';
 
 const validationSchema = z.object({
     name: z.string().min(1, 'Name is required'),
@@ -67,31 +68,61 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
     const { data: health } = useHealth();
     const { data: githubUserCredential } = useGithubUserCredential();
 
-    const canWriteToDbtProject = !!(
-        health?.hasGithub &&
-        [DbtProjectType.GITHUB, DbtProjectType.GITLAB].includes(
-            project?.dbtConnection.type as DbtProjectType,
-        )
-    );
+    const canWriteToDbtProject =
+        isBitbucketCloudConnection(project?.dbtConnection) ||
+        !!(
+            health?.hasGithub &&
+            [DbtProjectType.GITHUB, DbtProjectType.GITLAB].includes(
+                project?.dbtConnection.type as DbtProjectType,
+            )
+        );
 
     const isGithubProject =
         project?.dbtConnection.type === DbtProjectType.GITHUB;
 
     useEffect(() => {
-        if (!opened || !projectUuid || !sql || !columns) return;
+        if (
+            !opened ||
+            !projectUuid ||
+            !sql ||
+            !columns ||
+            !canWriteToDbtProject
+        ) {
+            return;
+        }
+        let isCurrentPreview = true;
 
         const loadPreview = async () => {
-            const data = await getWritePreview({
-                projectUuid,
-                name: debouncedName || 'custom view',
-                sql,
-                columns,
-            });
-            setWritePreviewData(data);
+            try {
+                const data = await getWritePreview({
+                    projectUuid,
+                    name: debouncedName || 'custom view',
+                    sql,
+                    columns,
+                });
+                if (isCurrentPreview) {
+                    setWritePreviewData(data);
+                }
+            } catch {
+                if (isCurrentPreview) {
+                    setWritePreviewData(undefined);
+                }
+            }
         };
 
         void loadPreview();
-    }, [opened, projectUuid, debouncedName, sql, columns, getWritePreview]);
+        return () => {
+            isCurrentPreview = false;
+        };
+    }, [
+        opened,
+        projectUuid,
+        debouncedName,
+        sql,
+        columns,
+        getWritePreview,
+        canWriteToDbtProject,
+    ]);
 
     const handleSubmit = useCallback(
         async (data: { name: string }) => {
@@ -116,7 +147,7 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
             opened={opened}
             onClose={onClose}
             title="Write back to dbt"
-            icon={IconBrandGithub}
+            icon={IconGitPullRequest}
             cancelDisabled={isLoadingPullRequest}
             actions={
                 <Button
@@ -162,7 +193,7 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                                 color="ldGray.9"
                                 fz="xs"
                                 leftSection={
-                                    <MantineIcon icon={IconBrandGithub} />
+                                    <MantineIcon icon={IconGitPullRequest} />
                                 }
                                 onClick={() => {
                                     window.open(

--- a/packages/frontend/src/features/sqlRunner/hooks/useGithubDbtWritePreview.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useGithubDbtWritePreview.tsx
@@ -40,10 +40,10 @@ export const useGithubDbtWritePreview = () => {
     >(createPullRequest, {
         mutationKey: ['sqlRunner', 'githubDbtWritePreview'],
 
-        onError: () => {
+        onError: (error) => {
             showToastError({
-                title: 'Failed to get github preview',
-                subtitle: 'Please check your Github settings.',
+                title: 'Failed to preview dbt writeback',
+                subtitle: error.error.message,
             });
         },
     });

--- a/packages/frontend/src/features/sqlRunner/utils/isBitbucketCloudConnection.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/isBitbucketCloudConnection.ts
@@ -1,0 +1,14 @@
+import { DbtProjectType, type DbtProjectConfig } from '@lightdash/common';
+
+export const isBitbucketCloudConnection = (
+    connection: DbtProjectConfig | undefined,
+): boolean => {
+    if (connection?.type !== DbtProjectType.BITBUCKET) {
+        return false;
+    }
+    const host = connection.host_domain
+        ?.trim()
+        .toLowerCase()
+        .replace(/\.$/, '');
+    return !host || host === 'bitbucket.org';
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1998

## Summary

Enables SQL Runner users to save queries as dbt models in Bitbucket Cloud through a pull request. Uses the project's token and SourceCode permission, with no GitHub integration requirement.

Part of [Bitbucket writeback](https://linear.app/lightdash/issue/SPK-1994), following merged [AI writeback #28932](https://github.com/lightdash/lightdash/pull/28932) and [Explorer writeback #28933](https://github.com/lightdash/lightdash/pull/28933). This PR branches from refreshed main.

## Changes

SQL Runner creates the SQL and YAML files together in one commit on a new branch, respecting the configured base branch and dbt subfolder. Existing files reject the operation; branch changes during collision checks reject the commit. Model naming, column metadata and the `created-by-lightdash` tag follow the existing GitHub/GitLab behavior.

```text
SQL Runner query + columns
  -> authorize project SourceCode access
  -> create change branch from configured base
  -> check SQL and YAML paths are absent
  -> commit both files against captured parent
  -> create Bitbucket PR -> record provider + return URL
```

The existing model-name dialog previews the Bitbucket repository and filenames. Stale preview responses cannot replace newer results. GitHub/GitLab behavior and unrelated source-editor capabilities remain covered by regression tests.

## Test plan

- [x] 56 backend tests across SQL Runner and existing GitIntegrationService suites.
- [x] 11 rendered frontend tests, including Cloud without GitHub setup, SourceCode denial, unsupported hosts, legacy gates and stale preview responses.
- [x] Backend/frontend typechecks and lint pass; frontend full lint reports one existing warning in `LearnPage.test.tsx`.
- [x] Actual API baseline returns 400 for unsupported Bitbucket; final API and browser flows create real Bitbucket PRs.
- [x] Verify nested SQL/YAML paths, model content, both files in one commit, configured destination branch and persisted Bitbucket/SQL Runner metadata.
- [x] Real SQL-only and YAML-only collisions return 409 without a commit; invalid token returns 403 and anonymous request returns 401.
- [x] Decline test PRs, delete disposable branches and local fixture, and verify repository main is unchanged.

GitHub/GitLab compatibility and missing individual token scopes are verified with automated tests; live external verification uses Bitbucket Cloud.
