### PR TITLE
fix(dashboard): in-dashboard chart editor no longer opens dirty

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -1,6 +1,4 @@
 import {
-    ChartType,
-    mergeDashboardCustomMetrics,
     type AdditionalMetric,
     type DashboardCustomMetricAffectedChart,
     type SavedChart,
@@ -17,7 +15,6 @@ import {
 } from 'react';
 import { Provider } from 'react-redux';
 import {
-    buildInitialExplorerState,
     createExplorerStore,
     selectActiveFields,
     selectHasUnsavedChanges,
@@ -30,7 +27,6 @@ import { useDeleteDashboardCustomMetric } from '../../hooks/dashboard/useUpdateD
 import useToaster from '../../hooks/toaster/useToaster';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
-import { ExplorerSection } from '../../providers/Explorer/types';
 import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
 import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
@@ -39,6 +35,7 @@ import { useChartGalleryRightSidebar } from '../Explorer/ChartGallery/useChartGa
 import RegistryImpactPreviewModal from '../Explorer/CustomMetricModal/RegistryImpactPreviewModal';
 import ExploreSideBar from '../Explorer/ExploreSideBar';
 import PageSpinner from '../PageSpinner';
+import { buildDashboardEditorInitialState } from './buildDashboardEditorInitialState';
 
 type ContentProps = {
     exploreId: string;
@@ -92,54 +89,10 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
     // No useExplorerRoute — it would rewrite the dashboard URL from the modal.
     const [store] = useState(() =>
         createExplorerStore({
-            explorer: buildInitialExplorerState({
-                isEditMode: true,
-                initialState: {
-                    expandedSections: [
-                        ExplorerSection.FILTERS,
-                        ExplorerSection.VISUALIZATION,
-                        ExplorerSection.RESULTS,
-                    ],
-                    savedChart: editChart,
-                    unsavedChartVersion: {
-                        tableName: exploreId,
-                        // Editing: seeded metrics fill gaps, the chart's own
-                        // snapshot wins on collision.
-                        metricQuery: editChart
-                            ? {
-                                  ...editChart.metricQuery,
-                                  additionalMetrics:
-                                      mergeDashboardCustomMetrics(
-                                          editChart.metricQuery
-                                              .additionalMetrics ?? [],
-                                          seededMetrics,
-                                      ),
-                              }
-                            : {
-                                  exploreName: exploreId,
-                                  dimensions: [],
-                                  metrics: [],
-                                  filters: {},
-                                  sorts: [],
-                                  limit: 500,
-                                  tableCalculations: [],
-                                  additionalMetrics: seededMetrics,
-                                  timezone: undefined,
-                              },
-                        chartConfig: editChart?.chartConfig ?? {
-                            type: ChartType.CARTESIAN,
-                            config: {
-                                layout: { xField: '', yField: [] },
-                                eChartsConfig: { series: [] },
-                            },
-                        },
-                        tableConfig: editChart?.tableConfig ?? {
-                            columnOrder: [],
-                        },
-                        pivotConfig: editChart?.pivotConfig ?? { columns: [] },
-                    },
-                },
-                defaultLimit: 500,
+            explorer: buildDashboardEditorInitialState({
+                exploreId,
+                editChart,
+                seededMetrics,
             }),
         }),
     );

--- a/packages/frontend/src/components/DashboardTiles/buildDashboardEditorInitialState.test.ts
+++ b/packages/frontend/src/components/DashboardTiles/buildDashboardEditorInitialState.test.ts
@@ -1,0 +1,108 @@
+import {
+    ChartType,
+    MetricType,
+    type AdditionalMetric,
+    type SavedChart,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    createExplorerStore,
+    explorerActions,
+    selectHasUnsavedChanges,
+} from '../../features/explorer/store';
+import { buildDashboardEditorInitialState } from './buildDashboardEditorInitialState';
+
+const registryMetric: AdditionalMetric = {
+    name: 'first_name_count_distinct',
+    label: 'Count distinct of First name',
+    table: 'customers',
+    sql: '${TABLE}.first_name',
+    type: MetricType.COUNT_DISTINCT,
+    baseDimensionName: 'first_name',
+};
+
+const editChart = {
+    uuid: 'chart-uuid',
+    name: 'Revenue per payment method',
+    tableName: 'payments',
+    metricQuery: {
+        exploreName: 'payments',
+        dimensions: ['payments_payment_method'],
+        metrics: ['payments_total_revenue'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: { xField: 'payments_payment_method', yField: [] },
+            eChartsConfig: { series: [] },
+        },
+    },
+    tableConfig: { columnOrder: [] },
+    pivotConfig: undefined,
+    colorPaletteUuid: 'palette-uuid',
+} as unknown as SavedChart;
+
+const buildStore = (seededMetrics: AdditionalMetric[]) =>
+    createExplorerStore({
+        explorer: buildDashboardEditorInitialState({
+            exploreId: 'payments',
+            editChart,
+            seededMetrics,
+        }),
+    });
+
+describe('buildDashboardEditorInitialState', () => {
+    it('opens an editing session clean with an empty registry', () => {
+        // Pins the non-seed dirty sources: pivotConfig defaulting and the
+        // palette baseline.
+        const store = buildStore([]);
+        expect(selectHasUnsavedChanges(store.getState())).toBe(false);
+    });
+
+    it('opens an editing session clean when registry metrics are seeded', () => {
+        const store = buildStore([registryMetric]);
+
+        // The seed reaches the draft…
+        expect(
+            store.getState().explorer.unsavedChartVersion.metricQuery
+                .additionalMetrics,
+        ).toEqual([registryMetric]);
+        // …but is baseline context, not an unsaved edit.
+        expect(selectHasUnsavedChanges(store.getState())).toBe(false);
+    });
+
+    it('keeps the chart snapshot on collision and still opens clean', () => {
+        const chartsOwnCopy = { ...registryMetric, label: 'Chart-local label' };
+        const chartWithMetric = {
+            ...editChart,
+            metricQuery: {
+                ...editChart.metricQuery,
+                additionalMetrics: [chartsOwnCopy],
+            },
+        } as SavedChart;
+        const store = createExplorerStore({
+            explorer: buildDashboardEditorInitialState({
+                exploreId: 'payments',
+                editChart: chartWithMetric,
+                seededMetrics: [registryMetric],
+            }),
+        });
+
+        expect(
+            store.getState().explorer.unsavedChartVersion.metricQuery
+                .additionalMetrics,
+        ).toEqual([chartsOwnCopy]);
+        expect(selectHasUnsavedChanges(store.getState())).toBe(false);
+    });
+
+    it('still reads dirty after a real edit', () => {
+        const store = buildStore([registryMetric]);
+        store.dispatch(explorerActions.setRowLimit(25));
+        expect(selectHasUnsavedChanges(store.getState())).toBe(true);
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/buildDashboardEditorInitialState.ts
+++ b/packages/frontend/src/components/DashboardTiles/buildDashboardEditorInitialState.ts
@@ -1,0 +1,80 @@
+import {
+    ChartType,
+    mergeDashboardCustomMetrics,
+    type AdditionalMetric,
+    type SavedChart,
+} from '@lightdash/common';
+import { buildInitialExplorerState } from '../../features/explorer/store';
+import { ExplorerSection } from '../../providers/Explorer/types';
+/**
+ * Explorer state for a dashboard-hosted editing session. Seeded registry
+ * metrics fill gaps in the draft (the chart's own snapshot wins on collision)
+ * and the same seeded query becomes the savedChart baseline, so host-provided
+ * seeding never reads as an unsaved user edit. The palette must be seeded
+ * explicitly: the custom-initial-state path of buildInitialExplorerState
+ * does not derive unsavedColorPaletteUuid from savedChart.
+ */
+export const buildDashboardEditorInitialState = ({
+    exploreId,
+    editChart,
+    seededMetrics,
+}: {
+    exploreId: string;
+    editChart: SavedChart | undefined;
+    seededMetrics: AdditionalMetric[];
+}) => {
+    const seededMetricQuery = editChart
+        ? {
+              ...editChart.metricQuery,
+              additionalMetrics: mergeDashboardCustomMetrics(
+                  editChart.metricQuery.additionalMetrics ?? [],
+                  seededMetrics,
+              ),
+          }
+        : undefined;
+    return buildInitialExplorerState({
+        isEditMode: true,
+        initialState: {
+            expandedSections: [
+                ExplorerSection.FILTERS,
+                ExplorerSection.VISUALIZATION,
+                ExplorerSection.RESULTS,
+            ],
+            unsavedColorPaletteUuid: editChart?.colorPaletteUuid ?? null,
+            savedChart:
+                editChart && seededMetricQuery
+                    ? { ...editChart, metricQuery: seededMetricQuery }
+                    : editChart,
+            unsavedChartVersion: {
+                tableName: exploreId,
+                metricQuery: seededMetricQuery ?? {
+                    exploreName: exploreId,
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 500,
+                    tableCalculations: [],
+                    additionalMetrics: seededMetrics,
+                    timezone: undefined,
+                },
+                chartConfig: editChart?.chartConfig ?? {
+                    type: ChartType.CARTESIAN,
+                    config: {
+                        layout: { xField: '', yField: [] },
+                        eChartsConfig: { series: [] },
+                    },
+                },
+                tableConfig: editChart?.tableConfig ?? {
+                    columnOrder: [],
+                },
+                // Mirror the chart exactly — defaulting an absent pivotConfig
+                // to { columns: [] } reads as an unsaved edit in the dirty diff
+                pivotConfig: editChart
+                    ? editChart.pivotConfig
+                    : { columns: [] },
+            },
+        },
+        defaultLimit: 500,
+    });
+};


### PR DESCRIPTION
Relates: [GLITCH-770](https://linear.app/lightdash/issue/GLITCH-770/in-dashboard-chart-editor-opens-dirty-when-the-dashboard-registry-has)

### Description

Opening **Edit chart** on a dashboard tile and closing without touching anything raised the "Discard chart changes?" guard. The editor's initial Explorer state disagreed with the `savedChart` baseline that `selectHasUnsavedChanges` diffs against, in three independent ways:

1. **`pivotConfig` defaulting** — an absent `pivotConfig` was defaulted to `{ columns: [] }` in the draft. `removeEmptyProperties` strips the saved side's `undefined` key but keeps the empty object, so the key counts differ and `deepEqual` fails. This hit **every non-pivot chart**.
2. **Palette baseline** — the custom-initial-state path of `buildInitialExplorerState` never seeds `unsavedColorPaletteUuid` from `savedChart`, so any chart with a non-null `colorPaletteUuid` diffed `null !== uuid`.
3. **Seeded registry metrics** — `mergeDashboardCustomMetrics` output entered the draft but not the baseline, so compatible registry metrics read as user edits on dashboards with a registry.

### Fix

The initial-state construction moves out of the component into `buildDashboardEditorInitialState`, which now:

- mirrors the chart's `pivotConfig` verbatim instead of defaulting it,
- seeds `unsavedColorPaletteUuid` from the chart,
- applies the same merged `additionalMetrics` to the `savedChart` baseline (seeding is host-provided context, not a user edit).

Unit tests pin each source: clean open with an empty registry, with a seeded registry, and on a name collision (chart snapshot wins), plus dirty-after-a-real-edit.