### PR TITLE
feat(content): record bounded recently viewed history

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -302,6 +302,10 @@ import {
     QueryHistoryTableName,
 } from '../database/entities/queryHistory';
 import {
+    RecentContentTable,
+    RecentContentTableName,
+} from '../database/entities/recentContent';
+import {
     RolesTableName,
     RoleTable,
     ScopedRolesTableName,
@@ -694,6 +698,7 @@ declare module 'knex/types/tables' {
         [SlackAuthTokensTableName]: SlackAuthTokensTable;
         [SlackChannelsTableName]: SlackChannelsTable;
         [AnalyticsChartViewsTableName]: AnalyticsChartViews;
+        [RecentContentTableName]: RecentContentTable;
         [AnalyticsDashboardViewsTableName]: AnalyticsDashboardViews;
         [AnalyticsAppViewsTableName]: AnalyticsAppViews;
         [PinnedListTableName]: PinnedListTable;

--- a/packages/backend/src/controllers/v2/RecentContentController.test.ts
+++ b/packages/backend/src/controllers/v2/RecentContentController.test.ts
@@ -1,0 +1,39 @@
+import type { Account } from '@lightdash/common';
+import type express from 'express';
+import { buildAccount } from '../../auth/account/account.mock';
+import { RecentContentController } from './RecentContentController';
+
+describe('RecentContentController', () => {
+    const recordView = vi.fn();
+    const controller = new RecentContentController({
+        getRecentContentService: () => ({ recordView }),
+    } as unknown as ConstructorParameters<typeof RecentContentController>[0]);
+    const view = {
+        projectUuid: 'project',
+        contentType: 'dashboard' as const,
+        contentUuid: 'dashboard',
+    };
+    beforeEach(() => {
+        recordView.mockReset();
+    });
+
+    it.each(['jwt', 'service-account', 'personal-access-token', 'oauth'])(
+        'rejects %s tracking',
+        async (type) => {
+            const account = { authentication: { type } } as Account;
+            await expect(
+                controller.recordView({ account } as express.Request, view),
+            ).rejects.toThrow('not session auth');
+            expect(recordView).not.toHaveBeenCalled();
+        },
+    );
+
+    it('derives the viewer from the session', async () => {
+        const account = buildAccount();
+        await controller.recordView({ account } as express.Request, view);
+        expect(recordView).toHaveBeenCalledWith(
+            expect.objectContaining({ userUuid: account.user.id }),
+            view,
+        );
+    });
+});

--- a/packages/backend/src/controllers/v2/RecentContentController.ts
+++ b/packages/backend/src/controllers/v2/RecentContentController.ts
@@ -1,0 +1,37 @@
+import {
+    assertSessionAuth,
+    type ApiErrorPayload,
+    type ApiSuccessEmpty,
+    type RecordRecentContentView,
+} from '@lightdash/common';
+import {
+    Body,
+    Middlewares,
+    Post,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import type express from 'express';
+import { toSessionUser } from '../../auth/account';
+import { isAuthenticated } from '../authentication';
+import { BaseController } from '../baseController';
+
+@Route('/api/v2/content/recently-viewed')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('v2', 'Content')
+export class RecentContentController extends BaseController {
+    @Post('/')
+    @Middlewares([isAuthenticated])
+    async recordView(
+        @Request() req: express.Request,
+        @Body() body: RecordRecentContentView,
+    ): Promise<ApiSuccessEmpty> {
+        assertSessionAuth(req.account);
+        await this.services
+            .getRecentContentService()
+            .recordView(toSessionUser(req.account), body);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/database/entities/recentContent.ts
+++ b/packages/backend/src/database/entities/recentContent.ts
@@ -1,0 +1,14 @@
+import type { RecentContentType } from '@lightdash/common';
+import type { Knex } from 'knex';
+
+export const RecentContentTableName = 'user_recent_content';
+
+export type DbRecentContent = {
+    user_uuid: string;
+    project_uuid: string;
+    content_type: RecentContentType;
+    content_uuid: string;
+    last_viewed_at: Date;
+};
+
+export type RecentContentTable = Knex.CompositeTableType<DbRecentContent>;

--- a/packages/backend/src/database/migrations/20260909120000_create_user_recent_content.ts
+++ b/packages/backend/src/database/migrations/20260909120000_create_user_recent_content.ts
@@ -1,0 +1,40 @@
+import type { Knex } from 'knex';
+
+export const classification = {
+    kind: 'safe',
+    reason: 'Creates an empty recency table and its indexes without scanning or altering historical analytics events.',
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.createTable('user_recent_content', (table) => {
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable('projects')
+            .onDelete('CASCADE')
+            .index();
+        table.text('content_type').notNullable();
+        table.uuid('content_uuid').notNullable();
+        table.timestamp('last_viewed_at', { useTz: true }).notNullable();
+        table.check("content_type IN ('chart', 'dashboard')");
+        table.primary([
+            'user_uuid',
+            'project_uuid',
+            'content_type',
+            'content_uuid',
+        ]);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw("SET LOCAL lock_timeout = '5s'");
+    await knex.schema.dropTable('user_recent_content');
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -59,6 +59,7 @@ import { ProjectModel } from './ProjectModel/ProjectModel';
 import { ProjectParametersModel } from './ProjectParametersModel';
 import { PullRequestsModel } from './PullRequestsModel';
 import { QueryHistoryModel } from './QueryHistoryModel/QueryHistoryModel';
+import { RecentContentModel } from './RecentContentModel';
 import { ResourceViewItemModel } from './ResourceViewItemModel';
 import { RolesModel } from './RolesModel';
 import { SavedChartAccessModel } from './SavedChartAccessModel';
@@ -94,6 +95,7 @@ import { WarehouseConnectCodeModel } from './WarehouseConnectCodeModel';
 
 export type ModelManifest = {
     analyticsModel: AnalyticsModel;
+    recentContentModel: RecentContentModel;
     appAccessModel: AppAccessModel;
     appModel: AppModel;
     commentModel: CommentModel;
@@ -300,6 +302,13 @@ export class ModelRepository
      * Holds memoized instances of models after their initial instantiation:
      */
     protected modelInstances: Partial<ModelManifest> = {};
+
+    public getRecentContentModel(): RecentContentModel {
+        return this.getModel(
+            'recentContentModel',
+            () => new RecentContentModel(this.database),
+        );
+    }
 
     public getAnalyticsModel(): AnalyticsModel {
         return this.getModel(

--- a/packages/backend/src/models/RecentContentModel.integration.test.ts
+++ b/packages/backend/src/models/RecentContentModel.integration.test.ts
@@ -1,0 +1,166 @@
+import knex, { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import { RecentContentTableName } from '../database/entities/recentContent';
+import {
+    down,
+    up,
+} from '../database/migrations/20260909120000_create_user_recent_content';
+import { RecentContentModel } from './RecentContentModel';
+
+describe('RecentContentModel (PostgreSQL)', () => {
+    let database: Knex;
+    let model: RecentContentModel;
+    const schema = `recent_content_test_${randomUUID().replaceAll('-', '')}`;
+    const userUuid = randomUUID();
+    const otherUserUuid = randomUUID();
+    const projectUuid = randomUUID();
+    const otherProjectUuid = randomUUID();
+    const now = new Date();
+    const expired = new Date(now.getTime() - 91 * 24 * 3600 * 1000);
+    const view = (contentUuid = randomUUID(), viewedAt = now) => ({
+        userUuid,
+        projectUuid,
+        contentUuid,
+        contentType: 'chart' as const,
+        viewedAt,
+    });
+
+    beforeAll(async () => {
+        if (
+            !process.env.RECENT_CONTENT_TEST_DATABASE_URL &&
+            !process.env.PGDATABASE
+        ) {
+            throw new Error(
+                'Set RECENT_CONTENT_TEST_DATABASE_URL or PG connection variables for PostgreSQL tests',
+            );
+        }
+        const connection = process.env.RECENT_CONTENT_TEST_DATABASE_URL ?? {
+            host: process.env.PGHOST,
+            port: Number(process.env.PGPORT ?? 5432),
+            user: process.env.PGUSER,
+            password: process.env.PGPASSWORD,
+            database: process.env.PGDATABASE,
+        };
+        database = knex({
+            client: 'pg',
+            connection,
+            searchPath: [schema],
+            pool: { min: 0, max: 10 },
+        });
+        await database.schema.createSchema(schema);
+        await database.schema.createTable('users', (table) => {
+            table.uuid('user_uuid').primary();
+        });
+        await database.schema.createTable('projects', (table) => {
+            table.uuid('project_uuid').primary();
+        });
+        await database.transaction(up);
+        await database<{ user_uuid: string }>('users').insert([
+            { user_uuid: userUuid },
+            { user_uuid: otherUserUuid },
+        ]);
+        await database<{ project_uuid: string }>('projects').insert([
+            { project_uuid: projectUuid },
+            { project_uuid: otherProjectUuid },
+        ]);
+        model = new RecentContentModel(database);
+    });
+    afterEach(async () => {
+        await database(RecentContentTableName).delete();
+    });
+    afterAll(async () => {
+        if (database) {
+            await database.schema.dropSchemaIfExists(schema, true);
+            await database.destroy();
+        }
+    });
+
+    it('can roll back and reapply the schema migration', async () => {
+        await database.transaction(down);
+        await database.transaction(up);
+        await model.recordView(view());
+        expect(await model.find(userUuid, projectUuid)).toHaveLength(1);
+    });
+
+    it('keeps one row per item and never moves its timestamp backwards', async () => {
+        const item = view();
+        await model.recordView(item);
+        await model.recordView({
+            ...item,
+            viewedAt: new Date(now.getTime() - 1000),
+        });
+        expect(await model.find(userUuid, projectUuid)).toEqual([
+            { contentType: 'chart', uuid: item.contentUuid, viewedAt: now },
+        ]);
+    });
+
+    it('isolates types, users and projects', async () => {
+        const item = view();
+        await model.recordView(item);
+        await model.recordView({ ...item, contentType: 'dashboard' });
+        await model.recordView({ ...item, userUuid: otherUserUuid });
+        await model.recordView({ ...item, projectUuid: otherProjectUuid });
+        expect(await model.find(userUuid, projectUuid)).toHaveLength(2);
+        expect(await model.find(otherUserUuid, projectUuid)).toHaveLength(1);
+        expect(await model.find(userUuid, otherProjectUuid)).toHaveLength(1);
+    });
+
+    it('serializes concurrent writes and retains exactly the newest fifty', async () => {
+        const views = Array.from({ length: 65 }, (_, index) =>
+            view(randomUUID(), new Date(now.getTime() - index * 1000)),
+        );
+        await Promise.all(views.map((item) => model.recordView(item)));
+        const rows = await model.find(userUuid, projectUuid);
+        expect(rows.map((row) => row.uuid)).toEqual(
+            views.slice(0, 50).map((item) => item.contentUuid),
+        );
+        const [{ count }] = await database(RecentContentTableName).count<
+            { count: string }[]
+        >('*');
+        expect(Number(count)).toBe(50);
+    });
+
+    it('retains deterministic ties and promotes an older item on revisit', async () => {
+        const views = Array.from({ length: 51 }, () => view());
+        await Promise.all(views.map((item) => model.recordView(item)));
+        const ordered = views.map((item) => item.contentUuid).sort();
+        expect(
+            (await model.find(userUuid, projectUuid)).map((item) => item.uuid),
+        ).toEqual(ordered.slice(0, 50));
+        await model.recordView(
+            view(ordered[50], new Date(now.getTime() + 1000)),
+        );
+        expect((await model.find(userUuid, projectUuid))[0].uuid).toBe(
+            ordered[50],
+        );
+    });
+
+    it('excludes expired views and prunes them when recording', async () => {
+        await model.recordView(view(randomUUID(), expired));
+        expect(await model.find(userUuid, projectUuid)).toEqual([]);
+        const [{ count }] = await database(RecentContentTableName).count<
+            { count: string }[]
+        >('*');
+        expect(Number(count)).toBe(0);
+    });
+
+    it('cascades project and user deletion', async () => {
+        const disposableUser = randomUUID();
+        const disposableProject = randomUUID();
+        await database<{ user_uuid: string }>('users').insert({
+            user_uuid: disposableUser,
+        });
+        await database<{ project_uuid: string }>('projects').insert({
+            project_uuid: disposableProject,
+        });
+        await model.recordView({ ...view(), userUuid: disposableUser });
+        await model.recordView({ ...view(), projectUuid: disposableProject });
+        await database<{ user_uuid: string }>('users')
+            .where('user_uuid', disposableUser)
+            .delete();
+        await database<{ project_uuid: string }>('projects')
+            .where('project_uuid', disposableProject)
+            .delete();
+        expect(await database(RecentContentTableName)).toEqual([]);
+    });
+});

--- a/packages/backend/src/models/RecentContentModel.ts
+++ b/packages/backend/src/models/RecentContentModel.ts
@@ -1,0 +1,97 @@
+import type {
+    RecentContentItem,
+    RecordRecentContentView,
+} from '@lightdash/common';
+import type { Knex } from 'knex';
+import { RecentContentTableName } from '../database/entities/recentContent';
+
+export const RECENT_CONTENT_CAPACITY = 50;
+const RECENT_CONTENT_WINDOW_DAYS = 90;
+
+export class RecentContentModel {
+    constructor(private readonly database: Knex) {}
+
+    async recordView({
+        userUuid,
+        projectUuid,
+        contentType,
+        contentUuid,
+        viewedAt,
+    }: RecordRecentContentView & {
+        userUuid: string;
+        viewedAt: Date;
+    }): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            await trx.raw("SET LOCAL lock_timeout = '2s'");
+            await trx.raw("SET LOCAL statement_timeout = '5s'");
+            await trx.raw(
+                'SELECT pg_advisory_xact_lock(hashtextextended(?, 0))',
+                [`recent-content:${userUuid}:${projectUuid}`],
+            );
+            await trx(RecentContentTableName)
+                .insert({
+                    user_uuid: userUuid,
+                    project_uuid: projectUuid,
+                    content_type: contentType,
+                    content_uuid: contentUuid,
+                    last_viewed_at: viewedAt,
+                })
+                .onConflict([
+                    'user_uuid',
+                    'project_uuid',
+                    'content_type',
+                    'content_uuid',
+                ])
+                .merge({
+                    last_viewed_at: trx.raw(
+                        'GREATEST(user_recent_content.last_viewed_at, EXCLUDED.last_viewed_at)',
+                    ),
+                });
+            await trx.raw(
+                `
+                DELETE FROM user_recent_content
+                WHERE user_uuid = ? AND project_uuid = ?
+                  AND (last_viewed_at <= now() - make_interval(days => ?)
+                    OR (content_type, content_uuid) IN (
+                        SELECT content_type, content_uuid FROM user_recent_content
+                        WHERE user_uuid = ? AND project_uuid = ?
+                        ORDER BY last_viewed_at DESC, content_type, content_uuid
+                        OFFSET ?
+                    ))
+            `,
+                [
+                    userUuid,
+                    projectUuid,
+                    RECENT_CONTENT_WINDOW_DAYS,
+                    userUuid,
+                    projectUuid,
+                    RECENT_CONTENT_CAPACITY,
+                ],
+            );
+        });
+    }
+
+    async find(
+        userUuid: string,
+        projectUuid: string,
+    ): Promise<RecentContentItem[]> {
+        const rows = await this.database(RecentContentTableName)
+            .where({ user_uuid: userUuid, project_uuid: projectUuid })
+            .where(
+                'last_viewed_at',
+                '>',
+                this.database.raw('now() - make_interval(days => ?)', [
+                    RECENT_CONTENT_WINDOW_DAYS,
+                ]),
+            )
+            .orderBy('last_viewed_at', 'desc')
+            .orderBy('content_type')
+            .orderBy('content_uuid')
+            .limit(RECENT_CONTENT_CAPACITY);
+        return rows.map((row) => ({
+            contentType: row.content_type,
+            uuid: row.content_uuid,
+            viewedAt: row.last_viewed_at,
+        }));
+    }
+}

--- a/packages/backend/src/services/RecentContentService/RecentContentService.test.ts
+++ b/packages/backend/src/services/RecentContentService/RecentContentService.test.ts
@@ -1,0 +1,78 @@
+import {
+    ChartSourceType,
+    ContentType,
+    type SummaryContent,
+} from '@lightdash/common';
+import { defaultSessionUser } from '../../auth/account/account.mock';
+import type { RecentContentModel } from '../../models/RecentContentModel';
+import { RecentContentService } from './RecentContentService';
+
+describe('RecentContentService.recordView', () => {
+    const find = vi.fn();
+    const recordView = vi.fn();
+    const service = new RecentContentService({
+        contentService: { find },
+        recentContentModel: { recordView } as unknown as RecentContentModel,
+    });
+    const view = {
+        projectUuid: 'project',
+        contentType: 'chart' as const,
+        contentUuid: 'chart',
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it('records the authenticated viewer after a scoped permission-aware lookup', async () => {
+        find.mockResolvedValue({
+            data: [
+                {
+                    uuid: 'chart',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.DBT_EXPLORE,
+                } as SummaryContent,
+            ],
+        });
+        await service.recordView(defaultSessionUser, view);
+        expect(find).toHaveBeenCalledWith(
+            defaultSessionUser,
+            {
+                projectUuids: ['project'],
+                uuids: ['chart'],
+                contentTypes: [ContentType.CHART],
+            },
+            {},
+            { page: 1, pageSize: 1 },
+        );
+        expect(recordView).toHaveBeenCalledWith({
+            ...view,
+            userUuid: defaultSessionUser.userUuid,
+            viewedAt: expect.any(Date),
+        });
+    });
+
+    it('does not record missing, deleted or inaccessible content', async () => {
+        find.mockResolvedValue({ data: [] });
+        await expect(
+            service.recordView(defaultSessionUser, view),
+        ).rejects.toThrow('Content not found');
+        expect(recordView).not.toHaveBeenCalled();
+    });
+
+    it('does not treat SQL charts as explorer charts', async () => {
+        find.mockResolvedValue({
+            data: [
+                {
+                    uuid: 'chart',
+                    contentType: ContentType.CHART,
+                    source: ChartSourceType.SQL,
+                } as SummaryContent,
+            ],
+        });
+        await expect(
+            service.recordView(defaultSessionUser, view),
+        ).rejects.toThrow('Content not found');
+        expect(recordView).not.toHaveBeenCalled();
+    });
+});

--- a/packages/backend/src/services/RecentContentService/RecentContentService.ts
+++ b/packages/backend/src/services/RecentContentService/RecentContentService.ts
@@ -1,0 +1,59 @@
+import {
+    ChartSourceType,
+    ContentType,
+    NotFoundError,
+    type RecordRecentContentView,
+    type SessionUser,
+} from '@lightdash/common';
+import type { RecentContentModel } from '../../models/RecentContentModel';
+import { BaseService } from '../BaseService';
+import type { ContentService } from '../ContentService/ContentService';
+
+type RecentContentServiceArguments = {
+    recentContentModel: RecentContentModel;
+    contentService: Pick<ContentService, 'find'>;
+};
+
+export class RecentContentService extends BaseService {
+    constructor(private readonly args: RecentContentServiceArguments) {
+        super();
+    }
+
+    async recordView(
+        user: SessionUser,
+        view: RecordRecentContentView,
+    ): Promise<void> {
+        const viewedAt = new Date();
+        const { data } = await this.args.contentService.find(
+            user,
+            {
+                projectUuids: [view.projectUuid],
+                uuids: [view.contentUuid],
+                contentTypes: [
+                    view.contentType === 'chart'
+                        ? ContentType.CHART
+                        : ContentType.DASHBOARD,
+                ],
+            },
+            {},
+            { page: 1, pageSize: 1 },
+        );
+        const content = data.find(
+            (item) =>
+                item.uuid === view.contentUuid &&
+                item.contentType === view.contentType,
+        );
+        if (
+            !content ||
+            (content.contentType === ContentType.CHART &&
+                content.source !== ChartSourceType.DBT_EXPLORE)
+        ) {
+            throw new NotFoundError('Content not found');
+        }
+        await this.args.recentContentModel.recordView({
+            ...view,
+            userUuid: user.userUuid,
+            viewedAt,
+        });
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -77,6 +77,7 @@ import { PullRequestsService } from './PullRequestsService/PullRequestsService';
 import { QuerySourceRegistry } from './QuerySourceService/QuerySourceRegistry';
 import { QuerySourceService } from './QuerySourceService/QuerySourceService';
 import type { ReadinessService } from './ReadinessService/ReadinessService';
+import { RecentContentService } from './RecentContentService/RecentContentService';
 import { RenameService } from './RenameService/RenameService';
 import { RolesService } from './RolesService/RolesService';
 import { SavedChartService } from './SavedChartsService/SavedChartService';
@@ -159,6 +160,7 @@ interface ServiceManifest {
     promoteService: PromoteService;
     savedSqlService: SavedSqlService;
     contentService: ContentService;
+    recentContentService: RecentContentService;
     contentVerificationService: ContentVerificationService;
     coderService: CoderService;
     contentAsCodeWritebackService: ContentAsCodeWritebackService;
@@ -1556,6 +1558,17 @@ export class ServiceRepository
                     schedulerModel: this.models.getSchedulerModel(),
                     analyticsModel: this.models.getAnalyticsModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                }),
+        );
+    }
+
+    public getRecentContentService(): RecentContentService {
+        return this.getService(
+            'recentContentService',
+            () =>
+                new RecentContentService({
+                    recentContentModel: this.models.getRecentContentModel(),
+                    contentService: this.getContentService(),
                 }),
         );
     }

--- a/packages/backend/vitest.config.recent-content.ts
+++ b/packages/backend/vitest.config.recent-content.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import unitConfig from './vitest.config';
+
+// PostgreSQL only: these tests do not bootstrap an app or require an EE license.
+export default defineConfig({
+    ...unitConfig,
+    test: {
+        ...unitConfig.test,
+        include: ['src/models/RecentContentModel.integration.test.ts'],
+        exclude: ['node_modules', 'dist'],
+        testTimeout: 15_000,
+        hookTimeout: 15_000,
+    },
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1239,3 +1239,4 @@ export * from './compiler/compileLightdashModels';
 
 export * from './lightdash/LightdashModelEditor';
 export * from './lightdash/convertCustomMetricToLightdash';
+export * from './types/recentContent';

--- a/packages/common/src/types/recentContent.ts
+++ b/packages/common/src/types/recentContent.ts
@@ -1,0 +1,18 @@
+import type { ApiSuccess } from './api/success';
+import type { UUID } from './api/uuid';
+
+export type RecentContentType = 'chart' | 'dashboard';
+
+export type RecordRecentContentView = {
+    projectUuid: UUID;
+    contentType: RecentContentType;
+    contentUuid: UUID;
+};
+
+export type RecentContentItem = {
+    contentType: RecentContentType;
+    uuid: string;
+    viewedAt: Date;
+};
+
+export type ApiRecentContentResponse = ApiSuccess<RecentContentItem[]>;

--- a/packages/frontend/src/hooks/useRecordContentView.test.tsx
+++ b/packages/frontend/src/hooks/useRecordContentView.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { StrictMode, type PropsWithChildren } from 'react';
+import { lightdashApi } from '../api';
+import { useRecordContentView } from './useRecordContentView';
+
+vi.mock('../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../providers/App/useApp', () => ({
+    default: () => ({ user: { data: { userUuid: 'viewer' } } }),
+}));
+
+describe('useRecordContentView', () => {
+    beforeEach(() => {
+        vi.mocked(lightdashApi).mockReset().mockResolvedValue(undefined);
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+        <StrictMode>
+            <QueryClientProvider client={new QueryClient()}>
+                {children}
+            </QueryClientProvider>
+        </StrictMode>
+    );
+
+    it('waits for content then records once across renders and StrictMode effects', async () => {
+        const { rerender } = renderHook(
+            ({ uuid }: { uuid: string | undefined }) =>
+                useRecordContentView('project', 'chart', uuid),
+            {
+                initialProps: { uuid: undefined as string | undefined },
+                wrapper,
+            },
+        );
+        expect(lightdashApi).not.toHaveBeenCalled();
+        rerender({ uuid: 'chart-1' });
+        await waitFor(() => expect(lightdashApi).toHaveBeenCalledTimes(1));
+        rerender({ uuid: 'chart-1' });
+        expect(lightdashApi).toHaveBeenCalledTimes(1);
+        expect(lightdashApi).toHaveBeenCalledWith(
+            expect.objectContaining({
+                body: JSON.stringify({
+                    projectUuid: 'project',
+                    contentType: 'chart',
+                    contentUuid: 'chart-1',
+                }),
+            }),
+        );
+    });
+
+    it('records a different item and a subsequent revisit', async () => {
+        const { rerender } = renderHook(
+            ({ uuid }) => useRecordContentView('project', 'dashboard', uuid),
+            { initialProps: { uuid: 'first' }, wrapper },
+        );
+        rerender({ uuid: 'second' });
+        rerender({ uuid: 'first' });
+        await waitFor(() => expect(lightdashApi).toHaveBeenCalledTimes(3));
+    });
+
+    it('does not retry failed tracking on rerender', async () => {
+        vi.mocked(lightdashApi).mockRejectedValue(new Error('offline'));
+        const { rerender } = renderHook(
+            () => useRecordContentView('project', 'chart', 'chart'),
+            { wrapper },
+        );
+        await waitFor(() => expect(lightdashApi).toHaveBeenCalledTimes(1));
+        rerender();
+        expect(lightdashApi).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/frontend/src/hooks/useRecordContentView.ts
+++ b/packages/frontend/src/hooks/useRecordContentView.ts
@@ -1,0 +1,46 @@
+import type { RecordRecentContentView } from '@lightdash/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { lightdashApi } from '../api';
+import useApp from '../providers/App/useApp';
+
+const recentContentQueryKey = (
+    userUuid: string | undefined,
+    projectUuid: string | undefined,
+) => ['recent_content', userUuid, projectUuid];
+
+export function useRecordContentView(
+    projectUuid: string | undefined,
+    contentType: RecordRecentContentView['contentType'],
+    contentUuid: string | undefined,
+) {
+    const { user } = useApp();
+    const userUuid = user.data?.userUuid;
+    const queryClient = useQueryClient();
+    const lastRecorded = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!userUuid || !projectUuid || !contentUuid) return;
+        const key = `${userUuid}:${projectUuid}:${contentType}:${contentUuid}`;
+        if (lastRecorded.current === key) return;
+        lastRecorded.current = key;
+        void lightdashApi<undefined>({
+            version: 'v2',
+            url: '/content/recently-viewed',
+            method: 'POST',
+            body: JSON.stringify({
+                projectUuid,
+                contentType,
+                contentUuid,
+            } satisfies RecordRecentContentView),
+        })
+            .then(() => {
+                void queryClient.invalidateQueries({
+                    queryKey: recentContentQueryKey(userUuid, projectUuid),
+                });
+            })
+            .catch(() => {
+                // Recency tracking must not interrupt opening content.
+            });
+    }, [userUuid, projectUuid, contentType, contentUuid, queryClient]);
+}

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -64,6 +64,7 @@ import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import { useProjectUrlIdentifier } from '../hooks/useProjectRoute';
 import { useProjectUuid } from '../hooks/useProjectUuid';
+import { useRecordContentView } from '../hooks/useRecordContentView';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import useApp from '../providers/App/useApp';
 import DashboardAiAgentContextBridge from '../providers/Dashboard/DashboardAiAgentContextBridge';
@@ -104,6 +105,11 @@ const Dashboard: FC = () => {
     );
 
     const dashboardError = useDashboardContext((c) => c.dashboardError);
+    useRecordContentView(
+        projectUuid,
+        'dashboard',
+        !isDashboardLoading && !dashboardError ? dashboardUuid : undefined,
+    );
     const dashboardFilters = useDashboardContext((c) => c.dashboardFilters);
     const dashboardTemporaryFilters = useDashboardContext(
         (c) => c.dashboardTemporaryFilters,

--- a/packages/frontend/src/pages/SavedExplorer.tsx
+++ b/packages/frontend/src/pages/SavedExplorer.tsx
@@ -20,6 +20,7 @@ import { MergeProvider } from '../features/mergeQuery/context/MergeContext';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useExplorerQueryEffects } from '../hooks/useExplorerQueryEffects';
 import { useProjectUuid } from '../hooks/useProjectUuid';
+import { useRecordContentView } from '../hooks/useRecordContentView';
 import { useSavedQuery } from '../hooks/useSavedQuery';
 import useApp from '../providers/App/useApp';
 import { ExplorerSection } from '../providers/Explorer/types';
@@ -76,6 +77,11 @@ const SavedExplorer = () => {
         projectUuid,
         includeUnpublishedDraft: true,
     });
+    useRecordContentView(
+        projectUuid,
+        'chart',
+        !isInitialLoading && !error ? data?.uuid : undefined,
+    );
     const [isChangeExploreModalOpen, changeExploreModalHandlers] =
         useDisclosure(false);
 


### PR DESCRIPTION
Opening saved charts and dashboards now records OSS recently viewed state in a dedicated table, capped at 50 items per user/project. Existing analytics events and counters continue unchanged. This first PR starts ingestion; #28946 switches reads and #28947 adds omnibar recents.

The additive migration creates an empty table with a composite primary key and project index, without historical backfill or new indexes on analytics tables. Upsert and eviction share a transaction-scoped user/project lock. Writes prune expired and excess rows; no scheduled cleanup is needed. Inactive pairs retain at most 50 rows, with a 90-day read window. Tracking is session-only and comes from explicit page opens, excluding dashboard tiles and query refetches.

Validation: seven real PostgreSQL tests (concurrent cap, timestamp ordering, isolation, expiry, cascades, migration rollback/reapply), eight service/controller tests, three React hook tests, backend/frontend typechecks, API generation, and lint. Browser confirmed direct chart/dashboard opens record only those items while existing analytics still records views. Database tests need PostgreSQL only, with no EE license: `pnpm -F backend exec vitest run --config vitest.config.recent-content.ts` with PG connection variables.

History starts at deployment. Ship ingestion before the reader if warm-up is desired; installations skipping that release start with empty history. Earlier pending analytics migrations remain unchanged.

Stack: this PR → #28946 → #28947. Merge and retarget in that order.
