### PR TITLE
feat(ai): write native YAML to Bitbucket pull requests

### DIFF
--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.test.ts
@@ -1488,21 +1488,21 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
         });
     });
 
-    const bitbucketProjectModel = () => ({
+    const bitbucketProjectModel = (connection = bitbucketConnection) => ({
         get: vi.fn().mockResolvedValue({
             organizationUuid: ORG,
             name: 'Bitbucket analytics',
             dbtConnection: {
-                ...bitbucketConnection,
+                ...connection,
                 personal_access_token: undefined,
             },
-            warehouseConnection: null,
+            warehouseConnection: { type: WarehouseTypes.POSTGRES },
             dbtVersion: SupportedDbtVersions.V1_9,
         }),
         getSummary: vi.fn().mockResolvedValue({ organizationUuid: ORG }),
         getWithSensitiveFields: vi
             .fn()
-            .mockResolvedValue({ dbtConnection: bitbucketConnection }),
+            .mockResolvedValue({ dbtConnection: connection }),
     });
 
     it('clones the configured Bitbucket branch with the project token and creates no PR without changes', async () => {
@@ -1757,6 +1757,96 @@ describe('AiWritebackService.run (mocked end-to-end)', () => {
             expect(sandbox.git.clone.mock.calls[0][1]).toMatchObject({
                 branch: 'release',
             });
+        },
+    );
+
+    it.each([
+        { valid: true, existing: false },
+        { valid: true, existing: true },
+        { valid: false, existing: false },
+        { valid: false, existing: true },
+    ])(
+        'validates native Bitbucket YAML before opening or updating a PR (valid=$valid, existing=$existing)',
+        async ({ valid, existing }) => {
+            const sandbox = fakeSandbox(0, true);
+            fakeSandboxProvider.create.mockResolvedValue(sandbox);
+            const runCommand = sandbox.commands.run.getMockImplementation();
+            sandbox.commands.run.mockImplementation(
+                (command: string, options: unknown) => {
+                    if (command.includes('.ld-native-snapshot.cjs')) {
+                        return Promise.resolve({
+                            exitCode: 0,
+                            stdout: JSON.stringify({
+                                'models/nested/orders.yaml': `type: model\nname: orders\nsql_from: public.orders\ndimensions:\n  - name: amount\n    type: number\n    sql: ${valid ? '${TABLE}.amount' : '${orders.missing}'}\n`,
+                            }),
+                        });
+                    }
+                    return runCommand(command, options);
+                },
+            );
+            const prUrl =
+                'https://bitbucket.org/acme/bitbucket-analytics/pull-requests/9';
+            const adopt = vi
+                .spyOn(BitbucketProvider.prototype, 'adoptPullRequest')
+                .mockResolvedValue({
+                    prUrl,
+                    owner: 'acme',
+                    repo: 'bitbucket-analytics',
+                    pullNumber: 9,
+                    headRef: 'feature/native-edit',
+                });
+            const open = vi
+                .spyOn(BitbucketProvider.prototype, 'openPullRequest')
+                .mockResolvedValue({ prUrl, ...LANDED });
+            const update = vi
+                .spyOn(BitbucketProvider.prototype, 'updatePullRequest')
+                .mockResolvedValue(LANDED);
+            try {
+                const result = runService(sandbox, existing ? { prUrl } : {}, {
+                    projectModel: bitbucketProjectModel({
+                        ...bitbucketConnection,
+                        semanticLayer: 'lightdash',
+                        project_sub_path: '/native',
+                    }),
+                });
+                if (valid) {
+                    await expect(result).resolves.toMatchObject({
+                        prUrl,
+                        prAction: existing ? 'updated' : 'opened',
+                        repository: 'acme/bitbucket-analytics',
+                    });
+                    expect(open).toHaveBeenCalledTimes(existing ? 0 : 1);
+                    expect(update).toHaveBeenCalledTimes(existing ? 1 : 0);
+                } else {
+                    await expect(result).rejects.toThrow(/missing/);
+                    expect(open).not.toHaveBeenCalled();
+                    expect(update).not.toHaveBeenCalled();
+                    expect(sandbox.git.createBranch).not.toHaveBeenCalled();
+                    expect(sandbox.git.commit).not.toHaveBeenCalled();
+                }
+                const commands = sandbox.commands.run.mock.calls
+                    .map(([command]: [string]) => command)
+                    .join('\n');
+                expect(commands).not.toMatch(/dbt deps|profiles\.yml/);
+                expect(sandbox.files.write).not.toHaveBeenCalledWith(
+                    COMPILE_WRAPPER_PATH,
+                    expect.anything(),
+                );
+                expect(sandbox.git.clone).toHaveBeenCalledWith(
+                    'https://bitbucket.org/acme/bitbucket-analytics.git',
+                    expect.objectContaining({
+                        branch: existing
+                            ? 'feature/native-edit'
+                            : 'release/dbt',
+                    }),
+                );
+                expect(createPullRequest).not.toHaveBeenCalled();
+                expect(fakeSandboxProvider.destroy).toHaveBeenCalledTimes(1);
+            } finally {
+                adopt.mockRestore();
+                open.mockRestore();
+                update.mockRestore();
+            }
         },
     );
 
@@ -3076,33 +3166,48 @@ describe('AiWritebackService.resolveWritableRepoTarget (fail-closed authz)', () 
 });
 
 describe('AiWritebackService.dbtWritebackConfig', () => {
-    it('uses native instructions and omits shell and profile access for native projects', async () => {
-        const service = buildService();
-        vi.spyOn(service as AnyType, 'gatherRepoContext').mockResolvedValue(
-            null,
-        );
-        const prepareProfiles = vi.spyOn(service as AnyType, 'prepareProfiles');
-        const turn = turnContext();
-        const setup = await (service as AnyType)
-            .dbtWritebackConfig()
-            .buildAgentSetup({
-                sandbox: {},
-                turn: {
-                    ...turn,
-                    gitConnection: {
-                        ...turn.gitConnection,
-                        provider: PullRequestProvider.GITHUB,
-                        semanticLayer: 'lightdash',
+    it.each([PullRequestProvider.GITHUB, PullRequestProvider.BITBUCKET])(
+        'uses native instructions without shell or profiles for %s projects',
+        async (provider) => {
+            const service = buildService();
+            vi.spyOn(service as AnyType, 'gatherRepoContext').mockResolvedValue(
+                null,
+            );
+            const prepareProfiles = vi.spyOn(
+                service as AnyType,
+                'prepareProfiles',
+            );
+            const turn = turnContext();
+            const setup = await (service as AnyType)
+                .dbtWritebackConfig()
+                .buildAgentSetup({
+                    sandbox: {},
+                    turn: {
+                        ...turn,
+                        gitConnection: {
+                            ...turn.gitConnection,
+                            provider,
+                            semanticLayer: 'lightdash',
+                        },
                     },
-                },
-                repository: 'acme/analytics',
-            });
-        expect(prepareProfiles).not.toHaveBeenCalled();
-        expect(setup.systemPrompt).toContain('native Lightdash YAML');
-        expect(setup.systemPrompt).toContain('lightdash.project_context.yml');
-        expect(setup.allowedTools).not.toMatch(/Bash\(|ld-profiles/);
-        expect(setup.disallowedTools).toBe(GENERAL_DISALLOWED_TOOLS);
-    });
+                    repository: 'acme/analytics',
+                });
+            expect(prepareProfiles).not.toHaveBeenCalled();
+            expect(setup.systemPrompt).toContain('native Lightdash YAML');
+            expect(setup.systemPrompt).toContain(
+                'lightdash.project_context.yml',
+            );
+            expect(setup.allowedTools).not.toMatch(/Bash\(|ld-profiles/);
+            expect(setup.disallowedTools).toContain(GENERAL_DISALLOWED_TOOLS);
+            if (provider === PullRequestProvider.BITBUCKET) {
+                for (const tool of ['Read', 'Grep', 'Edit', 'Write']) {
+                    expect(setup.disallowedTools).toContain(
+                        `${tool}(//home/user/repo/.git/**)`,
+                    );
+                }
+            }
+        },
+    );
 
     it('returns gathered repository context through the agent setup', async () => {
         const service = buildService();

--- a/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/AiWritebackService.ts
@@ -2449,7 +2449,9 @@ export class AiWritebackService extends BaseService {
 
             if (
                 hasChanges &&
-                turn.gitConnection.provider === PullRequestProvider.GITHUB &&
+                (turn.gitConnection.provider === PullRequestProvider.GITHUB ||
+                    turn.gitConnection.provider ===
+                        PullRequestProvider.BITBUCKET) &&
                 turn.gitConnection.semanticLayer === 'lightdash'
             ) {
                 recordStep({
@@ -4300,8 +4302,10 @@ export class AiWritebackService extends BaseService {
                     turn.gitConnection.projectSubPath,
                 );
                 if (
-                    turn.gitConnection.provider ===
-                        PullRequestProvider.GITHUB &&
+                    (turn.gitConnection.provider ===
+                        PullRequestProvider.GITHUB ||
+                        turn.gitConnection.provider ===
+                            PullRequestProvider.BITBUCKET) &&
                     turn.gitConnection.semanticLayer === 'lightdash'
                 ) {
                     return {
@@ -4320,7 +4324,16 @@ export class AiWritebackService extends BaseService {
                         ),
                         repoContext,
                         allowedTools: NATIVE_ALLOWED_TOOLS,
-                        disallowedTools: GENERAL_DISALLOWED_TOOLS,
+                        disallowedTools:
+                            turn.gitConnection.provider ===
+                            PullRequestProvider.BITBUCKET
+                                ? [
+                                      GENERAL_DISALLOWED_TOOLS,
+                                      ...['Edit', 'Write'].map(
+                                          (tool) => `${tool}(/${CWD}/.git/**)`,
+                                      ),
+                                  ].join(',')
+                                : GENERAL_DISALLOWED_TOOLS,
                         addDirs: ['/tmp', SKILLS_DIR, CLAUDE_SKILLS_DIR],
                         model: CLAUDE_MODEL,
                     };
@@ -4361,7 +4374,9 @@ export class AiWritebackService extends BaseService {
                 };
             },
             beforeAgentRun: (sandbox, turn) =>
-                turn.gitConnection.provider === PullRequestProvider.GITHUB &&
+                (turn.gitConnection.provider === PullRequestProvider.GITHUB ||
+                    turn.gitConnection.provider ===
+                        PullRequestProvider.BITBUCKET) &&
                 turn.gitConnection.semanticLayer === 'lightdash'
                     ? this.prepareWarehouseSkills(sandbox, turn)
                     : this.prepareDbtAgentRun(sandbox, turn),

--- a/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.test.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.test.ts
@@ -142,6 +142,26 @@ const writeArgs = (sandbox: ReturnType<typeof sandboxFixture>) => ({
 afterEach(() => vi.restoreAllMocks());
 
 describe('Bitbucket project authentication', () => {
+    it('preserves native format and nested project paths without carrying credentials', () => {
+        const { provider } = setup();
+        const resolved = provider.resolveConnection(
+            {
+                ...config,
+                semanticLayer: 'lightdash',
+                project_sub_path: '/analytics/native/',
+            },
+            { projectUuid: 'project', projectDbtSourceUuid: null },
+        );
+        expect(resolved).toEqual({
+            ...connection,
+            semanticLayer: 'lightdash',
+            projectSubPath: 'analytics/native',
+        });
+        expect(JSON.stringify(resolved)).not.toContain(
+            config.personal_access_token,
+        );
+    });
+
     it('resolves sanitized connection identity without carrying a token', () => {
         const { provider } = setup();
         expect(
@@ -319,6 +339,29 @@ describe('Bitbucket project authentication', () => {
 });
 
 describe('Bitbucket PR lifecycle', () => {
+    it('stages only the native project directory without reading a dbt manifest', async () => {
+        vi.spyOn(BitbucketClient, 'createPullRequest').mockResolvedValue(
+            pullRequest,
+        );
+        const read = vi
+            .fn()
+            .mockRejectedValue(new Error('No dbt manifest in native projects'));
+        const sandbox = { ...sandboxFixture(), files: { read } };
+        await setup().provider.openPullRequest({
+            ...writeArgs(sandbox),
+            connection: {
+                ...connection,
+                semanticLayer: 'lightdash',
+                projectSubPath: 'analytics/native',
+            },
+        });
+        expect(sandbox.git.add).toHaveBeenCalledWith(CWD, {
+            files: ['analytics/native'],
+        });
+        expect(read).not.toHaveBeenCalled();
+        expect(sandbox.git.push).toHaveBeenCalled();
+    });
+
     it.each([
         'https://evil.test/workspace/analytics/pull-requests/42',
         'http://bitbucket.org/workspace/analytics/pull-requests/42',

--- a/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/providers/BitbucketProvider.ts
@@ -176,6 +176,7 @@ export class BitbucketProvider extends BaseService implements GitProvider {
                 dbtConnection.project_sub_path,
             ),
             branch: dbtConnection.branch,
+            semanticLayer: dbtConnection.semanticLayer,
         };
     }
 
@@ -430,11 +431,14 @@ export class BitbucketProvider extends BaseService implements GitProvider {
                 'Could not disable Bitbucket sandbox Git hooks',
             );
         }
-        const paths = await resolveDbtProjectPaths(
-            args.sandbox,
-            connection.projectSubPath,
-            this.logger,
-        );
+        const paths =
+            connection.semanticLayer === 'lightdash'
+                ? [connection.projectSubPath]
+                : await resolveDbtProjectPaths(
+                      args.sandbox,
+                      connection.projectSubPath,
+                      this.logger,
+                  );
         await stageChanges(args.sandbox, paths, this.logger);
         await assertStagedPathsAllowed(args.sandbox);
         const diffStat = await collectDiffStat(args.sandbox);

--- a/packages/backend/src/ee/services/AiWritebackService/types.ts
+++ b/packages/backend/src/ee/services/AiWritebackService/types.ts
@@ -56,6 +56,7 @@ export type GitlabConnection = {
  * service can read the shared fields while each provider narrows for its own.
  */
 export type BitbucketConnection = {
+    semanticLayer?: 'dbt' | 'lightdash';
     provider: PullRequestProvider.BITBUCKET;
     owner: string;
     repo: string;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-2023

## Summary

PR 2 of 2 for [native Bitbucket AI writeback](https://linear.app/lightdash/issue/SPK-2021), stacked on [#28953](https://github.com/lightdash/lightdash/pull/28953), the native Bitbucket connection/compiler foundation.

AI edits to standalone Lightdash YAML now create and update Bitbucket Cloud pull requests. Reuses native prompts, restricted tools and host-side compilation, skips dbt preparation, and stages the configured native project path. Bitbucket credential cleanup, Git protections and PR lifecycle remain enforced.

```text
AI native edit → native compile → commit/push → Bitbucket PR
                      └─ invalid YAML → fail before mutation
```

## Test plan

- Backend typecheck and lint; 193 service/provider tests covering create/update, invalid YAML before mutation, nested staging, authorization, credential cleanup and Git restrictions.
- Real E2B + Anthropic + Bitbucket Cloud: create PR, verify remote YAML, update the same PR, reject a follow-up after decline, create a fresh PR, and leave the branch unchanged for a no-change request.
- Both disposable PRs declined, branches removed and sandbox cleaned up; repository main remained unchanged.

The live AI test compiles with the BigQuery SQL builder; it does not query the original BigQuery dataset because local ADC requires reauthentication. Warehouse query validation uses a separate native Postgres fixture in the foundation tests.
