### PR TITLE
perf(content): serve recently viewed from bounded OSS history

### DIFF
--- a/packages/backend/src/controllers/v2/RecentContentController.test.ts
+++ b/packages/backend/src/controllers/v2/RecentContentController.test.ts
@@ -24,6 +24,12 @@ describe('RecentContentController', () => {
             await expect(
                 controller.recordView({ account } as express.Request, view),
             ).rejects.toThrow('not session auth');
+            await expect(
+                controller.getRecentlyViewed(
+                    { account } as express.Request,
+                    'project',
+                ),
+            ).rejects.toThrow('not session auth');
             expect(recordView).not.toHaveBeenCalled();
         },
     );

--- a/packages/backend/src/controllers/v2/RecentContentController.ts
+++ b/packages/backend/src/controllers/v2/RecentContentController.ts
@@ -1,13 +1,17 @@
 import {
     assertSessionAuth,
     type ApiErrorPayload,
+    type ApiRecentContentResponse,
     type ApiSuccessEmpty,
     type RecordRecentContentView,
+    type UUID,
 } from '@lightdash/common';
 import {
     Body,
+    Get,
     Middlewares,
     Post,
+    Query,
     Request,
     Response,
     Route,
@@ -22,6 +26,21 @@ import { BaseController } from '../baseController';
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('v2', 'Content')
 export class RecentContentController extends BaseController {
+    @Get('/')
+    @Middlewares([isAuthenticated])
+    async getRecentlyViewed(
+        @Request() req: express.Request,
+        @Query() projectUuid: UUID,
+    ): Promise<ApiRecentContentResponse> {
+        assertSessionAuth(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getRecentContentService()
+                .getRecentlyViewed(toSessionUser(req.account), projectUuid),
+        };
+    }
+
     @Post('/')
     @Middlewares([isAuthenticated])
     async recordView(

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -301,6 +301,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 context,
             }) =>
                 new ProjectHomepageService({
+                    recentContentService: repository.getRecentContentService(),
                     projectHomepageModel:
                         models.getProjectHomepageModel<ProjectHomepageModel>(),
                     analytics: context.lightdashAnalytics,

--- a/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.test.ts
@@ -6,7 +6,6 @@ import {
 } from '@lightdash/common';
 import knex, { Knex } from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
-import { DatabaseError } from 'pg';
 import { UserTableName } from '../../database/entities/users';
 import {
     AnnouncementsTableName,
@@ -339,36 +338,6 @@ describe('ProjectHomepageModel', () => {
 
             expect(result[0]?.announcement.authorName).toBeNull();
             expect(result[0]?.slackChannelId).toBe('C1');
-        });
-    });
-
-    describe('getRecentlyViewed', () => {
-        const USER_UUID = '00000000-0000-0000-0000-000000000020';
-
-        it('returns no items when the query hits the statement timeout', async () => {
-            const timeout = new DatabaseError(
-                'canceling statement due to statement timeout',
-                0,
-                'error',
-            );
-            timeout.code = '57014';
-            tracker.on.any(/statement_timeout/).responseOnce([]);
-            tracker.on.any(/analytics_chart_views/).simulateErrorOnce(timeout);
-
-            await expect(
-                model.getRecentlyViewed(PROJECT_UUID, USER_UUID),
-            ).resolves.toEqual([]);
-        });
-
-        it('rethrows other database errors', async () => {
-            tracker.on.any(/statement_timeout/).responseOnce([]);
-            tracker.on
-                .any(/analytics_chart_views/)
-                .simulateErrorOnce(new Error('connection reset'));
-
-            await expect(
-                model.getRecentlyViewed(PROJECT_UUID, USER_UUID),
-            ).rejects.toThrow('connection reset');
         });
     });
 

--- a/packages/backend/src/ee/models/ProjectHomepageModel.ts
+++ b/packages/backend/src/ee/models/ProjectHomepageModel.ts
@@ -11,7 +11,6 @@ import {
     type HomepageBlock,
     type HomepageConfig,
     type HomepageOpening,
-    type HomepageRecentlyViewedItem,
     type OrganizationHomepageSettings,
     type ProjectAnnouncement,
     type ProjectHomepage,
@@ -23,8 +22,6 @@ import {
 } from '@lightdash/common';
 import { type Knex } from 'knex';
 import { UserTableName } from '../../database/entities/users';
-import { isStatementTimeout } from '../../database/errors';
-import Logger from '../../logging/logger';
 import { OrganizationHomepageSettingsTableName } from '../database/entities/organizationHomepageSettings';
 import {
     AnnouncementsTableName,
@@ -33,9 +30,6 @@ import {
     type DbAnnouncement,
     type DbProjectHomepage,
 } from '../database/entities/projectHomepages';
-
-const RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS = 10_000;
-const RECENTLY_VIEWED_WINDOW_DAYS = 90;
 
 type RankableGroupAssignment = {
     groupUuid: string;
@@ -367,108 +361,6 @@ export class ProjectHomepageModel {
             throw new NotFoundError('Homepage not found');
         }
         return ProjectHomepageModel.mapDbHomepage(row);
-    }
-
-    // Derived from the existing analytics view events — no separate tracking
-    async getRecentlyViewed(
-        projectUuid: string,
-        userUuid: string,
-        limit: number = 8,
-    ): Promise<HomepageRecentlyViewedItem[]> {
-        try {
-            return await this.database.transaction(async (trx) => {
-                await trx.raw(
-                    `SET LOCAL statement_timeout = ${RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS}`,
-                );
-                const { rows } = await trx.raw<{
-                    rows: Array<{
-                        content_type: 'chart' | 'dashboard';
-                        content_uuid: string;
-                        viewed_at: Date;
-                    }>;
-                }>(
-                    `
-            -- Opening a dashboard records a view for every tile on it, which
-            -- would bury the dashboard the user actually opened. Tiles are
-            -- tagged where we can, but several code paths write untagged rows,
-            -- so chart views that land in the moments around one of this
-            -- user's dashboard views are dropped too. That check is done with a
-            -- window over the user's merged view stream rather than an
-            -- anti-join: a range predicate cannot be hashed, so the anti-join
-            -- degraded to every chart view × every dashboard view.
-            WITH user_views AS (
-                SELECT 'chart' AS kind, chart_uuid AS content_uuid, context, timestamp
-                FROM analytics_chart_views
-                WHERE user_uuid = :userUuid
-                  AND timestamp > now() - make_interval(days => :windowDays)
-                UNION ALL
-                SELECT 'dashboard' AS kind, dashboard_uuid AS content_uuid, context, timestamp
-                FROM analytics_dashboard_views
-                WHERE user_uuid = :userUuid
-                  AND timestamp > now() - make_interval(days => :windowDays) - interval '15 seconds'
-            ),
-            shadowed_chart_views AS (
-                SELECT kind, content_uuid, context, timestamp,
-                       count(*) FILTER (WHERE kind = 'dashboard') OVER (
-                           ORDER BY timestamp
-                           RANGE BETWEEN interval '15 seconds' PRECEDING
-                                     AND interval '2 seconds' FOLLOWING
-                       ) AS nearby_dashboard_views
-                FROM user_views
-            )
-            SELECT content_type, content_uuid, max(viewed_at) AS viewed_at
-            FROM (
-                SELECT 'chart' AS content_type,
-                       acv.content_uuid,
-                       acv.timestamp AS viewed_at
-                FROM shadowed_chart_views acv
-                JOIN saved_queries sq ON sq.saved_query_uuid = acv.content_uuid
-                JOIN spaces s ON s.space_id = sq.space_id
-                JOIN projects p ON p.project_id = s.project_id
-                WHERE acv.kind = 'chart'
-                  AND p.project_uuid = :projectUuid
-                  AND sq.deleted_at IS NULL
-                  AND s.deleted_at IS NULL
-                  AND (acv.context ->> 'source') IS DISTINCT FROM 'dashboard'
-                  AND acv.nearby_dashboard_views = 0
-                UNION ALL
-                SELECT 'dashboard' AS content_type,
-                       adv.dashboard_uuid AS content_uuid,
-                       adv.timestamp AS viewed_at
-                FROM analytics_dashboard_views adv
-                JOIN dashboards d ON d.dashboard_uuid = adv.dashboard_uuid
-                JOIN spaces s ON s.space_id = d.space_id
-                JOIN projects p ON p.project_id = s.project_id
-                WHERE adv.user_uuid = :userUuid
-                  AND adv.timestamp > now() - make_interval(days => :windowDays)
-                  AND p.project_uuid = :projectUuid
-                  AND d.deleted_at IS NULL
-                  AND s.deleted_at IS NULL
-            ) views
-            GROUP BY content_type, content_uuid
-            ORDER BY viewed_at DESC
-            LIMIT :limit
-            `,
-                    {
-                        userUuid,
-                        projectUuid,
-                        limit,
-                        windowDays: RECENTLY_VIEWED_WINDOW_DAYS,
-                    },
-                );
-                return rows.map((row) => ({
-                    contentType: row.content_type,
-                    uuid: row.content_uuid,
-                    viewedAt: row.viewed_at,
-                }));
-            });
-        } catch (error) {
-            if (!isStatementTimeout(error)) throw error;
-            Logger.warn(
-                `Recently viewed query exceeded ${RECENTLY_VIEWED_STATEMENT_TIMEOUT_MS}ms in project ${projectUuid}; returning no items`,
-            );
-            return [];
-        }
     }
 
     // Publishing to "everyone" promotes the homepage to the project default

--- a/packages/backend/src/ee/services/ProjectHomepageService.test.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.test.ts
@@ -154,6 +154,9 @@ const makeService = ({
     >;
 } = {}) =>
     new ProjectHomepageService({
+        recentContentService: {
+            getRecentlyViewed: vi.fn().mockResolvedValue([]),
+        },
         analytics: { track: vi.fn() },
         featureFlagService: {
             get: vi.fn().mockResolvedValue({
@@ -165,7 +168,6 @@ const makeService = ({
             getDefault: vi.fn().mockResolvedValue(undefined),
             getByUuid: vi.fn().mockResolvedValue(makeHomepage()),
             getPublishedDefault: vi.fn().mockResolvedValue(undefined),
-            getRecentlyViewed: vi.fn().mockResolvedValue([]),
             getAssignments: vi.fn().mockResolvedValue([]),
             updateGroupPriorities: vi.fn().mockResolvedValue(undefined),
             resolvePublished: vi.fn().mockResolvedValue(undefined),

--- a/packages/backend/src/ee/services/ProjectHomepageService.ts
+++ b/packages/backend/src/ee/services/ProjectHomepageService.ts
@@ -50,6 +50,7 @@ import { type UserModel } from '../../models/UserModel';
 import { BaseService } from '../../services/BaseService';
 import { type FeatureFlagService } from '../../services/FeatureFlag/FeatureFlagService';
 import { type PersistentDownloadFileService } from '../../services/PersistentDownloadFileService/PersistentDownloadFileService';
+import type { RecentContentService } from '../../services/RecentContentService/RecentContentService';
 import { secureFetch } from '../../utils/secureFetch/secureFetch';
 import { type ProjectHomepageModel } from '../models/ProjectHomepageModel';
 import { type CommercialSchedulerClient } from '../scheduler/SchedulerClient';
@@ -171,12 +172,12 @@ const readImageDimensions = (buffer: Buffer): ImageDimensions | null =>
     readJpegDimensions(buffer);
 
 export type ProjectHomepageServiceArguments = {
+    recentContentService: Pick<RecentContentService, 'getRecentlyViewed'>;
     projectHomepageModel: Pick<
         ProjectHomepageModel,
         | 'getDefault'
         | 'getByUuid'
         | 'getPublishedDefault'
-        | 'getRecentlyViewed'
         | 'getAssignments'
         | 'updateGroupPriorities'
         | 'resolvePublished'
@@ -220,6 +221,7 @@ export type ProjectHomepageServiceArguments = {
 };
 
 export class ProjectHomepageService extends BaseService {
+    private readonly recentContentService: ProjectHomepageServiceArguments['recentContentService'];
     private readonly projectHomepageModel: ProjectHomepageServiceArguments['projectHomepageModel'];
 
     private readonly analytics: ProjectHomepageServiceArguments['analytics'];
@@ -247,6 +249,7 @@ export class ProjectHomepageService extends BaseService {
     constructor(args: ProjectHomepageServiceArguments) {
         super();
         this.projectHomepageModel = args.projectHomepageModel;
+        this.recentContentService = args.recentContentService;
         this.analytics = args.analytics;
         this.featureFlagService = args.featureFlagService;
         this.groupsModel = args.groupsModel;
@@ -560,10 +563,15 @@ export class ProjectHomepageService extends BaseService {
     ): Promise<HomepageRecentlyViewedItem[]> {
         await this.assertFlagEnabled(user);
         await this.assertCanView(user, projectUuid);
-        return this.projectHomepageModel.getRecentlyViewed(
+        const entries = await this.recentContentService.getRecentlyViewed(
+            user,
             projectUuid,
-            user.userUuid,
         );
+        return entries.map(({ contentType, uuid, viewedAt }) => ({
+            contentType,
+            uuid,
+            viewedAt,
+        }));
     }
 
     async getHomepageForBuilder(

--- a/packages/backend/src/scripts/benchmark-recent-content.ts
+++ b/packages/backend/src/scripts/benchmark-recent-content.ts
@@ -1,0 +1,108 @@
+import knex from 'knex';
+import { randomUUID } from 'node:crypto';
+import { up } from '../database/migrations/20260909120000_create_user_recent_content';
+import { RecentContentModel } from '../models/RecentContentModel';
+
+async function main() {
+    if (!process.env.PGDATABASE)
+        throw new Error(
+            'Set PG connection variables to a disposable PostgreSQL database',
+        );
+    const schema = `recent_benchmark_${randomUUID().replaceAll('-', '')}`;
+    const db = knex({
+        client: 'pg',
+        connection: {
+            host: process.env.PGHOST,
+            port: Number(process.env.PGPORT),
+            user: process.env.PGUSER,
+            password: process.env.PGPASSWORD,
+            database: process.env.PGDATABASE,
+        },
+        searchPath: [schema],
+        pool: { min: 0, max: 10 },
+    });
+    try {
+        await db.schema.createSchema(schema);
+        await db.schema.createTable('users', (t) =>
+            t.uuid('user_uuid').primary(),
+        );
+        await db.schema.createTable('projects', (t) =>
+            t.uuid('project_uuid').primary(),
+        );
+        await db.transaction(up);
+        const projectUuid = randomUUID();
+        await db<{ project_uuid: string }>('projects').insert({
+            project_uuid: projectUuid,
+        });
+        await db.raw(
+            'INSERT INTO users SELECT gen_random_uuid() FROM generate_series(1, 10000)',
+        );
+        const started = performance.now();
+        await db.raw(
+            `INSERT INTO user_recent_content SELECT user_uuid, ?::uuid, 'chart', gen_random_uuid(), now() - n * interval '1 second' FROM users CROSS JOIN generate_series(1,50) n`,
+            [projectUuid],
+        );
+        await db.raw('ANALYZE user_recent_content');
+        const user = await db<{ user_uuid: string }>('users').first();
+        if (!user) throw new Error('Benchmark user missing');
+        const userUuid = user.user_uuid;
+        const model = new RecentContentModel(db);
+        const readTimes: number[] = [];
+        const writeTimes: number[] = [];
+        /* eslint-disable no-await-in-loop -- Measure sequential request latency. */
+        for (let i = 0; i < 100; i += 1) {
+            let t = performance.now();
+            await model.find(userUuid, projectUuid);
+            readTimes.push(performance.now() - t);
+            t = performance.now();
+            await model.recordView({
+                userUuid,
+                projectUuid,
+                contentType: 'chart',
+                contentUuid: randomUUID(),
+                viewedAt: new Date(),
+            });
+            writeTimes.push(performance.now() - t);
+        }
+        /* eslint-enable no-await-in-loop */
+        const metrics = (times: number[]) => {
+            times.sort((a, b) => a - b);
+            return { p50ms: times[49], p95ms: times[94], maxMs: times[99] };
+        };
+        const sizes = await db.raw<{
+            rows: {
+                table_bytes: string;
+                index_bytes: string;
+                total_bytes: string;
+            }[];
+        }>(
+            `SELECT pg_table_size('user_recent_content') AS table_bytes, pg_indexes_size('user_recent_content') AS index_bytes, pg_total_relation_size('user_recent_content') AS total_bytes`,
+        );
+        const plan = await db.raw<{ rows: { 'QUERY PLAN': string }[] }>(
+            `EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM user_recent_content WHERE user_uuid = ? AND project_uuid = ? AND last_viewed_at > now() - interval '90 days' ORDER BY last_viewed_at DESC, content_type, content_uuid LIMIT 50`,
+            [userUuid, projectUuid],
+        );
+        console.log(
+            JSON.stringify(
+                {
+                    rows: 500000,
+                    pairs: 10000,
+                    fixtureAndBenchmarkMs: performance.now() - started,
+                    read: metrics(readTimes),
+                    write: metrics(writeTimes),
+                    sizes: sizes.rows,
+                    plan: plan.rows,
+                },
+                null,
+                2,
+            ),
+        );
+    } finally {
+        await db.schema.dropSchemaIfExists(schema, true);
+        await db.destroy();
+    }
+}
+main().catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+});

--- a/packages/backend/src/services/RecentContentService/RecentContentService.test.ts
+++ b/packages/backend/src/services/RecentContentService/RecentContentService.test.ts
@@ -11,6 +11,7 @@ describe('RecentContentService.recordView', () => {
     const find = vi.fn();
     const recordView = vi.fn();
     const service = new RecentContentService({
+        projectModel: { getSummary: vi.fn() },
         contentService: { find },
         recentContentModel: { recordView } as unknown as RecentContentModel,
     });
@@ -74,5 +75,106 @@ describe('RecentContentService.recordView', () => {
             service.recordView(defaultSessionUser, view),
         ).rejects.toThrow('Content not found');
         expect(recordView).not.toHaveBeenCalled();
+    });
+});
+
+describe('RecentContentService.getRecentlyViewed', () => {
+    const findContent = vi.fn();
+    const findRecent = vi.fn();
+    const getSummary = vi.fn();
+    const service = new RecentContentService({
+        projectModel: { getSummary },
+        contentService: { find: findContent },
+        recentContentModel: {
+            find: findRecent,
+        } as unknown as RecentContentModel,
+    });
+    const candidates = Array.from({ length: 50 }, (_, index) => ({
+        contentType: 'chart' as const,
+        uuid: `chart-${index}`,
+        viewedAt: new Date(2026, 8, 9, 0, 0, 50 - index),
+    }));
+    const contentFor = (uuid: string): SummaryContent =>
+        ({
+            uuid,
+            contentType: ContentType.CHART,
+            source: ChartSourceType.DBT_EXPLORE,
+            project: { uuid: 'project' },
+        }) as SummaryContent;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        getSummary.mockResolvedValue({
+            organizationUuid: defaultSessionUser.organizationUuid,
+        });
+        findRecent.mockResolvedValue(candidates);
+    });
+
+    it('filters before limiting and preserves recency despite hydration order', async () => {
+        findContent.mockResolvedValue({
+            data: candidates
+                .slice(20)
+                .map((item) => contentFor(item.uuid))
+                .reverse(),
+        });
+        const entries = await service.getRecentlyViewed(
+            defaultSessionUser,
+            'project',
+        );
+        expect(entries.map((item) => item.uuid)).toEqual(
+            candidates.slice(20, 30).map((item) => item.uuid),
+        );
+        expect(entries[0].content).toEqual(contentFor('chart-20'));
+        expect(findRecent).toHaveBeenCalledWith(
+            defaultSessionUser.userUuid,
+            'project',
+        );
+        expect(findContent).toHaveBeenCalledWith(
+            defaultSessionUser,
+            expect.objectContaining({
+                projectUuids: ['project'],
+                uuids: candidates.map((item) => item.uuid),
+                chart: { sources: [ChartSourceType.DBT_EXPLORE] },
+            }),
+            {},
+            { page: 1, pageSize: 100 },
+        );
+    });
+
+    it('returns no references for deleted or inaccessible content', async () => {
+        findContent.mockResolvedValue({ data: [] });
+        expect(
+            await service.getRecentlyViewed(defaultSessionUser, 'project'),
+        ).toEqual([]);
+    });
+
+    it('does not resolve content or fall back to history for an empty table', async () => {
+        findRecent.mockResolvedValue([]);
+        expect(
+            await service.getRecentlyViewed(defaultSessionUser, 'project'),
+        ).toEqual([]);
+        expect(findContent).not.toHaveBeenCalled();
+    });
+
+    it('rejects another organization before reading recency', async () => {
+        getSummary.mockResolvedValue({ organizationUuid: 'another-org' });
+        await expect(
+            service.getRecentlyViewed(defaultSessionUser, 'project'),
+        ).rejects.toThrow('Cannot view this project');
+        expect(findRecent).not.toHaveBeenCalled();
+    });
+
+    it('does not expose content that moved to another project', async () => {
+        findContent.mockResolvedValue({
+            data: [
+                {
+                    ...contentFor('chart-0'),
+                    project: { uuid: 'other-project' },
+                },
+            ],
+        });
+        expect(
+            await service.getRecentlyViewed(defaultSessionUser, 'project'),
+        ).toEqual([]);
     });
 });

--- a/packages/backend/src/services/RecentContentService/RecentContentService.ts
+++ b/packages/backend/src/services/RecentContentService/RecentContentService.ts
@@ -1,22 +1,87 @@
+import { subject } from '@casl/ability';
 import {
     ChartSourceType,
     ContentType,
+    ForbiddenError,
     NotFoundError,
+    type RecentContentEntry,
     type RecordRecentContentView,
     type SessionUser,
 } from '@lightdash/common';
+import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import type { RecentContentModel } from '../../models/RecentContentModel';
+import { RECENT_CONTENT_CAPACITY } from '../../models/RecentContentModel';
 import { BaseService } from '../BaseService';
 import type { ContentService } from '../ContentService/ContentService';
 
 type RecentContentServiceArguments = {
     recentContentModel: RecentContentModel;
     contentService: Pick<ContentService, 'find'>;
+    projectModel: Pick<ProjectModel, 'getSummary'>;
 };
 
 export class RecentContentService extends BaseService {
     constructor(private readonly args: RecentContentServiceArguments) {
         super();
+    }
+
+    async getRecentlyViewed(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<RecentContentEntry[]> {
+        const project = await this.args.projectModel.getSummary(projectUuid);
+        if (
+            project.organizationUuid !== user.organizationUuid ||
+            this.createAuditedAbility(user).cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid: project.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError('Cannot view this project');
+        }
+        const candidates = await this.args.recentContentModel.find(
+            user.userUuid,
+            projectUuid,
+        );
+        if (candidates.length === 0) return [];
+        const { data } = await this.args.contentService.find(
+            user,
+            {
+                projectUuids: [projectUuid],
+                uuids: candidates.map((item) => item.uuid),
+                contentTypes: [ContentType.CHART, ContentType.DASHBOARD],
+                chart: { sources: [ChartSourceType.DBT_EXPLORE] },
+            },
+            {},
+            { page: 1, pageSize: RECENT_CONTENT_CAPACITY * 2 },
+        );
+        const byId = new Map(
+            data.map((content) => [
+                `${content.contentType}:${content.uuid}`,
+                content,
+            ]),
+        );
+        return candidates
+            .flatMap((item): RecentContentEntry[] => {
+                const content = byId.get(`${item.contentType}:${item.uuid}`);
+                if (
+                    !content ||
+                    content.project.uuid !== projectUuid ||
+                    (content.contentType !== ContentType.CHART &&
+                        content.contentType !== ContentType.DASHBOARD)
+                )
+                    return [];
+                if (
+                    content.contentType === ContentType.CHART &&
+                    content.source !== ChartSourceType.DBT_EXPLORE
+                )
+                    return [];
+                return [{ ...item, content }];
+            })
+            .slice(0, 10);
     }
 
     async recordView(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1568,6 +1568,7 @@ export class ServiceRepository
             () =>
                 new RecentContentService({
                     recentContentModel: this.models.getRecentContentModel(),
+                    projectModel: this.models.getProjectModel(),
                     contentService: this.getContentService(),
                 }),
         );

--- a/packages/common/src/types/recentContent.ts
+++ b/packages/common/src/types/recentContent.ts
@@ -1,5 +1,6 @@
 import type { ApiSuccess } from './api/success';
 import type { UUID } from './api/uuid';
+import type { ChartContent, DashboardContent } from './content';
 
 export type RecentContentType = 'chart' | 'dashboard';
 
@@ -15,4 +16,8 @@ export type RecentContentItem = {
     viewedAt: Date;
 };
 
-export type ApiRecentContentResponse = ApiSuccess<RecentContentItem[]>;
+export type RecentContentEntry = RecentContentItem & {
+    content: ChartContent | DashboardContent;
+};
+
+export type ApiRecentContentResponse = ApiSuccess<RecentContentEntry[]>;

--- a/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
+++ b/packages/frontend/src/ee/features/homepageBuilder/hooks/useRecentContents.ts
@@ -1,40 +1,14 @@
-import {
-    type ApiError,
-    type HomepageRecentlyViewedItem,
-} from '@lightdash/common';
-import { useQuery } from '@tanstack/react-query';
-import { lightdashApi } from '../../../../api';
-import { useCollectionContent } from './useCollectionContent';
-
-const getRecentlyViewed = async (projectUuid: string) =>
-    lightdashApi<HomepageRecentlyViewedItem[]>({
-        url: `/projects/${projectUuid}/homepage/recently-viewed`,
-        method: 'GET',
-        body: undefined,
-    });
+import { useRecentContent } from '../../../../hooks/useRecentContent';
 
 const MAX_RECENT_ITEMS = 4;
 
-const useRecentlyViewed = (projectUuid: string | undefined) =>
-    useQuery<HomepageRecentlyViewedItem[], ApiError>({
-        queryKey: ['homepage_recently_viewed', projectUuid],
-        queryFn: () => getRecentlyViewed(projectUuid!),
-        enabled: !!projectUuid,
-    });
-
-/** The viewer's recently-viewed content, resolved to real items. Exposed as a
- * hook so a surface that owns the section header (day-0) can decide whether to
- * render one at all — both callers share the same queries. */
 export const useRecentContents = (projectUuid: string | undefined) => {
-    const { data: recents, isInitialLoading } = useRecentlyViewed(projectUuid);
-    const uuids = (recents ?? [])
-        .slice(0, MAX_RECENT_ITEMS)
-        .map((item) => item.uuid);
-    const { data: contents, isInitialLoading: isResolving } =
-        useCollectionContent(projectUuid ?? '', uuids);
+    const { data, isInitialLoading } = useRecentContent(projectUuid);
     return {
-        recents: recents ?? [],
-        contents: contents ?? [],
-        isLoading: isInitialLoading || isResolving,
+        recents: data ?? [],
+        contents: (data ?? [])
+            .slice(0, MAX_RECENT_ITEMS)
+            .map((item) => item.content),
+        isLoading: isInitialLoading,
     };
 };

--- a/packages/frontend/src/hooks/useRecentContent.ts
+++ b/packages/frontend/src/hooks/useRecentContent.ts
@@ -1,0 +1,25 @@
+import type { ApiError, RecentContentEntry } from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+import useApp from '../providers/App/useApp';
+import { recentContentQueryKey } from './useRecordContentView';
+
+export function useRecentContent(
+    projectUuid: string | undefined,
+    enabled = true,
+) {
+    const { user } = useApp();
+    const userUuid = user.data?.userUuid;
+    return useQuery<RecentContentEntry[], ApiError>({
+        queryKey: recentContentQueryKey(userUuid, projectUuid),
+        queryFn: () =>
+            lightdashApi<RecentContentEntry[]>({
+                version: 'v2',
+                url: `/content/recently-viewed?${new URLSearchParams({ projectUuid: projectUuid! })}`,
+                method: 'GET',
+                body: undefined,
+            }),
+        enabled: enabled && !!userUuid && !!projectUuid,
+        staleTime: 30_000,
+    });
+}

--- a/packages/frontend/src/hooks/useRecordContentView.ts
+++ b/packages/frontend/src/hooks/useRecordContentView.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { lightdashApi } from '../api';
 import useApp from '../providers/App/useApp';
 
-const recentContentQueryKey = (
+export const recentContentQueryKey = (
     userUuid: string | undefined,
     projectUuid: string | undefined,
 ) => ['recent_content', userUuid, projectUuid];


### PR DESCRIPTION
Recently viewed now reads at most 50 live rows per user/project from the OSS table in #28944. The OSS endpoint applies current content permissions before returning up to ten items, with metadata already loaded during authorization. The existing homepage route preserves its response shape and four-item layout.

Removes the historical analytics aggregation and tile timing heuristic. Existing analytics tables and writers remain unchanged. No backfill or fallback to the old query. Deploy #28944 first if warm-up is desired; installations skipping it begin with empty history.

Validation: 91 focused backend tests, backend/frontend typechecks, API generation, browser checks for direct chart/dashboard opens, and a reproducible PostgreSQL benchmark. The final two-index schema with 500k rows / 10k user-project pairs used 94.3 MiB on local Docker PostgreSQL (Apple M4 Pro). Repeat measurements: candidate read p95 1.79 ms, capped write p95 19.62 ms. A run alongside development builds had write p95 86.97 ms, so these are variable local measurements, not production SLAs or sustained-load results. Separately, 30 full endpoint requests with one recent item on the seeded project measured p95 92.3 ms. Reproduce the database measurements with `packages/backend/src/scripts/benchmark-recent-content.ts`, which also reports the query plan.

Stack: #28944 → this PR → #28947. Merge and retarget in that order.

