### PR TITLE
feat(omnibar): surface recently viewed charts and dashboards

### DIFF
--- a/packages/frontend/src/features/omnibar/components/Omnibar.tsx
+++ b/packages/frontend/src/features/omnibar/components/Omnibar.tsx
@@ -43,6 +43,7 @@ import { AiAgentIcon } from '../../../ee/features/aiCopilot/components/AiAgentIc
 import { useAiAgentButtonVisibility } from '../../../ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility';
 import { useProject } from '../../../hooks/useProject';
 import { useOptionalProjectRoute } from '../../../hooks/useProjectRoute';
+import { useRecentContent } from '../../../hooks/useRecentContent';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import { useValidationUserAbility } from '../../../hooks/validation/useValidation';
 import useApp from '../../../providers/App/useApp';
@@ -56,6 +57,7 @@ import {
     type OmnibarGroup,
     type SearchItem,
 } from '../types/searchItem';
+import { getRecentContentSearchItems } from '../utils/getRecentContentSearchItems';
 import { getSearchItemLabel } from '../utils/getSearchItemLabel';
 import classes from './Omnibar.module.css';
 import OmnibarEmptyState from './OmnibarEmptyState';
@@ -81,6 +83,17 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     const canUserManageValidation = useValidationUserAbility(projectUuid);
     const [searchFilters, setSearchFilters] = useState<SearchFilters>();
     const [query, setQuery] = useState<string>();
+    const hasEnteredQuery = query !== undefined && query !== '';
+    const hasEnteredMinQueryLength =
+        hasEnteredQuery && hasMinQueryLength(query);
+    const hasActiveFilters = Boolean(
+        searchFilters?.type ||
+        searchFilters?.verifiedOnly ||
+        searchFilters?.fromDate ||
+        searchFilters?.toDate ||
+        searchFilters?.createdByUuid,
+    );
+
     const [debouncedValue] = useDebouncedValue(query, 300);
     const { targetRef: scrollRef } = useScrollIntoView<HTMLDivElement>(); // couldn't get scroll to work with mantine's function
 
@@ -102,6 +115,20 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
 
     const [isOmnibarOpen, { open: openOmnibar, close: closeOmnibar }] =
         useDisclosure(false);
+
+    const { data: recentContent, isInitialLoading: isLoadingRecentContent } =
+        useRecentContent(
+            projectUuid,
+            isOmnibarOpen && !hasEnteredQuery && !hasActiveFilters,
+        );
+    const recentItems = useMemo(
+        () =>
+            getRecentContentSearchItems(
+                recentContent ?? [],
+                projectUrlIdentifier,
+            ),
+        [recentContent, projectUrlIdentifier],
+    );
 
     const { data: spaceSummaries } = useSpaceSummaries(projectUuid, true, {
         enabled: isOmnibarOpen,
@@ -190,7 +217,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
             name: EventName.SEARCH_RESULT_CLICKED,
             properties: {
                 type: item.type,
-                id: getSearchResultId(item.item),
+                id: item.recentContent?.uuid ?? getSearchResultId(item.item),
                 verifiedOnly: searchFilters?.verifiedOnly === true,
             },
         });
@@ -225,17 +252,6 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
         }
         setQuery(undefined);
     };
-
-    const hasEnteredQuery = query !== undefined && query !== '';
-    const hasEnteredMinQueryLength =
-        hasEnteredQuery && hasMinQueryLength(query);
-    const hasActiveFilters = Boolean(
-        searchFilters?.type ||
-        searchFilters?.verifiedOnly ||
-        searchFilters?.fromDate ||
-        searchFilters?.toDate ||
-        searchFilters?.createdByUuid,
-    );
 
     const searchGroups = useMemo<OmnibarGroup[]>(() => {
         const contentGroups = searchResults
@@ -283,10 +299,21 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     };
 
     const displayGroups = useMemo<OmnibarGroup[]>(() => {
-        const groups =
-            !hasEnteredQuery || !hasEnteredMinQueryLength || !searchResults
-                ? []
-                : searchGroups;
+        const groups: OmnibarGroup[] = !hasEnteredQuery
+            ? !hasActiveFilters && recentItems.length > 0
+                ? [
+                      {
+                          key: 'recently-viewed',
+                          label: 'Recently viewed',
+                          items: recentItems,
+                          totalCount: recentItems.length,
+                          collapsed: false,
+                      },
+                  ]
+                : []
+            : !hasEnteredMinQueryLength || !searchResults
+              ? []
+              : searchGroups;
 
         return groups.map((group) =>
             collapsedGroupKeys.includes(group.key)
@@ -296,6 +323,8 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
     }, [
         hasEnteredQuery,
         hasEnteredMinQueryLength,
+        hasActiveFilters,
+        recentItems,
         searchResults,
         searchGroups,
         collapsedGroupKeys,
@@ -385,7 +414,7 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
                             wrap="nowrap"
                             className={classes.inputRow}
                         >
-                            {isFetching ? (
+                            {isFetching || isLoadingRecentContent ? (
                                 <Loader size="xs" color="ldGray.5" />
                             ) : (
                                 <MantineIcon
@@ -429,7 +458,14 @@ const Omnibar: FC<Props> = ({ projectUuid }) => {
 
                         <Box className={classes.resultsArea}>
                             {displayGroups.length === 0 ? (
-                                !hasEnteredQuery && hasActiveFilters ? (
+                                !hasEnteredQuery &&
+                                !hasActiveFilters &&
+                                isLoadingRecentContent ? (
+                                    <OmnibarEmptyState
+                                        variant="loading"
+                                        title="Loading recently viewed..."
+                                    />
+                                ) : !hasEnteredQuery && hasActiveFilters ? (
                                     <OmnibarEmptyState
                                         title="Search with these filters"
                                         hint="Start typing to apply them."

--- a/packages/frontend/src/features/omnibar/components/OmnibarPreview.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarPreview.tsx
@@ -50,17 +50,20 @@ const OmnibarPreview: FC<Props> = ({ item, spaceName }) => {
     const hasError = itemHasValidationError(item);
     const hasVerification = itemHasVerification(item);
 
+    const displaySpaceName = spaceName ?? item.recentContent?.space.name;
     const viewsCount =
-        item.item && 'viewsCount' in item.item
+        item.recentContent?.views ??
+        (item.item && 'viewsCount' in item.item
             ? item.item.viewsCount
-            : undefined;
-    const createdBy =
-        item.item && 'createdBy' in item.item && item.item.createdBy
-            ? `${item.item.createdBy.firstName} ${item.item.createdBy.lastName}`
-            : undefined;
-
+            : undefined);
+    const author =
+        item.recentContent?.createdBy ??
+        (item.item && 'createdBy' in item.item ? item.item.createdBy : null);
+    const createdBy = author
+        ? `${author.firstName} ${author.lastName}`
+        : undefined;
     const hasFacts =
-        spaceName !== undefined ||
+        displaySpaceName !== undefined ||
         viewsCount !== undefined ||
         createdBy !== undefined;
 
@@ -86,8 +89,8 @@ const OmnibarPreview: FC<Props> = ({ item, spaceName }) => {
 
             {hasFacts && (
                 <Stack gap={6} mt="md" className={classes.facts}>
-                    {spaceName !== undefined && (
-                        <Fact label="Space">{spaceName}</Fact>
+                    {displaySpaceName !== undefined && (
+                        <Fact label="Space">{displaySpaceName}</Fact>
                     )}
                     {viewsCount !== undefined && (
                         <Fact label="Views">{viewsCount}</Fact>

--- a/packages/frontend/src/features/omnibar/components/utils.ts
+++ b/packages/frontend/src/features/omnibar/components/utils.ts
@@ -95,10 +95,11 @@ export const itemHasValidationError = (searchItem: SearchItem) =>
     searchItem.item.validationErrors?.length > 0;
 
 export const itemHasVerification = (searchItem: SearchItem) =>
-    searchItem.item &&
-    'verification' in searchItem.item &&
-    searchItem.item.verification !== null &&
-    searchItem.item.verification !== undefined;
+    Boolean(searchItem.recentContent?.verification) ||
+    (searchItem.item &&
+        'verification' in searchItem.item &&
+        searchItem.item.verification !== null &&
+        searchItem.item.verification !== undefined);
 
 export const getSearchResultsGroupsSorted = (results: SearchResultMap) =>
     Object.entries(results)

--- a/packages/frontend/src/features/omnibar/types/searchItem.ts
+++ b/packages/frontend/src/features/omnibar/types/searchItem.ts
@@ -1,4 +1,8 @@
-import { SearchItemType, type SearchResult } from '@lightdash/common';
+import {
+    SearchItemType,
+    type RecentContentEntry,
+    type SearchResult,
+} from '@lightdash/common';
 import { type Icon as TablerIcon } from '@tabler/icons-react';
 
 // Display order for the omnibar's "Item type" filter dropdown.
@@ -27,6 +31,7 @@ export type SearchItem = {
     description?: string;
     location: { pathname: string; search?: string };
     item?: SearchResult;
+    recentContent?: RecentContentEntry['content'];
     searchRank?: number;
     slug?: string;
 };

--- a/packages/frontend/src/features/omnibar/utils/getRecentContentSearchItems.test.ts
+++ b/packages/frontend/src/features/omnibar/utils/getRecentContentSearchItems.test.ts
@@ -1,0 +1,79 @@
+import {
+    ContentType,
+    SearchItemType,
+    type ChartContent,
+    type DashboardContent,
+    type RecentContentEntry,
+} from '@lightdash/common';
+import { getRecentContentSearchItems } from './getRecentContentSearchItems';
+
+describe('recently viewed omnibar items', () => {
+    const dashboard = {
+        contentType: ContentType.DASHBOARD,
+        uuid: 'dashboard-uuid',
+        slug: 'sales-dashboard',
+        name: 'Sales dashboard',
+        description: 'Sales overview',
+        space: { name: 'Sales' },
+        views: 12,
+        verification: null,
+    } as DashboardContent;
+    const chart = {
+        contentType: ContentType.CHART,
+        uuid: 'chart-uuid',
+        slug: 'monthly-sales',
+        name: 'Monthly sales',
+        description: null,
+        space: { name: 'Sales' },
+        views: 3,
+        verification: null,
+    } as ChartContent;
+    const entries: RecentContentEntry[] = [
+        {
+            contentType: 'dashboard',
+            uuid: dashboard.uuid,
+            viewedAt: new Date(),
+            content: dashboard,
+        },
+        {
+            contentType: 'chart',
+            uuid: chart.uuid,
+            viewedAt: new Date(),
+            content: chart,
+        },
+    ];
+
+    it('keeps recency order across content types and navigates using project/content slugs', () => {
+        const items = getRecentContentSearchItems(entries, 'jaffle-shop');
+        expect(
+            items.map((item) => [
+                item.type,
+                item.title,
+                item.location.pathname,
+            ]),
+        ).toEqual([
+            [
+                SearchItemType.DASHBOARD,
+                'Sales dashboard',
+                '/projects/jaffle-shop/dashboards/sales-dashboard/view',
+            ],
+            [
+                SearchItemType.CHART,
+                'Monthly sales',
+                '/projects/jaffle-shop/saved/monthly-sales/view',
+            ],
+        ]);
+    });
+
+    it('retains authorized metadata for previews without fabricating search results', () => {
+        const items = getRecentContentSearchItems(entries, 'project-uuid');
+        expect(items[0].recentContent).toBe(dashboard);
+        expect(items[1].contextLabel).toBe('Sales');
+        expect(items[1].description).toBeUndefined();
+        expect(items[1].item).toBeUndefined();
+    });
+
+    it('handles an empty history', () => {
+        expect(getRecentContentSearchItems([], 'project-uuid')).toEqual([]);
+    });
+});

--- a/packages/frontend/src/features/omnibar/utils/getRecentContentSearchItems.ts
+++ b/packages/frontend/src/features/omnibar/utils/getRecentContentSearchItems.ts
@@ -1,0 +1,29 @@
+import {
+    ContentType,
+    SearchItemType,
+    type RecentContentEntry,
+} from '@lightdash/common';
+import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
+import type { SearchItem } from '../types/searchItem';
+
+export const getRecentContentSearchItems = (
+    entries: RecentContentEntry[],
+    projectUrlIdentifier: string,
+): SearchItem[] =>
+    entries.map(({ content }) => ({
+        type:
+            content.contentType === ContentType.CHART
+                ? SearchItemType.CHART
+                : SearchItemType.DASHBOARD,
+        title: content.name,
+        description: content.description ?? undefined,
+        contextLabel: content.space.name,
+        recentContent: content,
+        icon:
+            content.contentType === ContentType.CHART
+                ? getChartIcon(content.chartKind)
+                : undefined,
+        location: {
+            pathname: `/projects/${projectUrlIdentifier}/${content.contentType === ContentType.CHART ? 'saved' : 'dashboards'}/${content.slug}/view`,
+        },
+    }));


### PR DESCRIPTION
Opening global search with an empty query and no filters now shows up to ten recently viewed charts and dashboards from the OSS endpoint in #28946. Typing or applying filters keeps the existing search behavior; clearing the query returns to recents. Existing keyboard navigation, canonical links, and previews work for recent items.

Fetches only while the omnibar is open in the recent-content state. Reuses metadata already authorized by the backend and adds no preview/view tracking.

Validation: 21 focused frontend tests, frontend typecheck and lint (one unrelated existing warning). Browser checked empty-query recents, arrow-key selection and Enter navigation, typed search, clearing, filters, and direct dashboard opens without adding its tile charts to recency. Screenshots were captured from the running development app.

Stack: #28944 → #28946 → this PR. Merge and retarget in that order.
