### PR TITLE
fix(learn): keep walkthrough forms open when closing menus

### DIFF
--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.test.tsx
@@ -1,7 +1,8 @@
-import { Popover } from '@mantine/core';
+import { Button, Popover, TextInput } from '@mantine/core';
+import { useForm } from '@mantine/form';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../testing/testUtils';
 import MantineModal from '../MantineModal';
@@ -38,6 +39,100 @@ describe('GuidedTour', () => {
 
         await user.click(screen.getByRole('button', { name: 'Back' }));
         expect(screen.getByText('Step one')).toBeInTheDocument();
+    });
+
+    it('updates controlled form state when accepting a suggested name', async () => {
+        const Form = () => {
+            const form = useForm({ initialValues: { name: '' } });
+            return (
+                <>
+                    <TextInput
+                        aria-label="Dashboard name"
+                        data-name-field
+                        {...form.getInputProps('name')}
+                    />
+                    <Button disabled={!form.values.name}>
+                        Create dashboard
+                    </Button>
+                    <GuidedTour
+                        steps={[
+                            {
+                                target: '[data-name-field]',
+                                title: 'Name your dashboard',
+                                body: '',
+                                interactive: true,
+                                advanceOnTargetInput: true,
+                                suggestion: 'Orders overview',
+                            },
+                        ]}
+                        opened
+                        onClose={vi.fn()}
+                    />
+                </>
+            );
+        };
+        const user = userEvent.setup();
+        renderWithProviders(<Form />);
+        expect(
+            screen.getByRole('button', { name: 'Create dashboard' }),
+        ).toBeDisabled();
+        await user.click(screen.getByRole('button', { name: 'Use it' }));
+        expect(
+            screen.getByRole('textbox', { name: 'Dashboard name' }),
+        ).toHaveValue('Orders overview');
+        expect(
+            screen.getByRole('button', { name: 'Create dashboard' }),
+        ).toBeEnabled();
+    });
+
+    it('does not advance a typed step when its field resets before settling', async () => {
+        const onStepChange = vi.fn();
+        const onClose = vi.fn();
+        const Form = () => {
+            const [name, setName] = useState('');
+            return (
+                <>
+                    <input
+                        aria-label="Transient name"
+                        data-transient-name
+                        value={name}
+                        onChange={(event) => {
+                            setName(event.currentTarget.value);
+                            window.setTimeout(() => setName(''), 20);
+                        }}
+                    />
+                    <GuidedTour
+                        steps={[
+                            {
+                                target: '[data-transient-name]',
+                                title: 'Name',
+                                body: '',
+                                interactive: true,
+                                advanceOnTargetInput: true,
+                                suggestion: 'Orders overview',
+                            },
+                            { target: null, title: 'Next step', body: '' },
+                        ]}
+                        opened
+                        onClose={onClose}
+                        onStepChange={onStepChange}
+                    />
+                </>
+            );
+        };
+        const user = userEvent.setup();
+        renderWithProviders(<Form />);
+        await user.click(screen.getByRole('button', { name: 'Use it' }));
+        await waitFor(() =>
+            expect(
+                screen.getByRole('textbox', { name: 'Transient name' }),
+            ).toHaveValue(''),
+        );
+        await act(
+            async () =>
+                new Promise((resolve) => window.setTimeout(resolve, 1100)),
+        );
+        expect(onStepChange).not.toHaveBeenCalled();
     });
 
     it('closes when skipped', async () => {
@@ -215,6 +310,65 @@ describe('GuidedTour', () => {
             }
         });
 
+        it('offers a fallback click before a missing typed field can accept its suggestion', async () => {
+            const user = userEvent.setup();
+            const host = mount('<button data-x="open-form">Open form</button>');
+            host.querySelector('button')!.onclick = () => {
+                host.innerHTML = '<input data-x="name" aria-label="Name" />';
+            };
+            try {
+                renderWithProviders(
+                    <GuidedTour
+                        steps={[
+                            {
+                                target: '[data-x="name"]',
+                                title: 'Name your dashboard',
+                                body: '',
+                                interactive: true,
+                                advanceOnTargetInput: true,
+                                suggestion: 'Orders overview',
+                                detour: [
+                                    {
+                                        target: '[data-x="open-form"]',
+                                        title: 'Open form',
+                                    },
+                                ],
+                            },
+                        ]}
+                        opened
+                        onClose={vi.fn()}
+                    />,
+                );
+                await waitFor(() =>
+                    expect(host.querySelector('button')).toHaveAttribute(
+                        'data-tour-active',
+                    ),
+                );
+                expect(
+                    screen.queryByRole('button', { name: 'Use it' }),
+                ).not.toBeInTheDocument();
+                expect(
+                    screen.getByText(
+                        'Click the highlighted control to continue',
+                    ),
+                ).toBeVisible();
+                await user.click(host.querySelector('button')!);
+                await waitFor(() =>
+                    expect(
+                        screen.getByRole('button', { name: 'Use it' }),
+                    ).toBeVisible(),
+                );
+                await user.click(
+                    screen.getByRole('button', { name: 'Use it' }),
+                );
+                expect(
+                    screen.getByRole('textbox', { name: 'Name' }),
+                ).toHaveValue('Orders overview');
+            } finally {
+                host.remove();
+            }
+        });
+
         it('ignores the detour when the target is already there', async () => {
             const host = mount(
                 '<button data-x="chooser">Download data</button><button data-x="download">Download</button>',
@@ -331,22 +485,42 @@ describe('GuidedTour and the menus a step opens', () => {
 
     // Only menus: a dialog a step opened is part of what the walkthrough is
     // teaching, and the host shows the completion dialog over it.
-    it('leaves an open dialog alone', async () => {
-        const user = userEvent.setup();
-        renderWithProviders(
-            <>
-                <MantineModal opened onClose={vi.fn()} title="Save chart">
-                    <div>Chart name</div>
-                </MantineModal>
-                <GuidedTour
-                    steps={[{ target: null, title: 'Step one', body: '' }]}
-                    opened
-                    onClose={vi.fn()}
-                />
-            </>,
+    it('closes a dropdown without closing the dialog beside it', async () => {
+        const closeDialog = vi.fn();
+        const Page = () => {
+            const [opened, setOpened] = useState(true);
+            return (
+                <>
+                    <OpenMenu />
+                    <MantineModal
+                        opened={opened}
+                        onClose={() => {
+                            closeDialog();
+                            setOpened(false);
+                        }}
+                        title="Save chart"
+                    >
+                        <div id="chart-name">Chart name</div>
+                    </MantineModal>
+                    <GuidedTour
+                        steps={[
+                            {
+                                target: '#chart-name',
+                                title: 'Name chart',
+                                body: '',
+                            },
+                        ]}
+                        opened
+                        onClose={vi.fn()}
+                    />
+                </>
+            );
+        };
+        renderWithProviders(<Page />);
+        await waitFor(() =>
+            expect(screen.queryByText('Sales')).not.toBeInTheDocument(),
         );
-
-        await user.click(screen.getByRole('button', { name: 'Got it' }));
+        expect(closeDialog).not.toHaveBeenCalled();
         expect(screen.getByText('Chart name')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
+++ b/packages/frontend/src/components/common/GuidedTour/GuidedTour.tsx
@@ -509,17 +509,24 @@ const DROPDOWN_SELECTOR = '.mantine-Popover-dropdown';
  * ends. The one the tour is pointing inside is left alone (a comment thread
  * stays open while its step types into it).
  *
- * Escape is dispatched on the dropdown and does not bubble: React still runs
- * the dropdown's own capture handler, while the window-level listeners that
- * close a modal or a drawer never hear it, so a dialog a step opened on
- * purpose survives.
+ * Mantine modals listen for Escape during window capture, even when it does
+ * not bubble. Mark this synthetic event's target with Mantine's opt-out so
+ * closing a dropdown cannot also close the dialog a step just opened.
  */
 const closeOpenDropdowns = (keep: Element | null) => {
     document.querySelectorAll(DROPDOWN_SELECTOR).forEach((dropdown) => {
         if (keep && dropdown.contains(keep)) return;
-        dropdown.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Escape', bubbles: false }),
-        );
+        const attribute = 'data-mantine-stop-propagation';
+        const previous = dropdown.getAttribute(attribute);
+        dropdown.setAttribute(attribute, 'true');
+        try {
+            dropdown.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape', bubbles: false }),
+            );
+        } finally {
+            if (previous === null) dropdown.removeAttribute(attribute);
+            else dropdown.setAttribute(attribute, previous);
+        }
     });
 };
 
@@ -866,7 +873,19 @@ export const GuidedTour: FC<GuidedTourProps> = ({
         const onInput = () => {
             window.clearTimeout(debounce);
             if (typed().trim().length < MIN_INPUT_CHARS) return;
-            debounce = window.setTimeout(() => handleNext(), INPUT_SETTLE_MS);
+            const inputAtEvent = el;
+            debounce = window.setTimeout(() => {
+                // A form can reset or remount while the input settles. Only
+                // advance if the same visible field still holds the value.
+                if (
+                    !inputAtEvent?.isConnected ||
+                    document.querySelector(inputSelector) !== inputAtEvent ||
+                    el !== inputAtEvent ||
+                    typed().trim().length < MIN_INPUT_CHARS
+                )
+                    return;
+                handleNext();
+            }, INPUT_SETTLE_MS);
         };
         const tick = () => {
             if (el && !el.isConnected) {
@@ -1044,6 +1063,7 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                             // The highlighted control is the way forward; a
                             // Next button here would compete with it.
                             shownStep.advanceOnTargetInput &&
+                            spotlightSelector === shownStep.target &&
                             shownStep.suggestion ? (
                                 <Group gap="xs" wrap="nowrap">
                                     <Text fz="xs" c="dimmed">
@@ -1077,7 +1097,8 @@ export const GuidedTour: FC<GuidedTourProps> = ({
                                 </Group>
                             ) : (
                                 <Text fz="xs" c="dimmed">
-                                    {shownStep.advanceOnTargetInput
+                                    {shownStep.advanceOnTargetInput &&
+                                    spotlightSelector === shownStep.target
                                         ? 'Type in the highlighted field to continue'
                                         : 'Click the highlighted control to continue'}
                                 </Text>

--- a/scripts/scope-tours/smoke.ts
+++ b/scripts/scope-tours/smoke.ts
@@ -298,7 +298,17 @@ const runTour = async (
                 shot,
             );
         }
-        if (step?.advanceOnTargetInput) {
+        const typingTargetActive =
+            step?.advanceOnTargetInput &&
+            step.target &&
+            (await page.evaluate(
+                (selector) =>
+                    document
+                        .querySelector(selector)
+                        ?.hasAttribute('data-tour-active') === true,
+                step.target,
+            ));
+        if (typingTargetActive) {
             // A typed step: the card offers a value; take it, as a learner
             // in a hurry would. Typing anything else would do as well.
             const useIt = page


### PR DESCRIPTION
When a walkthrough moves from a menu into a modal, its synthetic Escape event also reaches Mantine’s window-capture listener. The modal closes and its form values are lost: dashboard creation then reopens with an empty name and a disabled Next button.

Keep the modal open while closing the menu. Typed steps offer their suggestion only when the real input is highlighted; fallback controls remain usable, and the input debounce rechecks the field before advancing. The smoke driver follows the same highlighted fallback path.

Validation: 15 GuidedTour tests passed, including regressions observed failing before the fix for a stateful modal and an input reset during the settle delay. All 33 walkthroughs passed browser smoke in disposable training copies, including all 15 dashboard-creation steps. Frontend typecheck and the combined 65-test focused suite passed.

Relates to CS-212. The parent curriculum PR depends on docs PR https://github.com/lightdash/mintlify-docs/pull/1230 merging first.
