### PR TITLE
fix(explorer): table charts no longer read as dirty on load

### DIFF
--- a/packages/frontend/src/features/explorer/store/selectors.test.ts
+++ b/packages/frontend/src/features/explorer/store/selectors.test.ts
@@ -1,8 +1,10 @@
 import { ChartType, type SavedChart } from '@lightdash/common';
+import { buildInitialExplorerState } from './buildInitialState';
 import { explorerActions, explorerReducer } from './explorerSlice';
 import {
     selectChartSidebarStep,
     selectHasPaletteChanges,
+    selectHasUnsavedChanges,
     selectIsChartTypeAuthoring,
     selectIsDataAppVizVersionReadyForSave,
 } from './selectors';
@@ -99,5 +101,67 @@ describe('selectIsDataAppVizVersionReadyForSave', () => {
         );
 
         expect(selectIsDataAppVizVersionReadyForSave({ explorer })).toBe(false);
+    });
+});
+
+describe('selectHasUnsavedChanges — table viz normalization', () => {
+    // Saved before the subtotal/row-grouping flags existed
+    const legacyTableChart = {
+        uuid: 'chart-uuid',
+        name: 'Legacy table',
+        tableName: 'customers',
+        colorPaletteUuid: null,
+        metricQuery: {
+            exploreName: 'customers',
+            dimensions: ['customers_first_name'],
+            metrics: [],
+            filters: {},
+            sorts: [],
+            limit: 500,
+            tableCalculations: [],
+            additionalMetrics: [],
+        },
+        chartConfig: {
+            type: ChartType.TABLE,
+            config: { showTableNames: false },
+        },
+        tableConfig: { columnOrder: ['customers_first_name'] },
+        pivotConfig: undefined,
+    } as unknown as SavedChart;
+
+    // What useTableConfig materializes into validConfig on mount
+    const normalizedTableConfig = {
+        showColumnCalculation: false,
+        showRowCalculation: false,
+        showTableNames: false,
+        showResultsTotal: false,
+        showSubtotals: false,
+        showSubtotalsExpanded: false,
+        showRowGrouping: false,
+        hideRowNumbers: false,
+        metricsAsRows: false,
+        conditionalFormattings: [],
+        columns: {},
+    };
+
+    const buildExplorer = (config: Record<string, unknown>) =>
+        explorerReducer(
+            buildInitialExplorerState({ savedChart: legacyTableChart }),
+            explorerActions.setChartConfig({
+                chartConfig: { type: ChartType.TABLE, config },
+            }),
+        );
+
+    it('stays clean when the table viz backfills default-false flags', () => {
+        const explorer = buildExplorer(normalizedTableConfig);
+        expect(selectHasUnsavedChanges({ explorer })).toBe(false);
+    });
+
+    it('reads dirty when a flag is actually enabled', () => {
+        const explorer = buildExplorer({
+            ...normalizedTableConfig,
+            showSubtotals: true,
+        });
+        expect(selectHasUnsavedChanges({ explorer })).toBe(true);
     });
 });

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -11,8 +11,21 @@ import { type ConfigCacheMap } from './types';
 const DEFAULTS = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
     [ChartType.BIG_NUMBER]: () => ({ showTableNamesInLabel: false }),
+    // Must mirror useTableConfig's normalization defaults: cleanConfig merges
+    // these into both diff sides so a chart saved before a flag existed does
+    // not read as dirty once the table viz materializes the flag in the draft
     [ChartType.TABLE]: () => ({
+        showColumnCalculation: false,
+        showRowCalculation: false,
         showTableNames: false,
+        showResultsTotal: false,
+        showSubtotals: false,
+        showSubtotalsExpanded: false,
+        showRowGrouping: false,
+        hideRowNumbers: false,
+        metricsAsRows: false,
+        conditionalFormattings: [],
+        columns: {},
     }),
     [ChartType.PIE]: () => ({ showLegend: false, valueLabel: 'outside' }),
     [ChartType.FUNNEL]: () => ({}),


### PR DESCRIPTION
Relates: [GLITCH-771](https://linear.app/lightdash/issue/GLITCH-771/table-charts-read-as-dirty-on-load-usetableconfig-backfills-absent)

### Description

Any TABLE chart whose stored config predates the newer display flags (`showSubtotals`, `showSubtotalsExpanded`, `showRowGrouping`, ...) read as having unsaved changes the moment it rendered — zero edits. In the regular Explorer that meant a navigation blocker + `beforeunload` dialog; in the in-dashboard editor, a discard prompt on close.

**Mechanism:** `useTableConfig` backfills absent flags as explicit `false` and `VisualizationProvider` pushes the normalized config into the draft on mount. The unsaved-changes diff runs both sides through `cleanConfig`, which merges per-type defaults exactly for this back-compat case — but `DEFAULTS[ChartType.TABLE]` only listed `showTableNames`, so the saved side lacked the keys the draft had (`removeEmptyProperties` keeps explicit `false`, strips absent) and `deepEqual` failed on key count.

**Fix:** mirror the full set of `useTableConfig` normalization defaults in the TABLE defaults. Selector-level tests pin both directions: backfilled default-false flags stay clean; an actually-enabled flag reads dirty. The test fails without the fix.

Found while verifying #28943 — this is the second, independent false-dirty source.