### PR TITLE
ci(learn): account for every training permission in content coverage

### DIFF
--- a/.github/workflows/scope-tours-check.yml
+++ b/.github/workflows/scope-tours-check.yml
@@ -9,7 +9,9 @@ on:
     pull_request:
         paths:
             - 'packages/frontend/src/**'
+            - 'packages/common/src/authorization/**'
             - 'scripts/scope-tours/**'
+            - 'package.json'
             - 'scripts/scope-tours/scope-tours.test.ts'
             - '.github/workflows/scope-tours-check.yml'
 
@@ -38,6 +40,10 @@ jobs:
               run: pnpm common-build
             - name: Checker tests
               run: npx tsx scripts/scope-tours/scope-tours.test.ts
+            - name: Content coverage tests
+              run: pnpm scope-tours:coverage:test
+            - name: Every training permission has a content disposition
+              run: pnpm scope-tours:coverage
             - name: Generated tours are up to date
               env:
                   LIGHTDASH_DOCS_DIR: ${{ github.workspace }}/mintlify-docs

--- a/docs/learn/content-coverage.md
+++ b/docs/learn/content-coverage.md
@@ -1,0 +1,53 @@
+# Curriculum coverage contract
+
+The coverage audit reconciles the base permissions returned by
+`getTrainingProjectScopes()` with generated `SCOPE_TOURS` and explicit curriculum
+dispositions in `scripts/scope-tours/coverage.ts`. It does not change permission
+grants, catalogue cards, or lesson runtime behavior. Modifier variants such as
+`@self` and `@space` are omitted, matching `buildLearnCatalogue()`.
+
+Run from the repository root with the pinned Node version:
+
+```sh
+pnpm scope-tours:coverage
+pnpm scope-tours:coverage:test
+pnpm scope-tours:release-check
+```
+
+The pure `auditCoverage` function accepts scopes, available tour keys, dispositions,
+and a strict-mode boolean. Its report keeps these categories separate:
+
+| Category | Meaning | Blocks release |
+| --- | --- | --- |
+| `generated` | A generated tour exists under this exact scope key | No |
+| `related` | Another tour is relevant, but teaching this permission's action is unverified | Yes |
+| `pending` | Content, prerequisites, or a format decision is outstanding | Yes |
+| `excluded` | An explicit reason documents a baseline/background permission or absent product surface | No |
+| `unclassified` | A base permission has neither a direct tour nor a disposition | Yes |
+
+`generated` measures generated content presence. It does not certify successful
+browser execution, accurate teaching, seed data, or training-copy isolation; those
+require separate checks. In particular, the create-virtual-view lesson does not
+prove managing or deleting a virtual view.
+
+The release audit is a structural coverage gate; generation, content checks, and
+browser smoke verification remain required.
+
+The normal audit allows documented pending and related work. Both normal and
+release audits fail for unclassified scopes, stale dispositions (a removed scope
+or a newly available direct tour), unavailable referenced tours, or dispositions
+without a reason and ticket. `--release` additionally fails for pending and related
+work. A release failure must be resolved with content or an evidenced curriculum
+decision; dropping a card is not completion.
+
+Dispositions derive from the [CS-212 catalogue](https://linear.app/lightdash/issue/CS-212)
+and its child-ticket evidence audited on 2026-09-08. Embed and CLI/API scopes await
+format decisions. Promotion awaits training-copy semantics. Metrics trees,
+validation, and Spotlight configuration retain their documented prerequisites.
+Related scope groupings are deliberately conservative until actual lesson steps
+prove the promised action. Remove a disposition when its direct tour is generated.
+
+This audit cannot discover content requests outside the current training permission
+set. [Usage analytics](https://linear.app/lightdash/issue/CS-232) and
+[agent knowledge documents](https://linear.app/lightdash/issue/CS-238) require a
+separate permission-boundary decision and remain outside its denominator.

--- a/package.json
+++ b/package.json
@@ -146,6 +146,9 @@
         "scope-tours:generate": "tsx scripts/scope-tours/generate.ts && pnpm -F frontend run formatter -- src/features/scopeTours/generated.ts",
         "scope-tours:order": "tsx scripts/scope-tours/order.ts && pnpm -F frontend run formatter -- src/features/scopeTours/curriculum.ts",
         "scope-tours:check": "tsx scripts/scope-tours/check.ts",
+        "scope-tours:coverage": "tsx scripts/scope-tours/coverage.ts",
+        "scope-tours:coverage:test": "tsx scripts/scope-tours/coverage.test.ts",
+        "scope-tours:release-check": "tsx scripts/scope-tours/coverage.ts --release",
         "scope-tours:suggest": "tsx scripts/scope-tours/suggest.ts",
         "scope-tours:smoke": "tsx scripts/scope-tours/smoke.ts"
     },

--- a/scripts/scope-tours/coverage.test.ts
+++ b/scripts/scope-tours/coverage.test.ts
@@ -1,0 +1,111 @@
+import { getTrainingProjectScopes } from '@lightdash/common';
+import * as assert from 'assert';
+import { SCOPE_TOURS } from '../../packages/frontend/src/features/scopeTours/generated';
+import {
+    auditCoverage,
+    SCOPE_DISPOSITIONS,
+    type ScopeDisposition,
+} from './coverage';
+
+const pending: ScopeDisposition = {
+    status: 'pending',
+    reason: 'Needs a supported lesson format.',
+    ticket: 'CS-212',
+    tour: null,
+};
+const related: ScopeDisposition = {
+    ...pending,
+    status: 'related',
+    tour: 'create:VirtualView',
+};
+
+assert.deepStrictEqual(
+    auditCoverage(['view:Thing@self'], [], {}).unclassified,
+    [],
+);
+assert.strictEqual(auditCoverage(['view:NewFeature'], [], {}).ok, false);
+assert.deepStrictEqual(
+    auditCoverage(['view:NewFeature'], [], {}).unclassified,
+    ['view:NewFeature'],
+);
+assert.strictEqual(
+    auditCoverage(['manage:VirtualView'], [], { 'manage:VirtualView': related })
+        .ok,
+    false,
+);
+assert.deepStrictEqual(
+    auditCoverage(['manage:VirtualView'], [], { 'manage:VirtualView': related })
+        .missingTours,
+    [{ scope: 'manage:VirtualView', tour: 'create:VirtualView' }],
+);
+const incomplete = auditCoverage(
+    ['create:VirtualView', 'manage:VirtualView', 'view:EmbedExplore'],
+    ['create:VirtualView'],
+    { 'manage:VirtualView': related, 'view:EmbedExplore': pending },
+);
+assert.strictEqual(incomplete.ok, true);
+assert.deepStrictEqual(incomplete.generated, ['create:VirtualView']);
+assert.deepStrictEqual(incomplete.related, ['manage:VirtualView']);
+assert.deepStrictEqual(incomplete.pending, ['view:EmbedExplore']);
+assert.strictEqual(
+    auditCoverage(
+        ['manage:VirtualView'],
+        ['create:VirtualView'],
+        { 'manage:VirtualView': related },
+        true,
+    ).ok,
+    false,
+);
+assert.strictEqual(
+    auditCoverage(
+        ['view:EmbedExplore'],
+        [],
+        { 'view:EmbedExplore': pending },
+        true,
+    ).ok,
+    false,
+);
+assert.deepStrictEqual(
+    auditCoverage([], [], { 'view:Removed': pending }).staleDispositions,
+    ['view:Removed'],
+);
+assert.strictEqual(
+    auditCoverage(['view:Done'], ['view:Done'], { 'view:Done': pending }).ok,
+    false,
+);
+assert.strictEqual(
+    auditCoverage(['view:MissingReason'], [], {
+        'view:MissingReason': { ...pending, reason: ' ' },
+    }).ok,
+    false,
+);
+assert.strictEqual(
+    auditCoverage(['view:MissingTicket'], [], {
+        'view:MissingTicket': { ...pending, ticket: '' },
+    }).ok,
+    false,
+);
+assert.strictEqual(
+    auditCoverage(['view:Related'], [], {
+        'view:Related': { ...related, tour: null },
+    }).ok,
+    false,
+);
+assert.strictEqual(
+    auditCoverage(
+        ['view:Internal'],
+        [],
+        { 'view:Internal': { ...pending, status: 'excluded' } },
+        true,
+    ).ok,
+    true,
+);
+
+const actual = auditCoverage(
+    getTrainingProjectScopes(),
+    Object.keys(SCOPE_TOURS),
+    SCOPE_DISPOSITIONS,
+);
+assert.strictEqual(actual.ok, true, JSON.stringify(actual, null, 2));
+assert.strictEqual(actual.unclassified.length, 0);
+console.log('scope coverage: all checks passed');

--- a/scripts/scope-tours/coverage.ts
+++ b/scripts/scope-tours/coverage.ts
@@ -1,0 +1,241 @@
+import { getTrainingProjectScopes } from '@lightdash/common';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SCOPE_TOURS } from '../../packages/frontend/src/features/scopeTours/generated';
+
+export type ScopeDisposition = {
+    status: 'pending' | 'excluded' | 'related';
+    reason: string;
+    ticket: string;
+    tour: string | null;
+};
+
+const pending = (reason: string, ticket = 'CS-212'): ScopeDisposition => ({
+    status: 'pending',
+    reason,
+    ticket,
+    tour: null,
+});
+const excluded = (reason: string, ticket = 'CS-212'): ScopeDisposition => ({
+    status: 'excluded',
+    reason,
+    ticket,
+    tour: null,
+});
+const related = (tour: string, reason: string): ScopeDisposition => ({
+    status: 'related',
+    reason,
+    ticket: 'CS-212',
+    tour,
+});
+
+export const SCOPE_DISPOSITIONS: Readonly<Record<string, ScopeDisposition>> = {
+    'view:AiAgent': related(
+        'create:AiAgentThread',
+        'Grouped with the agent lesson; scope-specific viewing coverage awaits verification.',
+    ),
+    'view:DataApp': related(
+        'create:DataApp',
+        'Grouped with app lessons; scope-specific viewing coverage awaits verification.',
+    ),
+    'view:ContentVerification': related(
+        'manage:ContentVerification',
+        'Grouped with verification; viewing coverage awaits verification.',
+    ),
+    'manage:VerifiedContent': related(
+        'manage:ContentVerification',
+        'Grouped with verification; editing verified content is not yet proved by the lesson.',
+    ),
+    'manage:CustomSql': related(
+        'manage:SqlRunner',
+        'Grouped with SQL Runner; the distinct custom SQL permission needs teaching evidence.',
+    ),
+    'manage:VirtualView': related(
+        'create:VirtualView',
+        'Creating a virtual view does not prove the lesson teaches managing an existing view.',
+    ),
+    'delete:VirtualView': related(
+        'create:VirtualView',
+        'Creating a virtual view does not teach deleting one.',
+    ),
+    'manage:ChangeCsvResults': related(
+        'manage:ExportCsv',
+        'Grouped with CSV export; changing result options needs teaching evidence.',
+    ),
+    'view:Project': excluded(
+        'Baseline project access has no standalone lesson-sized surface.',
+    ),
+    'view:Job': excluded(
+        'Background job permission has no standalone learner surface.',
+    ),
+    'view:JobStatus': excluded(
+        'Background job status permission has no standalone learner surface.',
+    ),
+    'view:SemanticViewer': excluded(
+        'Catalogue records no product surface for this permission.',
+    ),
+    'manage:SemanticViewer': excluded(
+        'Catalogue records no product surface for this permission.',
+    ),
+    'manage:DeletedContent': excluded(
+        'No product surface recorded; the associated content ticket is canceled.',
+        'CS-222',
+    ),
+    'view:SpotlightTableConfig': pending(
+        'The UI control is not named in docs; documented teaching content is required.',
+        'CS-233',
+    ),
+    'manage:SpotlightTableConfig': pending(
+        'The UI control is not named in docs; documented teaching content is required.',
+        'CS-233',
+    ),
+    'view:ContentAsCode': pending(
+        'CLI/API workflow needs an agreed content format beyond click walkthroughs.',
+    ),
+    'create:ContentAsCode': pending(
+        'CLI/API workflow needs an agreed content format beyond click walkthroughs.',
+    ),
+    'manage:ContentAsCode': pending(
+        'CLI/API workflow needs an agreed content format beyond click walkthroughs.',
+    ),
+    'promote:Dashboard': pending(
+        'Cross-project promotion semantics in a training copy remain unresolved.',
+    ),
+    'promote:SavedChart': pending(
+        'Cross-project promotion semantics in a training copy remain unresolved.',
+    ),
+    'view:MetricsTree': pending(
+        'Metrics tree lesson and supported interaction format remain deferred.',
+        'CS-234',
+    ),
+    'manage:MetricsTree': pending(
+        'Adding metrics requires drag-and-drop or a supported alternative lesson format.',
+        'CS-234',
+    ),
+    'manage:Validation': pending(
+        'Settings access requires excluded update:Project and a tour host outside the current layout.',
+        'CS-231',
+    ),
+    'view:EmbedDashboardFilters': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedDashboardFilterAddition': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedDashboardParameters': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedCsvExport': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedDashboardCsvExport': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedImageExport': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedPagePdfExport': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedDateZoom': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedExplore': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedUnderlyingData': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedDataApps': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+    'view:EmbedAiAgent': pending(
+        'Embedded application lesson format requires a curriculum decision.',
+    ),
+};
+
+export type CoverageAudit = {
+    ok: boolean;
+    generated: string[];
+    pending: string[];
+    excluded: string[];
+    related: string[];
+    unclassified: string[];
+    staleDispositions: string[];
+    missingTours: { scope: string; tour: string }[];
+    invalidDispositions: string[];
+};
+
+export const auditCoverage = (
+    trainingScopes: readonly string[],
+    availableTours: readonly string[],
+    dispositions: Readonly<Record<string, ScopeDisposition>>,
+    strict = false,
+): CoverageAudit => {
+    const scopes = new Set(
+        trainingScopes.filter((scope) => !scope.includes('@')),
+    );
+    const tours = new Set(availableTours);
+    const result: CoverageAudit = {
+        ok: true,
+        generated: [],
+        pending: [],
+        excluded: [],
+        related: [],
+        unclassified: [],
+        staleDispositions: [],
+        missingTours: [],
+        invalidDispositions: [],
+    };
+    for (const [scope, disposition] of Object.entries(dispositions)) {
+        if (!scopes.has(scope) || tours.has(scope))
+            result.staleDispositions.push(scope);
+        if (
+            !disposition.reason.trim() ||
+            !/^CS-\d+$/.test(disposition.ticket) ||
+            !['pending', 'excluded', 'related'].includes(disposition.status) ||
+            (disposition.status === 'related' && !disposition.tour)
+        ) {
+            result.invalidDispositions.push(scope);
+        }
+        if (disposition.tour !== null && !tours.has(disposition.tour)) {
+            result.missingTours.push({ scope, tour: disposition.tour });
+        }
+    }
+    for (const scope of scopes) {
+        if (tours.has(scope)) result.generated.push(scope);
+        else if (!Object.hasOwn(dispositions, scope))
+            result.unclassified.push(scope);
+        else {
+            const { status } = dispositions[scope];
+            if (
+                status === 'pending' ||
+                status === 'excluded' ||
+                status === 'related'
+            )
+                result[status].push(scope);
+        }
+    }
+    result.ok =
+        result.unclassified.length === 0 &&
+        result.staleDispositions.length === 0 &&
+        result.missingTours.length === 0 &&
+        result.invalidDispositions.length === 0 &&
+        (!strict ||
+            (result.pending.length === 0 && result.related.length === 0));
+    return result;
+};
+
+if (
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    const report = auditCoverage(
+        getTrainingProjectScopes(),
+        Object.keys(SCOPE_TOURS),
+        SCOPE_DISPOSITIONS,
+        process.argv.includes('--release'),
+    );
+    console.log(JSON.stringify(report, null, 2));
+    process.exitCode = report.ok ? 0 : 1;
+}


### PR DESCRIPTION
The Learn catalogue creates a module for every training permission, but a missing walkthrough currently has no explicit curriculum disposition. Add a coverage audit that detects new unclassified scopes, stale decisions, and references to missing tours.

CI permits documented work in progress; `pnpm scope-tours:release-check` fails while pending or unverified related coverage remains. Generated content presence is reported separately from runtime verification. This PR does not remove placeholders or mark unfinished lessons complete.

Validation: coverage fixture tests and current-inventory audit pass; strict release audit correctly fails for the outstanding content. Independently reviewed. First slice of the University content-completion stack.

Relates: CS-212
