### PR TITLE
test(ai): update agent tool contract snapshot for Bitbucket

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -5149,6 +5149,7 @@ Parameters:
                       "enum": [
                         "github_not_installed",
                         "gitlab_not_installed",
+                        "bitbucket_token_missing",
                         "unsupported_source_control",
                         "pull_request_not_open",
                         "git_write_permission",


### PR DESCRIPTION
The Bitbucket Cloud writeback change (#28932) added the `bitbucket_token_missing` error code to the agent tool schema without regenerating the contract snapshot, so `agentToolContracts.snapshot.test.ts` fails on main and on every branch rebased onto it.

This regenerates the snapshot. One line changes: the new enum value.

Relates: #28932