### PR TITLE
ci: mint automation tokens from the lightdash-cloud-ops app

### DIFF
--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -60,15 +60,24 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Create Cloud operations token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.CLOUD_OPS_APP_ID }}
+          private-key: ${{ secrets.CLOUD_OPS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: lightdash
+
       - name: Preflight - token can administer rulesets
         env:
-          GH_TOKEN: ${{ secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::error::No token available. Add a MERGE_FREEZE_TOKEN secret - a fine-grained PAT or App installation token on $REPO with Administration: write (rulesets), Variables: write and Commit statuses: write."
+            echo "::error::No App token available. Check CLOUD_OPS_APP_ID, CLOUD_OPS_APP_PRIVATE_KEY and the App installation on $REPO."
             exit 1
           fi
 
@@ -76,14 +85,14 @@ jobs:
           # doubles as the permission check. Failing here costs seconds; failing
           # after a half-applied freeze costs a confusing repo.
           if ! gh api "repos/$REPO/rulesets" >/dev/null 2>&1; then
-            echo "::error::The configured token cannot read repository rulesets on $REPO. It needs Administration: write (fine-grained) or repo admin (classic). GITHUB_TOKEN can never do this - 'administration' is not a grantable workflow permission scope."
+            echo "::error::The configured token cannot read repository rulesets on $REPO. The App needs Administration: write. GITHUB_TOKEN can never do this - 'administration' is not a grantable workflow permission scope."
             exit 1
           fi
 
       - name: ${{ inputs.action }} merges to main
         id: toggle
         env:
-          GH_TOKEN: ${{ secrets.MERGE_FREEZE_TOKEN || secrets.CI_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           ACTION: ${{ inputs.action }}
           ACTOR_LOGIN: ${{ github.actor }}

--- a/.github/workflows/merge-freeze.yml
+++ b/.github/workflows/merge-freeze.yml
@@ -19,7 +19,8 @@ name: Merge freeze
 # The ruleset and variables APIs need Administration: write, which GITHUB_TOKEN
 # cannot be granted (`administration` is not a workflow permission scope), so
 # this runs on a PAT/App token - see the preflight step. workflow_dispatch
-# already requires write access, so whoever can run this can already merge.
+# already requires write access, so whoever can run this can already merge;
+# dispatches from other refs are refused.
 #
 # SPK-985.
 
@@ -53,6 +54,7 @@ env:
 jobs:
   toggle:
     name: ${{ inputs.action }}
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/merge-freeze-workflow.test.py
+++ b/scripts/merge-freeze-workflow.test.py
@@ -627,6 +627,7 @@ class MergeFreezeTests(unittest.TestCase):
         inputs = workflow.split('    inputs:\n', 1)[1].split('\npermissions:', 1)[0]
         self.assertEqual(re.findall(r'^      (\w+):', inputs, re.M), ['action', 'slack_actor'])
         self.assertIn('group: merge-freeze-${{ github.repository }}\n  cancel-in-progress: false', workflow)
+        self.assertIn("if: github.ref == 'refs/heads/main'", workflow)
         self.assertIn("if: steps.toggle.outputs.changed == 'true'", workflow)
         self.assertIn('SLACK_ACTOR: ${{ inputs.slack_actor }}', workflow)
         self.assertNotIn('vars.MERGE_FREEZE_ACTOR', workflow)


### PR DESCRIPTION
Merge freezes use a personal token today. Engineers see changes to merge rules attributed to a person. Token rotation can stop the workflow.

Mint a GitHub App installation token for the merge freeze job. Scope the token to lightdash. Read CLOUD_OPS_APP_ID and CLOUD_OPS_APP_PRIVATE_KEY from the repository configuration. Keep the empty workflow permissions and the current dispatcher identity.

Validation: all 54 merge freeze workflow tests pass. Formatting passes. Actionlint passes with its unsupported concurrency.queue field excluded. The tests use fake GitHub and Slack services. No live freeze or upgrade workflow ran.

Cutover order:
1. An organization owner approves the App installation on lightdash and lightdash-cloud. This approval is pending.
2. Merge the lightdash change.
3. Merge the lightdash-cloud change, which includes the SPK-2011 integration: https://github.com/lightdash/lightdash-cloud/pull/3806.
4. Confirm a lightdash-cloud merge freeze and an auto-upgrade PR run as the App.
5. Revoke the personal tokens and delete MERGE_FREEZE_TOKEN, UPGRADE_AUTOMATION_TOKEN and PERSONAL_ACCESS_TOKEN where set.

Keep MERGE_FREEZE_SLACK_DISPATCHER unchanged until Cloudy uses App installation authentication. Keep CI_GITHUB_TOKEN unchanged.

Refs SPK-2015
