### PR TITLE
fix: wait for treemap rendering before screenshot readiness

### DIFF
--- a/packages/frontend/src/components/SimpleTreemap/index.test.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.test.tsx
@@ -1,0 +1,324 @@
+import { ChartType } from '@lightdash/common';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { createRef, type ContextType } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MantineProvider from '../../providers/MantineProvider';
+import { type EChartsReact } from '../EChartsReactWrapper';
+import VisualizationContext from '../LightdashVisualization/context';
+import { type VisualizationConfigTreemap } from '../LightdashVisualization/types';
+import SimpleTreemap from './index';
+
+const makeResultsData = (): NonNullable<TestContext['resultsData']> => ({
+    rows: [],
+    isInitialLoading: false,
+    isFetchingFirstPage: false,
+    isFetchingRows: false,
+    isFetchingAllPages: false,
+    fetchMoreRows: vi.fn(),
+    refetchRows: vi.fn(),
+    setFetchAll: vi.fn(),
+    fetchAll: false,
+    hasFetchedAllRows: false,
+    totalClientFetchTimeMs: undefined,
+    error: null,
+});
+
+const makeContext = () => {
+    const chartConfig: VisualizationConfigTreemap['chartConfig'] = {
+        validConfig: { visibleMin: 0, leafDepth: 1 },
+        isLoadingSubtotals: false,
+        subtotalsError: null,
+        groupFieldIds: ['category'],
+        groupReorder: vi.fn(),
+        sizeMetricId: 'amount',
+        selectedSizeMetric: undefined,
+        sizeMetricChange: vi.fn(),
+        colorMetricId: null,
+        selectedColorMetric: undefined,
+        colorMetricChange: vi.fn(),
+        useDynamicColors: false,
+        setStartColorThreshold: vi.fn(),
+        setEndColorThreshold: vi.fn(),
+        visibleMin: 0,
+        setVisibleMin: vi.fn(),
+        leafDepth: 1,
+        setLeafDepth: vi.fn(),
+        data: Array.from({ length: 40 }, (_, i) => ({
+            name: `Category ${i}`,
+            value: [40 - i],
+        })),
+    };
+    return {
+        minimal: true,
+        chartRef: createRef<EChartsReact>(),
+        leafletMapRef: createRef(),
+        pivotDimensions: undefined,
+        resultsData: { ...makeResultsData(), hasFetchedAllRows: true },
+        isLoading: false,
+        columnOrder: [],
+        itemsMap: {},
+        visualizationConfig: {
+            chartType: ChartType.TREEMAP,
+            chartConfig,
+            dimensions: {},
+            numericMetrics: {},
+        },
+        setStacking: vi.fn(),
+        setCartesianType: vi.fn(),
+        setChartType: vi.fn(),
+        setPivotDimensions: vi.fn(),
+        getSeriesColor: () => '#123456',
+        getGroupColor: () => '#123456',
+        colorPalette: ['#123456'],
+        chartConfig: { type: ChartType.TREEMAP, config: {} },
+        hasExplorerStore: false,
+        isTouchDevice: false,
+    } satisfies NonNullable<ContextType<typeof VisualizationContext>>;
+};
+
+type TestContext = NonNullable<ContextType<typeof VisualizationContext>>;
+
+const renderTreemap = (
+    context: TestContext,
+    onScreenshotReady: () => void,
+    onScreenshotError = vi.fn(),
+) => (
+    <MantineProvider env="test">
+        <VisualizationContext.Provider value={context}>
+            <SimpleTreemap
+                isInDashboard
+                opts={{ renderer: 'svg', width: 800, height: 600 }}
+                onScreenshotReady={onScreenshotReady}
+                onScreenshotError={onScreenshotError}
+            />
+        </VisualizationContext.Provider>
+    </MantineProvider>
+);
+
+afterEach(cleanup);
+
+describe('SimpleTreemap screenshot readiness', () => {
+    it('waits for the treemap to render and signals only once', async () => {
+        const context = makeContext();
+        const onScreenshotReady = vi.fn(() => {
+            expect(
+                context.chartRef.current
+                    ?.getEchartsInstance()
+                    .getZr()
+                    .animation.isFinished(),
+            ).toBe(true);
+            expect(
+                document.querySelectorAll('svg path').length,
+            ).toBeGreaterThan(40);
+            expect(document.querySelector('svg')?.textContent).toContain(
+                'Category 0',
+            );
+        });
+        render(renderTreemap(context, onScreenshotReady));
+
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+        await waitFor(() => expect(onScreenshotReady).toHaveBeenCalledOnce(), {
+            timeout: 3000,
+        });
+
+        act(() => context.chartRef.current?.getEchartsInstance().resize());
+        expect(onScreenshotReady).toHaveBeenCalledOnce();
+    });
+    it.each([false, true])(
+        'waits for all rows, including when initially empty (%s)',
+        async (empty) => {
+            const context = makeContext();
+            const resultsData = makeResultsData();
+            const onScreenshotReady = vi.fn();
+            const initialContext = {
+                ...context,
+                resultsData,
+                visualizationConfig: {
+                    ...context.visualizationConfig,
+                    chartConfig: {
+                        ...context.visualizationConfig.chartConfig,
+                        data: empty
+                            ? []
+                            : context.visualizationConfig.chartConfig.data,
+                    },
+                },
+            };
+            const { rerender } = render(
+                renderTreemap(initialContext, onScreenshotReady),
+            );
+            if (!empty) {
+                await waitFor(() =>
+                    expect(
+                        document.querySelector('svg')?.textContent,
+                    ).toContain('Category 0'),
+                );
+                const finished = vi.fn();
+                context.chartRef.current
+                    ?.getEchartsInstance()
+                    .on('finished', finished);
+                act(() =>
+                    context.chartRef.current
+                        ?.getEchartsInstance()
+                        .getZr()
+                        .refresh(),
+                );
+                await waitFor(() => expect(finished).toHaveBeenCalled(), {
+                    timeout: 3000,
+                });
+            }
+            expect(onScreenshotReady).not.toHaveBeenCalled();
+            expect(resultsData.setFetchAll).toHaveBeenCalledWith(true);
+
+            rerender(
+                renderTreemap(
+                    {
+                        ...initialContext,
+                        resultsData: {
+                            ...resultsData,
+                            hasFetchedAllRows: true,
+                        },
+                    },
+                    onScreenshotReady,
+                ),
+            );
+            await waitFor(
+                () => expect(onScreenshotReady).toHaveBeenCalledOnce(),
+                { timeout: 3000 },
+            );
+        },
+    );
+
+    it.each([true, false])(
+        'signals errors instead of success even with stale options (loading: %s)',
+        (isLoading) => {
+            const context = makeContext();
+            const onScreenshotReady = vi.fn();
+            const onScreenshotError = vi.fn();
+            const { rerender } = render(
+                renderTreemap(
+                    {
+                        ...context,
+                        isLoading: true,
+                        resultsData: makeResultsData(),
+                    },
+                    onScreenshotReady,
+                    onScreenshotError,
+                ),
+            );
+            expect(onScreenshotReady).not.toHaveBeenCalled();
+
+            const erroredContext = {
+                ...context,
+                isLoading,
+                resultsData: {
+                    ...makeResultsData(),
+                    hasFetchedAllRows: true,
+                    error: {
+                        status: 'error' as const,
+                        error: {
+                            name: 'Error',
+                            message: 'Query failed',
+                            statusCode: 500,
+                            data: {},
+                        },
+                    },
+                },
+            };
+            rerender(
+                renderTreemap(
+                    erroredContext,
+                    onScreenshotReady,
+                    onScreenshotError,
+                ),
+            );
+            expect(onScreenshotError).toHaveBeenCalledOnce();
+            expect(onScreenshotReady).not.toHaveBeenCalled();
+            rerender(
+                renderTreemap(
+                    { ...erroredContext, isLoading: false },
+                    onScreenshotReady,
+                    onScreenshotError,
+                ),
+            );
+            expect(onScreenshotError).toHaveBeenCalledOnce();
+        },
+    );
+    it.each(['initialization', 'subtotals'])(
+        'waits for %s before reporting a complete chart',
+        async (pending) => {
+            const context = makeContext();
+            const onScreenshotReady = vi.fn();
+            const { rerender } = render(
+                renderTreemap(
+                    {
+                        ...context,
+                        resultsData:
+                            pending === 'initialization'
+                                ? undefined
+                                : context.resultsData,
+                        visualizationConfig: {
+                            ...context.visualizationConfig,
+                            chartConfig: {
+                                ...context.visualizationConfig.chartConfig,
+                                data:
+                                    pending === 'initialization'
+                                        ? []
+                                        : context.visualizationConfig
+                                              .chartConfig.data,
+                                isLoadingSubtotals: pending === 'subtotals',
+                            },
+                        },
+                    },
+                    onScreenshotReady,
+                ),
+            );
+            if (pending === 'subtotals') {
+                const finished = vi.fn();
+                context.chartRef.current
+                    ?.getEchartsInstance()
+                    .on('finished', finished);
+                await waitFor(() => expect(finished).toHaveBeenCalled(), {
+                    timeout: 3000,
+                });
+            }
+            expect(onScreenshotReady).not.toHaveBeenCalled();
+            rerender(renderTreemap(context, onScreenshotReady));
+            await waitFor(
+                () => expect(onScreenshotReady).toHaveBeenCalledOnce(),
+                { timeout: 3000 },
+            );
+        },
+    );
+
+    it('signals a subtotal error without waiting for a render', () => {
+        const context = makeContext();
+        const onScreenshotReady = vi.fn();
+        const onScreenshotError = vi.fn();
+        render(
+            renderTreemap(
+                {
+                    ...context,
+                    visualizationConfig: {
+                        ...context.visualizationConfig,
+                        chartConfig: {
+                            ...context.visualizationConfig.chartConfig,
+                            subtotalsError: {
+                                status: 'error',
+                                error: {
+                                    name: 'Error',
+                                    message: 'Subtotals failed',
+                                    statusCode: 500,
+                                    data: {},
+                                },
+                            },
+                        },
+                    },
+                },
+                onScreenshotReady,
+                onScreenshotError,
+            ),
+        );
+        expect(onScreenshotError).toHaveBeenCalledOnce();
+        expect(onScreenshotReady).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/SimpleTreemap/index.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.tsx
@@ -1,10 +1,11 @@
 import { IconChartTreemap } from '@tabler/icons-react';
 import { type EChartsReactProps, type Opts } from 'echarts-for-react/lib/types';
-import { memo, useEffect, useRef, type FC } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, type FC } from 'react';
 import useEchartsTreemapConfig from '../../hooks/echarts/useEchartsTreemapConfig';
 import LoadingChart from '../common/LoadingChart';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
 import EChartsReact from '../EChartsReactWrapper';
+import { isTreemapVisualizationConfig } from '../LightdashVisualization/types';
 import { useVisualizationContext } from '../LightdashVisualization/useVisualizationContext';
 
 const EmptyChart = () => (
@@ -28,22 +29,80 @@ type SimpleTreemapProps = Omit<EChartsReactProps, 'option'> & {
 const EchartOptions: Opts = { renderer: 'svg' };
 
 const SimpleTreemap: FC<SimpleTreemapProps> = memo(
-    ({ onScreenshotReady, onScreenshotError, ...props }) => {
-        const { chartRef, isLoading, resultsData } = useVisualizationContext();
+    ({
+        onScreenshotReady,
+        onScreenshotError,
+        onEvents,
+        onChartReady,
+        ...props
+    }) => {
+        const { chartRef, isLoading, resultsData, visualizationConfig } =
+            useVisualizationContext();
+        const treemapConfig = isTreemapVisualizationConfig(visualizationConfig)
+            ? visualizationConfig.chartConfig
+            : undefined;
+        const screenshotError =
+            resultsData?.error ?? treemapConfig?.subtotalsError;
 
         const treemapOptions = useEchartsTreemapConfig(props.isInDashboard);
 
         const hasSignaledScreenshotReady = useRef(false);
 
-        useEffect(() => {
-            if (hasSignaledScreenshotReady.current) return;
-            if (!onScreenshotReady && !onScreenshotError) return;
+        const signalScreenshotReady = useCallback(() => {
+            if (hasSignaledScreenshotReady.current || !onScreenshotReady)
+                return;
+            if (
+                isLoading ||
+                screenshotError ||
+                !resultsData?.hasFetchedAllRows ||
+                treemapConfig?.isLoadingSubtotals
+            )
+                return;
 
-            if (!isLoading) {
-                onScreenshotReady?.();
+            hasSignaledScreenshotReady.current = true;
+            onScreenshotReady();
+        }, [
+            isLoading,
+            screenshotError,
+            resultsData?.hasFetchedAllRows,
+            treemapConfig?.isLoadingSubtotals,
+            onScreenshotReady,
+        ]);
+
+        const chartEvents = useMemo(
+            () => ({
+                ...onEvents,
+                finished: (...args: unknown[]) => {
+                    signalScreenshotReady();
+                    onEvents?.finished?.(...args);
+                },
+            }),
+            [onEvents, signalScreenshotReady],
+        );
+
+        const handleChartReady = useCallback<
+            NonNullable<EChartsReactProps['onChartReady']>
+        >(
+            (instance) => {
+                onChartReady?.(instance);
+                // The initial synchronous render can finish before echarts-for-react binds events.
+                if (onScreenshotReady) instance.getZr().refresh();
+            },
+            [onChartReady, onScreenshotReady],
+        );
+
+        useEffect(() => {
+            if (!treemapOptions) signalScreenshotReady();
+        }, [treemapOptions, signalScreenshotReady]);
+
+        useEffect(() => {
+            if (hasSignaledScreenshotReady.current || !onScreenshotError)
+                return;
+            if (screenshotError) {
                 hasSignaledScreenshotReady.current = true;
+                onScreenshotError();
             }
-        }, [isLoading, treemapOptions, onScreenshotReady, onScreenshotError]);
+        }, [screenshotError, onScreenshotError]);
 
         useEffect(() => {
             resultsData?.setFetchAll(true);
@@ -56,6 +115,7 @@ const SimpleTreemap: FC<SimpleTreemapProps> = memo(
             return () => window.removeEventListener('resize', listener);
         });
 
+        if (screenshotError) return <EmptyChart />;
         if (isLoading) return <LoadingChart />;
         if (!treemapOptions) return <EmptyChart />;
 
@@ -81,6 +141,9 @@ const SimpleTreemap: FC<SimpleTreemapProps> = memo(
                     option={treemapOptions.eChartsOption}
                     notMerge
                     {...props}
+                    onEvents={chartEvents}
+                    onChartReady={handleChartReady}
+                    lazyUpdate={onScreenshotReady ? false : props.lazyUpdate}
                 />
             </>
         );

--- a/packages/frontend/src/hooks/useTreemapChartConfig.ts
+++ b/packages/frontend/src/hooks/useTreemapChartConfig.ts
@@ -1,5 +1,6 @@
 import { isField, isMetric, isTableCalculation } from '@lightdash/common';
 import type {
+    ApiError,
     CustomDimension,
     Dimension,
     ItemsMap,
@@ -16,6 +17,8 @@ import { type InfiniteQueryResults } from './useQueryResults';
 
 type TreemapChartConfig = {
     validConfig: TreemapChart;
+    isLoadingSubtotals: boolean;
+    subtotalsError: ApiError | null;
 
     groupFieldIds: (string | null)[];
     groupReorder: (args: { from: number; to: number }) => void;
@@ -212,7 +215,11 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
         [],
     );
 
-    const { data: groupedSubtotals } = useAsyncCalculateSubtotals({
+    const {
+        data: groupedSubtotals,
+        isFetching: isLoadingSubtotals,
+        error: subtotalsError,
+    } = useAsyncCalculateSubtotals({
         projectUuid,
         sourceQueryUuid: resultsData?.queryUuid,
         dimensions: resultsData?.metricQuery?.dimensions,
@@ -368,6 +375,8 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
 
     return {
         validConfig,
+        isLoadingSubtotals,
+        subtotalsError,
 
         groupFieldIds: Array.from(groupFieldIds),
         groupReorder: handleGroupReorder,


### PR DESCRIPTION
## What changed

## Summary
- Wait for all result rows, asynchronous subtotals, and ECharts’ `finished` event before marking a treemap screenshot-ready.
- Prevent uninitialized visualization data from being treated as a completed empty chart; preserve completion for genuinely empty results.
- Signal screenshot errors for failed results or subtotals, and handle initial synchronous renders whose completion can precede event binding.
- Add real-ECharts regression coverage for render completion, pagination, initialization, empty results, subtotals, errors, and one-shot callbacks.

The treemap series enables its own animation despite the top-level animation setting, so query completion alone is insufficient. No backend delays or changes to other chart types are introduced.

## Verification

Passed:
- `pnpm -F frontend lint` — 0 warnings/errors.
- `pnpm -F frontend typecheck`.
- `pnpm -F frontend exec oxfmt src/components/SimpleTreemap/index.tsx src/components/SimpleTreemap/index.test.tsx src/hooks/useTreemapChartConfig.ts --check`.
- `pnpm -F frontend exec vitest related src/components/SimpleTreemap/index.tsx src/components/SimpleTreemap/index.test.tsx src/hooks/useTreemapChartConfig.ts --run` — 21 files, 110 tests passed, including 8 treemap cases.
- `git diff --check`; commit hooks also passed. Worktree clean.

Visual verification: created a demo dashboard with a customer treemap and matching bar chart. Captured its minimal screenshot surface after `#lightdash-ready-indicator[data-status="ready"]` appeared. Observations confirmed two visible chart SVGs, 264 paths, and 113 text elements.

Limitation: `curl -s -b /tmp/treemap-cookie -X POST http://127.0.0.1:3000/api/v1/saved/3ee69485-fdad-40d4-9316-d7207938f827/export` timed out at 120 seconds. PM2 logs and Maple trace 7a18a12d3c21417809df229f98f6e95a showed the separate headless browser received HTTP 404 for its configured localhost:3000 minimal page before waiting for readiness. Scheduled delivery/export was therefore not verified end to end.

Independent final standards and specification reviews reported no remaining findings.

## Visual evidence

### Minimal dashboard screenshot surface after both tiles report ready: a customer treemap alongside the matching bar chart.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/c5a081e6340ffb68399852c59a5112a692dc53dc961ac80187b456767b9b2fe0.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10769-31c1b486c183.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-10769](https://linear.app/lightdash/issue/PROD-10769)

