### PR TITLE
fix(ui): keep fullscreen modal headers below the navbar

### DIFF
--- a/packages/e2e/cypress/e2e/app/fullscreenModal.cy.ts
+++ b/packages/e2e/cypress/e2e/app/fullscreenModal.cy.ts
@@ -1,0 +1,57 @@
+import {
+    SEED_PROJECT,
+    type ApiChartSummaryListResponse,
+} from '@lightdash/common';
+
+const CHART_NAME = "What's our total revenue to date?";
+
+const openUnderlyingDataModal = (viewportHeight: number) => {
+    cy.viewport(1280, viewportHeight);
+    cy.request<ApiChartSummaryListResponse>(
+        `api/v1/projects/${SEED_PROJECT.project_uuid}/charts`,
+    ).then((chartsResponse) => {
+        expect(chartsResponse.status).to.eq(200);
+        const chart = chartsResponse.body.results.find(
+            ({ name }) => name === CHART_NAME,
+        );
+        expect(chart, `seeded chart "${CHART_NAME}"`).to.not.eq(undefined);
+
+        cy.visit(`/projects/${SEED_PROJECT.project_uuid}/saved/${chart!.uuid}`);
+    });
+
+    cy.contains('Results').click();
+    cy.findAllByText('Loading chart').should('have.length', 0);
+    cy.get('[data-testid="big-number-value"]').click();
+    cy.findByRole('menuitem', { name: 'View underlying data' }).click();
+};
+
+describe('Fullscreen modal', () => {
+    beforeEach(() => {
+        cy.login();
+    });
+
+    [720, 1234].forEach((viewportHeight) => {
+        it(`keeps underlying data below the navbar at ${viewportHeight}px`, () => {
+            openUnderlyingDataModal(viewportHeight);
+
+            cy.get('section[role="dialog"]')
+                .should('be.visible')
+                .should(($modal) => {
+                    const modalElement = $modal[0];
+                    const modal = modalElement.getBoundingClientRect();
+                    const win = modalElement.ownerDocument.defaultView!;
+                    const navbar = win.document
+                        .querySelector('#navbar-header')!
+                        .getBoundingClientRect();
+
+                    expect(modal.top).to.equal(navbar.bottom + 24);
+                    expect(modal.bottom).to.equal(win.innerHeight - 24);
+                    expect(modal.left).to.equal(24);
+                    expect(modal.right).to.equal(win.innerWidth - 24);
+                });
+
+            cy.findByRole('button', { name: 'Close' }).click();
+            cy.get('section[role="dialog"]').should('not.exist');
+        });
+    });
+});

--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -119,7 +119,12 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     // limitations (see: https://github.com/orgs/mantinedev/discussions/4803).
     // The manual `data-mantine-color-scheme="dark"` attribute helps CSS selectors match correctly.
     return (
-        <Box id="navbar-header" data-mantine-color-scheme="dark">
+        <Box
+            id="navbar-header"
+            data-mantine-color-scheme="dark"
+            data-has-visible-fixed-navbar={isFixed && !isFullscreen}
+            data-has-banner={hasBanner}
+        >
             <MantineBaseProvider
                 forceColorScheme="dark"
                 cssVariablesSelector="#navbar-header"

--- a/packages/frontend/src/components/common/MantineModal/MantineModal.module.css
+++ b/packages/frontend/src/components/common/MantineModal/MantineModal.module.css
@@ -25,6 +25,24 @@
     flex-direction: column;
 }
 
+/* Shift only Mantine's viewport inner below the fixed navbar;
+   the dialog content fills the remaining space with 24px gutters. */
+:global(body:has(#navbar-header[data-has-visible-fixed-navbar='true']))
+    .fullScreenContent.fullScreenContent:not([data-modal-content]) {
+    height: calc(100% - var(--navbar-height));
+    margin-top: var(--navbar-height);
+}
+
+:global(
+        body:has(
+            #navbar-header[data-has-visible-fixed-navbar='true'][data-has-banner='true']
+        )
+    )
+    .fullScreenContent.fullScreenContent:not([data-modal-content]) {
+    height: calc(100% - var(--navbar-height) - var(--banner-height));
+    margin-top: calc(var(--navbar-height) + var(--banner-height));
+}
+
 .fullScreenBody {
     flex: 1;
     min-height: 0;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11135/fullscreen-modal-headers-are-clipped-behind-the-navbar

### Description:

Fullscreen dialogs such as View underlying data start 24px from the viewport top, placing their header and Close button behind the fixed navbar. Reserve the visible navbar and banner height so the dialog starts 24px below them and retains 24px side and bottom gutters. Ordinary dialogs and modal stacking are unchanged.

The navbar exposes its visibility and banner state for the shared fullscreen layout. Add a Cypress regression that opens underlying data, checks the dialog bounds, and clicks Close at 720px and 1234px viewport heights.

Validation:
- Both Cypress cases pass with the fix and fail against the original CSS (top 24px instead of 74px).
- Shared modal unit tests: 5 passed, rerun after rebasing onto current main.
- Frontend and e2e lint, formatting, and commit hooks passed.
- Browser checks covered underlying-data export and closing, banner/hidden/absent navbar layouts, ordinary dialogs, and nested confirmation behavior. Before/after screenshots are attached to the linked ticket.

#### Before
<img width="1270" height="240" alt="image" src="https://github.com/user-attachments/assets/c40ca97e-d2b1-441a-928e-2f15912f28f1" />


#### After
<img width="1270" height="290" alt="image" src="https://github.com/user-attachments/assets/d805b862-92db-4fe1-95dc-2d78f0afb3f2" />

### Risk assessment:

- [ ] This is a high-risk change

Low risk: a reversible CSS layout adjustment limited to shared fullscreen dialogs, with a browser regression for header placement and closing.
