### PR TITLE
feat(bitbucket): compile native Lightdash YAML projects

### DIFF
--- a/packages/backend/src/dbt/gitCredentials.test.ts
+++ b/packages/backend/src/dbt/gitCredentials.test.ts
@@ -50,6 +50,6 @@ describe('createGithubGitCredentialFiles', () => {
                 host: 'github.example.com/attacker',
                 token: 'ghs_test-token',
             }),
-        ).toThrow('GitHub host domain must not include a path');
+        ).toThrow('Git host domain must not include a path');
     });
 });

--- a/packages/backend/src/dbt/gitCredentials.ts
+++ b/packages/backend/src/dbt/gitCredentials.ts
@@ -10,25 +10,27 @@ export type GitCredentialFiles = {
     configPath: string;
 };
 
-export const createGithubGitCredentialFiles = ({
+export const createGitCredentialFiles = ({
     host,
     token,
+    username,
 }: {
     host: string;
     token: string;
+    username: string;
 }): GitCredentialFiles => {
     const origin = new URL(`https://${host}`);
     if (origin.pathname !== '/' || origin.search || origin.hash) {
-        throw new Error('GitHub host domain must not include a path');
+        throw new Error('Git host domain must not include a path');
     }
 
     const directory = fs.mkdtempSync(
-        path.join(os.tmpdir(), 'github_credentials_'),
+        path.join(os.tmpdir(), 'git_credentials_'),
     );
     const credentialsPath = path.join(directory, 'credentials');
     const configPath = path.join(directory, 'gitconfig');
     const credentialUrl = new URL(origin);
-    credentialUrl.username = 'lightdash';
+    credentialUrl.username = username;
     credentialUrl.password = token;
 
     fs.writeFileSync(credentialsPath, `${credentialUrl.href}\n`, {
@@ -43,7 +45,7 @@ export const createGithubGitCredentialFiles = ({
             `    helper = ${quoteGitConfigValue(
                 `store --file=${credentialsPath}`,
             )}`,
-            '    username = lightdash',
+            `    username = ${quoteGitConfigValue(username)}`,
             `[url ${quoteGitConfigValue(`${origin.origin}/`)}]`,
             `    insteadOf = ${quoteGitConfigValue(`git@${origin.host}:`)}`,
             `    insteadOf = ${quoteGitConfigValue(
@@ -56,3 +58,9 @@ export const createGithubGitCredentialFiles = ({
 
     return { directory, configPath };
 };
+
+export const createGithubGitCredentialFiles = (args: {
+    host: string;
+    token: string;
+}): GitCredentialFiles =>
+    createGitCredentialFiles({ ...args, username: 'lightdash' });

--- a/packages/backend/src/projectAdapters/nativeGitProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/nativeGitProjectAdapter.ts
@@ -1,5 +1,6 @@
 import {
     compileLightdashModels,
+    DbtProjectType,
     DEFAULT_SPOTLIGHT_CONFIG,
     isExploreError,
     loadLightdashProjectConfig,
@@ -19,15 +20,19 @@ import os from 'os';
 import path from 'path';
 import simpleGit from 'simple-git';
 import {
-    createGithubGitCredentialFiles,
+    createGitCredentialFiles,
     type GitCredentialFiles,
 } from '../dbt/gitCredentials';
 import { preAggregatePostProcessor } from '../ee/preAggregates/postProcessor';
 import { type ProjectAdapter, type TrackingParams } from '../types';
-import { DEFAULT_GITHUB_HOST_DOMAIN } from '../utils/credentialDestination';
+import {
+    DEFAULT_BITBUCKET_HOST_DOMAIN,
+    DEFAULT_GITHUB_HOST_DOMAIN,
+    normalizeCredentialHost,
+} from '../utils/credentialDestination';
 import { GitRepository } from './gitRepository';
 
-export class NativeGithubProjectAdapter implements ProjectAdapter {
+export class NativeGitProjectAdapter implements ProjectAdapter {
     readonly dbtProjectDir: string;
 
     private readonly localRepositoryDir: string;
@@ -45,6 +50,8 @@ export class NativeGithubProjectAdapter implements ProjectAdapter {
         branch,
         projectSubPath,
         hostDomain,
+        provider,
+        username,
     }: {
         warehouseClient: WarehouseClient;
         token: string;
@@ -52,17 +59,41 @@ export class NativeGithubProjectAdapter implements ProjectAdapter {
         branch: string;
         projectSubPath: string;
         hostDomain?: string;
+        provider: DbtProjectType.GITHUB | DbtProjectType.BITBUCKET;
+        username?: string;
     }) {
-        const [valid, error] = validateGithubToken(token);
-        if (!valid) throw new ParameterError(error);
+        if (provider === DbtProjectType.GITHUB) {
+            const [valid, error] = validateGithubToken(token);
+            if (!valid) {
+                throw new ParameterError(error);
+            }
+        } else if (
+            normalizeCredentialHost(
+                hostDomain || DEFAULT_BITBUCKET_HOST_DOMAIN,
+            ) !== DEFAULT_BITBUCKET_HOST_DOMAIN
+        ) {
+            throw new ParameterError(
+                'Native Bitbucket projects require Bitbucket Cloud',
+            );
+        }
         const subPath = projectSubPath.replace(/^\/+/, '');
         if (subPath.split('/').includes('..') || subPath.includes('\\')) {
             throw new ParameterError(
                 'Project subdirectory must stay within the Git repository',
             );
         }
-        const host = hostDomain || DEFAULT_GITHUB_HOST_DOMAIN;
-        this.credentials = createGithubGitCredentialFiles({ host, token });
+        const host =
+            provider === DbtProjectType.BITBUCKET
+                ? DEFAULT_BITBUCKET_HOST_DOMAIN
+                : hostDomain || DEFAULT_GITHUB_HOST_DOMAIN;
+        this.credentials = createGitCredentialFiles({
+            host,
+            token,
+            username:
+                provider === DbtProjectType.BITBUCKET
+                    ? username || 'x-bitbucket-api-token-auth'
+                    : 'lightdash',
+        });
         this.localRepositoryDir = fs.mkdtempSync(
             path.join(os.tmpdir(), 'native_git_'),
         );

--- a/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.test.ts
+++ b/packages/backend/src/projectAdapters/nativeGithubProjectAdapter.test.ts
@@ -3,6 +3,7 @@ import {
     SupportedDbtVersions,
     WarehouseTypes,
     type DbtGithubProjectConfig,
+    type DbtProjectConfig,
 } from '@lightdash/common';
 import fs from 'fs/promises';
 import path from 'path';
@@ -10,8 +11,9 @@ import simpleGit from 'simple-git';
 import { getInstallationToken } from '../clients/github/Github';
 import { DbtCliClient } from '../dbt/dbtCliClient';
 import { warehouseClientMock } from '../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { DbtBitBucketProjectAdapter } from './dbtBitBucketProjectAdapter';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
-import { NativeGithubProjectAdapter } from './nativeGithubProjectAdapter';
+import { NativeGitProjectAdapter } from './nativeGitProjectAdapter';
 import { projectAdapterFromConfig } from './projectAdapter';
 
 vi.mock('simple-git');
@@ -44,7 +46,7 @@ describe('native GitHub server compilation', () => {
         branch: 'preview/change',
         project_sub_path: 'analytics',
     };
-    const createAdapter = (config = connection) =>
+    const createAdapter = (config: DbtProjectConfig = connection) =>
         projectAdapterFromConfig(
             config,
             {
@@ -87,7 +89,7 @@ describe('native GitHub server compilation', () => {
         const catalog = vi.spyOn(warehouseClientMock, 'getCatalog');
         const adapter = await createAdapter();
         adapters.push(adapter);
-        expect(adapter).toBeInstanceOf(NativeGithubProjectAdapter);
+        expect(adapter).toBeInstanceOf(NativeGitProjectAdapter);
         const explores = await adapter.compileAllExplores(undefined, true);
         expect(getInstallationToken).toHaveBeenCalledWith('123');
         expect(clone).toHaveBeenCalledWith(
@@ -111,7 +113,7 @@ describe('native GitHub server compilation', () => {
         ]);
         expect(env).toHaveBeenCalledWith(
             'GIT_CONFIG_GLOBAL',
-            expect.stringContaining('github_credentials_'),
+            expect.stringContaining('git_credentials_'),
         );
         catalog.mockRestore();
     });
@@ -150,5 +152,70 @@ describe('native GitHub server compilation', () => {
             createAdapter({ ...connection, project_sub_path: '../outside' }),
         ).rejects.toThrow('within the Git repository');
         expect(clone).not.toHaveBeenCalled();
+    });
+    const bitbucketConnection = {
+        type: DbtProjectType.BITBUCKET as const,
+        semanticLayer: 'lightdash' as const,
+        username: 'demo-user',
+        personal_access_token: 'test-bitbucket-token',
+        repository: 'org/native',
+        branch: 'main',
+        project_sub_path: 'analytics',
+    };
+
+    it('compiles and refreshes native Bitbucket files without dbt, preserving nested filenames', async () => {
+        const adapter = await createAdapter(bitbucketConnection);
+        adapters.push(adapter);
+        const explores = await adapter.compileAllExplores(undefined);
+        expect(adapter).toBeInstanceOf(NativeGitProjectAdapter);
+        expect(clone).toHaveBeenCalledWith(
+            'https://bitbucket.org/org/native.git',
+            expect.any(String),
+            expect.objectContaining({ '--branch': 'main' }),
+        );
+        expect(explores[0]?.tables?.orders.ymlPath).toBe(
+            'models/nested/sales.yaml',
+        );
+        expect(DbtCliClient).not.toHaveBeenCalled();
+        pull.mockResolvedValue({});
+        await fs.writeFile(
+            path.join(adapter.dbtProjectDir!, 'models/nested/sales.yaml'),
+            modelYaml.replace('sql: id', 'sql: order_id'),
+        );
+        const refreshed = await adapter.compileAllExplores(undefined);
+        expect(refreshed[0]?.tables?.orders.dimensions.id.sql).toBe('order_id');
+    });
+
+    it('rejects native Bitbucket Server before cloning', async () => {
+        await expect(
+            createAdapter({
+                ...bitbucketConnection,
+                host_domain: 'bitbucket.example.com',
+            }),
+        ).rejects.toThrow('Bitbucket Cloud');
+        expect(clone).not.toHaveBeenCalled();
+    });
+
+    it('keeps existing Bitbucket connections on dbt', async () => {
+        const adapter = await createAdapter({
+            ...bitbucketConnection,
+            semanticLayer: undefined,
+        });
+        adapters.push(adapter);
+        expect(adapter).toBeInstanceOf(DbtBitBucketProjectAdapter);
+    });
+
+    it('rejects invalid native Bitbucket refreshes before exposing a stream', async () => {
+        const adapter = await createAdapter(bitbucketConnection);
+        adapters.push(adapter);
+        await adapter.compileAllExplores(undefined);
+        pull.mockResolvedValue({});
+        await fs.writeFile(
+            path.join(adapter.dbtProjectDir!, 'models/broken.yml'),
+            'type: model\nname: broken\n',
+        );
+        await expect(
+            adapter.prepareExploreStream(undefined, false, true),
+        ).rejects.toThrow('broken');
     });
 });

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -23,7 +23,7 @@ import {
     ManifestInput,
 } from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
-import { NativeGithubProjectAdapter } from './nativeGithubProjectAdapter';
+import { NativeGitProjectAdapter } from './nativeGitProjectAdapter';
 
 export const projectAdapterFromConfig = async (
     config:
@@ -112,7 +112,8 @@ export const projectAdapterFromConfig = async (
                 );
             }
             if (config.semanticLayer === 'lightdash') {
-                return new NativeGithubProjectAdapter({
+                return new NativeGitProjectAdapter({
+                    provider: DbtProjectType.GITHUB,
                     warehouseClient,
                     token: githubToken,
                     repository: config.repository,
@@ -161,6 +162,18 @@ export const projectAdapterFromConfig = async (
                 selector: config.selector,
             });
         case DbtProjectType.BITBUCKET:
+            if (config.semanticLayer === 'lightdash') {
+                return new NativeGitProjectAdapter({
+                    provider: DbtProjectType.BITBUCKET,
+                    warehouseClient,
+                    token: config.personal_access_token,
+                    username: config.username,
+                    repository: config.repository,
+                    branch: config.branch,
+                    projectSubPath: config.project_sub_path,
+                    hostDomain: config.host_domain,
+                });
+            }
             return new DbtBitBucketProjectAdapter({
                 analytics,
                 warehouseClient,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -1106,6 +1106,7 @@ export interface DbtGitlabProjectConfig extends DbtProjectCompilerBase {
 
 export interface DbtBitBucketProjectConfig extends DbtProjectCompilerBase {
     type: DbtProjectType.BITBUCKET;
+    semanticLayer?: 'dbt' | 'lightdash';
     username: string;
     personal_access_token: string;
     repository: string;

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/BitBucketForm.tsx
@@ -1,5 +1,5 @@
 import { DbtProjectType } from '@lightdash/common';
-import { TextInput, Text, Anchor, PasswordInput } from '@mantine/core';
+import { TextInput, Text, Anchor, PasswordInput, Select } from '@mantine/core';
 import React, { type FC } from 'react';
 import { useFormContext } from '../formContext';
 import DbtVersionSelect from '../Inputs/DbtVersion';
@@ -11,8 +11,43 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
     const requireSecrets: boolean =
         savedProject?.dbtConnection.type !== DbtProjectType.BITBUCKET;
     const form = useFormContext();
+    const isNative =
+        form.values.dbt.type === DbtProjectType.BITBUCKET &&
+        form.values.dbt.semanticLayer === 'lightdash';
     return (
         <>
+            <Select
+                label="Semantic layer format"
+                description="Native Lightdash YAML uses Bitbucket Cloud (bitbucket.org)."
+                name="dbt.semanticLayer"
+                value={isNative ? 'lightdash' : 'dbt'}
+                allowDeselect={false}
+                disabled={disabled}
+                data={[
+                    { value: 'dbt', label: 'dbt' },
+                    { value: 'lightdash', label: 'Native Lightdash YAML' },
+                ]}
+                onChange={(value) => {
+                    if (
+                        (value !== 'dbt' && value !== 'lightdash') ||
+                        form.values.dbt.type !== DbtProjectType.BITBUCKET
+                    ) {
+                        return;
+                    }
+                    form.setFieldValue('dbt', {
+                        ...form.values.dbt,
+                        semanticLayer: value,
+                        ...(value === 'lightdash'
+                            ? {
+                                  target: undefined,
+                                  selector: undefined,
+                                  environment: undefined,
+                                  host_domain: 'bitbucket.org',
+                              }
+                            : {}),
+                    });
+                }}
+            />
             <TextInput
                 name="dbt.username"
                 {...form.getInputProps('dbt.username')}
@@ -42,18 +77,21 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                             requires Repositories: Write and Pull requests: Read
                             and Write permissions.
                         </Text>
-                        <Text component="span" display="block" size="xs">
-                            For Bitbucket Server, use an{' '}
-                            <Anchor
-                                inherit
-                                href="https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html"
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                HTTP access token
-                            </Anchor>{' '}
-                            with Project read and Repository read permissions.
-                        </Text>
+                        {!isNative && (
+                            <Text component="span" display="block" size="xs">
+                                For Bitbucket Server, use an{' '}
+                                <Anchor
+                                    inherit
+                                    href="https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    HTTP access token
+                                </Anchor>{' '}
+                                with Project read and Repository read
+                                permissions.
+                            </Text>
+                        )}
                     </>
                 }
                 required={requireSecrets}
@@ -76,7 +114,7 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 disabled={disabled}
                 placeholder="org/project"
             />
-            <DbtVersionSelect disabled={disabled} />
+            {!isNative && <DbtVersionSelect disabled={disabled} />}
 
             <TextInput
                 name="dbt.branch"
@@ -104,57 +142,68 @@ const BitBucketForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 {...form.getInputProps('dbt.project_sub_path')}
                 label="Project directory path"
                 description={
-                    <>
-                        <p>
-                            This is the folder where your <b>dbt_project.yml</b>{' '}
-                            file is found in the Bitbucket repository you
-                            entered above.
-                        </p>
-                        <p>
-                            If your <b>dbt_project.yml</b> file is in the main
-                            folder of your repo (e.g.{' '}
-                            <b>lightdash/lightdash-analytics/dbt_project.yml</b>
-                            ), then you don't need to change anything in here.
-                            You can just leave the default value we've put in.
-                        </p>
-                        <p>
-                            If your dbt project is in a sub-folder in your repo
-                            (e.g.{' '}
-                            <b>
-                                lightdash/lightdash-analytics/dbt/dbt_project.yml
-                            </b>
-                            ), then you'll need to include the path to the
-                            sub-folder where your dbt project is (e.g.
-                            <b>/dbt</b>).
-                        </p>
-                    </>
+                    isNative ? (
+                        'Folder containing lightdash.config.yml and models/ or lightdash/models/. Use / for the repository root.'
+                    ) : (
+                        <>
+                            <p>
+                                This is the folder where your{' '}
+                                <b>dbt_project.yml</b> file is found in the
+                                Bitbucket repository you entered above.
+                            </p>
+                            <p>
+                                If your <b>dbt_project.yml</b> file is in the
+                                main folder of your repo (e.g.{' '}
+                                <b>
+                                    lightdash/lightdash-analytics/dbt_project.yml
+                                </b>
+                                ), then you don't need to change anything in
+                                here. You can just leave the default value we've
+                                put in.
+                            </p>
+                            <p>
+                                If your dbt project is in a sub-folder in your
+                                repo (e.g.{' '}
+                                <b>
+                                    lightdash/lightdash-analytics/dbt/dbt_project.yml
+                                </b>
+                                ), then you'll need to include the path to the
+                                sub-folder where your dbt project is (e.g.
+                                <b>/dbt</b>).
+                            </p>
+                        </>
+                    )
                 }
                 required
                 disabled={disabled}
                 defaultValue={bitbucketDefaultValues.project_sub_path}
             />
-            <TextInput
-                name="dbt.host_domain"
-                {...form.getInputProps('dbt.host_domain')}
-                label="Host domain (for self-hosted instances)"
-                description={
-                    <p>
-                        If you've
-                        <Anchor
-                            inherit
-                            href="https://confluence.atlassian.com/bitbucketserver/specify-the-bitbucket-base-url-776640392.html"
-                            target="_blank"
-                            rel="noreferrer"
-                        >
-                            {' '}
-                            customized the domain for your Bitbucket server{' '}
-                        </Anchor>
-                        you can add the custom domain for your project in here.
-                    </p>
-                }
-                disabled={disabled}
-                defaultValue={bitbucketDefaultValues.host_domain}
-            />
+            {!isNative && (
+                <TextInput
+                    name="dbt.host_domain"
+                    {...form.getInputProps('dbt.host_domain')}
+                    label="Host domain (for self-hosted instances)"
+                    description={
+                        <p>
+                            If you've
+                            <Anchor
+                                inherit
+                                href="https://confluence.atlassian.com/bitbucketserver/specify-the-bitbucket-base-url-776640392.html"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                {' '}
+                                customized the domain for your Bitbucket
+                                server{' '}
+                            </Anchor>
+                            you can add the custom domain for your project in
+                            here.
+                        </p>
+                    }
+                    disabled={disabled}
+                    defaultValue={bitbucketDefaultValues.host_domain}
+                />
+            )}
         </>
     );
 };

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.test.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.test.tsx
@@ -1,13 +1,12 @@
-import {
-    DbtProjectType,
-    DefaultSupportedDbtVersion,
-    WarehouseTypes,
-} from '@lightdash/common';
+import { DefaultSupportedDbtVersion, WarehouseTypes } from '@lightdash/common';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { renderWithProviders } from '../../testing/testUtils';
-import { githubDefaultValues } from './DbtForms/defaultValues';
+import {
+    githubDefaultValues,
+    bitbucketDefaultValues,
+} from './DbtForms/defaultValues';
 import DbtSettingsForm from './DbtSettingsForm';
 import { FormProvider, useForm } from './formContext';
 import { ProjectFormProvider } from './ProjectFormProvider';
@@ -31,16 +30,23 @@ const warehouse = {
 const FormHarness = ({
     disabled = false,
     isDbtSource = false,
+    bitbucket = false,
 }: {
     disabled?: boolean;
     isDbtSource?: boolean;
+    bitbucket?: boolean;
 }) => {
     const form = useForm({
         initialValues: {
             name: 'Existing native project',
             dbt: {
-                ...githubDefaultValues,
-                type: DbtProjectType.GITHUB,
+                ...(bitbucket
+                    ? {
+                          ...bitbucketDefaultValues,
+                          username: 'demo',
+                          personal_access_token: 'test',
+                      }
+                    : githubDefaultValues),
                 repository: 'org/native',
                 branch: 'staging',
                 project_sub_path: '/analytics',
@@ -68,45 +74,52 @@ const FormHarness = ({
 describe('native GitHub connection form', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('switches the build format while preserving Git and warehouse values and hiding dbt options', async () => {
-        const user = userEvent.setup();
-        renderWithProviders(<FormHarness />);
-        expect(screen.getByLabelText('Target name')).toBeInTheDocument();
-        await user.click(
-            screen.getByLabelText('Semantic layer format', {
-                selector: 'input',
-            }),
-        );
-        await user.click(
-            screen.getByRole('option', { name: 'Native Lightdash YAML' }),
-        );
-        expect(screen.queryByLabelText('Target name')).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('dbt version', { exact: false }),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.queryByText('Advanced configuration options'),
-        ).not.toBeInTheDocument();
-        expect(
-            screen.getByText(/containing lightdash.config.yml/),
-        ).toBeInTheDocument();
-        await user.click(screen.getByRole('button', { name: 'Submit' }));
-        expect(submit).toHaveBeenCalledWith(
-            expect.objectContaining({
-                warehouse,
-                dbt: expect.objectContaining({
-                    semanticLayer: 'lightdash',
-                    repository: 'org/native',
-                    branch: 'staging',
-                    project_sub_path: '/analytics',
-                    installation_id: '123',
-                    target: undefined,
-                    selector: undefined,
+    it.each([false, true])(
+        'switches the build format while preserving Git and warehouse values (Bitbucket: %s)',
+        async (bitbucket) => {
+            const user = userEvent.setup();
+            renderWithProviders(<FormHarness bitbucket={bitbucket} />);
+            expect(screen.getByLabelText('Target name')).toBeInTheDocument();
+            await user.click(
+                screen.getByLabelText('Semantic layer format', {
+                    selector: 'input',
                 }),
-            }),
-            expect.anything(),
-        );
-    });
+            );
+            await user.click(
+                screen.getByRole('option', { name: 'Native Lightdash YAML' }),
+            );
+            expect(
+                screen.queryByLabelText('Target name'),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('dbt version', { exact: false }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByText('Advanced configuration options'),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByText(/containing lightdash.config.yml/),
+            ).toBeInTheDocument();
+            await user.click(screen.getByRole('button', { name: 'Submit' }));
+            expect(submit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    warehouse,
+                    dbt: expect.objectContaining({
+                        semanticLayer: 'lightdash',
+                        repository: 'org/native',
+                        branch: 'staging',
+                        project_sub_path: '/analytics',
+                        ...(!bitbucket
+                            ? { installation_id: '123' }
+                            : { username: 'demo' }),
+                        target: undefined,
+                        selector: undefined,
+                    }),
+                }),
+                expect.anything(),
+            );
+        },
+    );
 
     it('keeps the format disabled when connection editing is forbidden', () => {
         renderWithProviders(<FormHarness disabled />);

--- a/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtSettingsForm.tsx
@@ -41,7 +41,8 @@ const DbtSettingsForm: FC<DbtSettingsFormProps> = ({
         form.values.dbt.type ?? (defaultType || DbtProjectType.GITHUB);
 
     const isNative =
-        form.values.dbt.type === DbtProjectType.GITHUB &&
+        (form.values.dbt.type === DbtProjectType.GITHUB ||
+            form.values.dbt.type === DbtProjectType.BITBUCKET) &&
         form.values.dbt.semanticLayer === 'lightdash';
 
     const warehouseType: WarehouseTypes =

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -34,7 +34,8 @@ export const ProjectForm: FC<Props> = ({
     const { savedProject } = useProjectFormContext();
     const warehouse = form.values.warehouse.type;
     const isNative =
-        form.values.dbt.type === DbtProjectType.GITHUB &&
+        (form.values.dbt.type === DbtProjectType.GITHUB ||
+            form.values.dbt.type === DbtProjectType.BITBUCKET) &&
         form.values.dbt.semanticLayer === 'lightdash';
 
     return (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-2022

## Summary

PR 1 of 2 for [native Bitbucket AI writeback](https://linear.app/lightdash/issue/SPK-2021). Bitbucket Cloud connections can select Native Lightdash YAML and compile/refresh the repository without dbt. Existing connections default to dbt.

Reuses the native GitHub compiler through a shared native Git adapter, with provider-specific credentials and a Bitbucket Cloud host restriction. The connection form hides dbt-only settings for native projects.

```text
Bitbucket connection → native Git checkout → Lightdash YAML compiler → explores
```

## Test plan

- Common/backend/frontend typechecks and lint; regenerated API schema exposes the optional format.
- 11 backend tests and 4 connection-form tests, covering native refresh, nested filenames, invalid YAML, Cloud-only enforcement, and existing dbt behavior.
- Real Bitbucket API-token clone, compilation and refresh of a native project: 8 explores; malformed YAML rejected; checkout cleaned up.
- Chrome DevTools: switch Bitbucket from dbt to native; dbt version, target, advanced dbt settings and self-hosted host input disappear.
- Real API create/test/deploy using a disposable nested native Postgres fixture on Bitbucket: persisted format/subpath, compiled source path, metric query returned 101 customers. Invalid YAML refresh failed and retained the last valid explore. Temporary branch/project removed; main unchanged.
