### PR TITLE
feat(dashboard): breadcrumb title in the in-dashboard chart editor

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -30,6 +30,7 @@ import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
 import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
 import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
+import TruncatedText from '../common/TruncatedText';
 import Explorer from '../Explorer';
 import { useChartGalleryRightSidebar } from '../Explorer/ChartGallery/useChartGalleryRightSidebar';
 import RegistryImpactPreviewModal from '../Explorer/CustomMetricModal/RegistryImpactPreviewModal';
@@ -300,6 +301,8 @@ const DashboardChartEditorModal: FC<Props> = ({
                         c="dimmed"
                         fw={500}
                         underline="hover"
+                        truncate="end"
+                        maw={300}
                         onClick={handleClose}
                     >
                         {dashboardName}
@@ -307,9 +310,13 @@ const DashboardChartEditorModal: FC<Props> = ({
                     <Text c="dimmed" fw={500}>
                         /
                     </Text>
-                    <Text fw={600}>
-                        {editChart ? 'Edit chart' : 'New chart'}
-                    </Text>
+                    {editChart ? (
+                        <TruncatedText fw={600} fz="md" maxWidth="100%" miw={0}>
+                            {`Edit ${editChart.name}`}
+                        </TruncatedText>
+                    ) : (
+                        <Text fw={600}>New chart</Text>
+                    )}
                 </Group>
             }
             icon={IconChartBar}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -3,7 +3,7 @@ import {
     type DashboardCustomMetricAffectedChart,
     type SavedChart,
 } from '@lightdash/common';
-import { Button, Group, Text } from '@mantine/core';
+import { Anchor, Button, Group, Text } from '@mantine/core';
 import { IconAlertTriangle, IconChartBar } from '@tabler/icons-react';
 import {
     useCallback,
@@ -294,7 +294,24 @@ const DashboardChartEditorModal: FC<Props> = ({
         <MantineModal
             opened={opened}
             onClose={handleClose}
-            title={editChart ? 'Edit chart' : 'New chart'}
+            title={
+                <Group gap={6} wrap="nowrap">
+                    <Anchor
+                        c="dimmed"
+                        fw={500}
+                        underline="hover"
+                        onClick={handleClose}
+                    >
+                        {dashboardName}
+                    </Anchor>
+                    <Text c="dimmed" fw={500}>
+                        /
+                    </Text>
+                    <Text fw={600}>
+                        {editChart ? 'Edit chart' : 'New chart'}
+                    </Text>
+                </Group>
+            }
             icon={IconChartBar}
             fullScreen
             cancelLabel={false}

--- a/packages/frontend/src/components/common/MantineModal/index.tsx
+++ b/packages/frontend/src/components/common/MantineModal/index.tsx
@@ -353,6 +353,9 @@ const MantineModal: React.FC<MantineModalProps> = ({
                         <Group
                             gap="sm"
                             flex={1}
+                            // Shrinkable, so long titles truncate instead of
+                            // pushing past the close button
+                            miw={0}
                             wrap="nowrap"
                             align={subtitle ? 'center' : 'flex-start'}
                         >


### PR DESCRIPTION
Relates: [GLITCH-765](https://linear.app/lightdash/issue/GLITCH-765/in-dashboard-chart-editor-compact-layout-stacked-sheet-context)

### Description

The in-dashboard chart editor's modal title becomes a breadcrumb — **{dashboard name} / Edit chart** (or **/ New chart**) — so the dashboard context is always visible while building a chart. The dashboard segment is dimmed with hover-underline and closes the editor through the existing dirty guard; the current step stays bold.

This lands the "stacked-sheet context" goal of GLITCH-765 in its simplest form. The literal stacked-sheet approach was prototyped and dropped: a see-through strip breaks as soon as the dashboard scrolls (neither the navbar nor the dashboard header is sticky), and a modal-owned strip just duplicated what the title can carry. The breadcrumb is deterministic at any scroll position and adds no new modal chrome.

Verified live: breadcrumb renders in the standard 24px-gutter fullscreen modal, and clicking the dashboard segment closes cleanly (discard guard fires only with real edits).

The compact-layout pass (item 1 of GLITCH-765) remains open.