### PR TITLE
fix(organizations): make deletion accessible for sole members and unnamed orgs

### DIFF
--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/DeleteOrganizationModal.tsx
@@ -1,4 +1,4 @@
-import { Text, TextInput, type ModalProps } from '@mantine/core';
+import { TextInput, type ModalProps } from '@mantine/core';
 import { useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useDeleteOrganizationMutation } from '../../../hooks/organization/useOrganizationDeleteMultation';
@@ -11,9 +11,12 @@ export const OrganizationDeleteModal: FC<
     const { mutateAsync, isLoading: isDeleting } =
         useDeleteOrganizationMutation();
 
-    const [confirmOrgName, setConfirmOrgName] = useState<string>();
+    const [confirmOrgName, setConfirmOrgName] = useState('');
 
     if (isInitialLoading || !organization) return null;
+
+    const organizationName = organization.name.trim();
+    const confirmationText = organizationName || 'DELETE';
 
     const handleConfirm = async () => {
         await mutateAsync(organization.organizationUuid);
@@ -21,7 +24,7 @@ export const OrganizationDeleteModal: FC<
     };
 
     const handleOnClose = () => {
-        setConfirmOrgName(undefined);
+        setConfirmOrgName('');
         onClose();
     };
 
@@ -29,26 +32,26 @@ export const OrganizationDeleteModal: FC<
         <MantineModal
             opened={opened}
             onClose={handleOnClose}
-            title="Delete Organization"
+            title={`Delete “${organizationName || 'Unnamed organization'}”?`}
             variant="delete"
-            resourceType="organization"
-            resourceLabel={organization.name}
+            confirmLabel="Permanently delete organization"
+            description="This permanently removes all projects, saved content, users, and service accounts in this organization. You will be signed out. This cannot be undone."
             size="md"
             onConfirm={handleConfirm}
             confirmDisabled={
-                confirmOrgName?.toLowerCase() !==
-                organization.name.toLowerCase()
+                confirmOrgName.toLowerCase() !== confirmationText.toLowerCase()
             }
             confirmLoading={isDeleting}
         >
-            <Text fz="sm" c="dimmed">
-                Type the name of this organization to confirm. This action will
-                delete all users and is not reversible.
-            </Text>
-
             <TextInput
                 name="confirmOrgName"
-                placeholder={organization.name}
+                label={`Type ${confirmationText} to confirm`}
+                description={
+                    organizationName
+                        ? undefined
+                        : 'This organization has no name, so use DELETE instead.'
+                }
+                placeholder={confirmationText}
                 value={confirmOrgName}
                 onChange={(e) => setConfirmOrgName(e.target.value)}
             />

--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/index.tsx
@@ -22,7 +22,7 @@ export const DeleteOrganizationPanel: FC = () => {
                 leftSection={<MantineIcon icon={IconTrash} />}
                 onClick={() => setShowDeleteOrganizationModal(true)}
             >
-                Delete '{organization.name}'
+                Delete '{organization.name.trim() || 'Unnamed organization'}'
             </Button>
 
             <OrganizationDeleteModal

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/LeaveOrganizationModal.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/LeaveOrganizationModal.tsx
@@ -11,9 +11,12 @@ export const LeaveOrganizationModal: FC<
     const { mutateAsync, isLoading: isLeaving } =
         useLeaveOrganizationMutation();
 
-    const [confirmOrgName, setConfirmOrgName] = useState<string>();
+    const [confirmOrgName, setConfirmOrgName] = useState('');
 
     if (isInitialLoading || !organization) return null;
+
+    const organizationName = organization.name.trim();
+    const confirmationText = organizationName || 'LEAVE';
 
     const handleConfirm = async () => {
         await mutateAsync();
@@ -21,7 +24,7 @@ export const LeaveOrganizationModal: FC<
     };
 
     const handleOnClose = () => {
-        setConfirmOrgName(undefined);
+        setConfirmOrgName('');
         onClose();
     };
 
@@ -29,27 +32,28 @@ export const LeaveOrganizationModal: FC<
         <MantineModal
             opened={opened}
             onClose={handleOnClose}
-            title="Leave organization"
+            title={`Leave “${organizationName || 'Unnamed organization'}”?`}
             variant="delete"
             confirmLabel="Leave"
             size="md"
             onConfirm={handleConfirm}
             confirmDisabled={
-                confirmOrgName?.toLowerCase() !==
-                organization.name.toLowerCase()
+                confirmOrgName.toLowerCase() !== confirmationText.toLowerCase()
             }
             confirmLoading={isLeaving}
         >
             <Stack gap="sm">
                 <Text fz="sm" c="dimmed">
-                    Type the name of this organization to confirm. You will lose
-                    access to all of its projects and will be signed out.
+                    You will lose access to all projects in this organization
+                    and will be signed out. The organization and its content
+                    will remain available to other members.
                 </Text>
 
                 <TextInput
                     name="confirmOrgName"
-                    placeholder={organization.name}
-                    value={confirmOrgName ?? ''}
+                    label={`Type ${confirmationText} to confirm`}
+                    placeholder={confirmationText}
+                    value={confirmOrgName}
                     onChange={(e) => setConfirmOrgName(e.target.value)}
                 />
             </Stack>

--- a/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/LeaveOrganizationPanel/index.tsx
@@ -1,14 +1,17 @@
 import { OrganizationMemberRole } from '@lightdash/common';
-import { Box, Button, Group, Tooltip } from '@mantine/core';
+import { Button, Stack, Text } from '@mantine/core';
 import { IconLogout } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import { useOrganizationUsers } from '../../../hooks/useOrganizationUsers';
 import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../../common/MantineIcon';
+import { DeleteOrganizationPanel } from '../DeleteOrganizationPanel';
 import { LeaveOrganizationModal } from './LeaveOrganizationModal';
 
-export const LeaveOrganizationPanel: FC = () => {
+export const LeaveOrganizationPanel: FC<{ showDeleteAction?: boolean }> = ({
+    showDeleteAction = true,
+}) => {
     const { user } = useApp();
     const { isInitialLoading: isOrganizationLoading, data: organization } =
         useOrganization();
@@ -42,27 +45,31 @@ export const LeaveOrganizationPanel: FC = () => {
             onClick={() => setShowModal(true)}
             disabled={isOnlyAdmin}
         >
-            Leave '{organization.name}'
+            Leave '{organization.name.trim() || 'Unnamed organization'}'
         </Button>
     );
 
     return (
-        <Group justify="flex-end">
+        <Stack align="flex-end" gap="sm">
+            {button}
             {isOnlyAdmin ? (
-                <Tooltip
-                    label="You are the only admin in this organization. Promote another member to admin before leaving."
-                    w={260}
-                >
-                    <Box>{button}</Box>
-                </Tooltip>
-            ) : (
-                button
-            )}
+                <>
+                    <Text fz="sm" c="dimmed" maw={360} ta="right">
+                        {orgUsers?.length === 1
+                            ? 'You are the only member. To leave, permanently delete this organization and its content.'
+                            : 'You are the only admin. Add or promote another admin before leaving. To remove this workspace instead, delete the organization.'}
+                    </Text>
+                    {showDeleteAction &&
+                        user.data.ability.can('delete', 'Organization') && (
+                            <DeleteOrganizationPanel />
+                        )}
+                </>
+            ) : null}
 
             <LeaveOrganizationModal
                 opened={showModal}
                 onClose={() => setShowModal(false)}
             />
-        </Group>
+        </Stack>
     );
 };

--- a/packages/frontend/src/components/UserSettings/OrganizationEscape.test.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationEscape.test.tsx
@@ -1,0 +1,169 @@
+import { OrganizationMemberRole } from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { describe, expect, it, vi } from 'vitest';
+import { BASE_API_URL } from '../../api';
+import { renderWithProviders } from '../../testing/testUtils';
+import { OrganizationDeleteModal } from './DeleteOrganizationPanel/DeleteOrganizationModal';
+import { LeaveOrganizationPanel } from './LeaveOrganizationPanel';
+import { LeaveOrganizationModal } from './LeaveOrganizationPanel/LeaveOrganizationModal';
+
+const user = {
+    userUuid: 'b264d83a-9000-426a-85ec-3f9c20f368ce',
+    organizationUuid: '172a2270-000f-42be-9c68-c4752c23ae51',
+    role: OrganizationMemberRole.ADMIN,
+};
+
+const mockOrganization = (name: string) =>
+    nock(BASE_API_URL)
+        .get('/api/v1/org')
+        .reply(200, {
+            status: 'ok',
+            results: { name, organizationUuid: user.organizationUuid },
+        });
+
+describe('organization escape', () => {
+    it.each(['', '   '])(
+        'requires DELETE to delete an unnamed organization (%j)',
+        async (name) => {
+            mockOrganization(name);
+            const onClose = vi.fn();
+            renderWithProviders(
+                <OrganizationDeleteModal opened onClose={onClose} />,
+            );
+
+            const input = await screen.findByRole('textbox', {
+                name: 'Type DELETE to confirm',
+            });
+            const confirm = screen.getByRole('button', {
+                name: 'Permanently delete organization',
+            });
+            expect(confirm).toBeDisabled();
+            expect(
+                screen.getByText(
+                    /all projects, saved content, users, and service accounts/,
+                ),
+            ).toBeInTheDocument();
+            fireEvent.change(input, { target: { value: 'wrong' } });
+            expect(confirm).toBeDisabled();
+            fireEvent.change(input, { target: { value: 'DELETE' } });
+            expect(confirm).toBeEnabled();
+
+            const deletion = nock(BASE_API_URL)
+                .delete(`/api/v1/org/${user.organizationUuid}`)
+                .reply(200, { status: 'ok' });
+            fireEvent.click(confirm);
+            await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+            expect(deletion.isDone()).toBe(true);
+        },
+    );
+
+    it('requires the name for a named organization and clears confirmation on cancel', async () => {
+        mockOrganization('Jaffle Shop');
+        const onClose = vi.fn();
+        renderWithProviders(
+            <OrganizationDeleteModal opened onClose={onClose} />,
+        );
+        const input = await screen.findByRole('textbox', {
+            name: 'Type Jaffle Shop to confirm',
+        });
+        const confirm = screen.getByRole('button', {
+            name: 'Permanently delete organization',
+        });
+        fireEvent.change(input, { target: { value: 'DELETE' } });
+        expect(confirm).toBeDisabled();
+        fireEvent.change(input, { target: { value: 'jaffle shop' } });
+        expect(confirm).toBeEnabled();
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(onClose).toHaveBeenCalledOnce();
+        expect(input).toHaveValue('');
+        expect(confirm).toBeDisabled();
+    });
+
+    it('requires LEAVE for an unnamed organization and calls only the leave endpoint', async () => {
+        mockOrganization('');
+        const onClose = vi.fn();
+        renderWithProviders(
+            <LeaveOrganizationModal opened onClose={onClose} />,
+        );
+        const input = await screen.findByRole('textbox', {
+            name: 'Type LEAVE to confirm',
+        });
+        const confirm = screen.getByRole('button', {
+            name: 'Leave',
+        });
+        expect(confirm).toBeDisabled();
+        fireEvent.change(input, { target: { value: 'DELETE' } });
+        expect(confirm).toBeDisabled();
+        fireEvent.change(input, { target: { value: 'LEAVE' } });
+        expect(confirm).toBeEnabled();
+        const leaving = nock(BASE_API_URL)
+            .delete('/api/v1/user/me/leaveOrganization')
+            .reply(200, { status: 'ok', results: null });
+        fireEvent.click(confirm);
+        await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+        expect(leaving.isDone()).toBe(true);
+    });
+
+    it.each([
+        { members: [user], explanation: /You are the only member/ },
+        {
+            members: [
+                user,
+                {
+                    ...user,
+                    userUuid: 'another-member',
+                    role: OrganizationMemberRole.MEMBER,
+                },
+            ],
+            explanation: /You are the only admin/,
+        },
+    ])(
+        'explains the blocked leave action for $members.length members and opens deletion',
+        async ({ members, explanation }) => {
+            mockOrganization('');
+            nock(BASE_API_URL)
+                .get('/api/v1/org/users')
+                .reply(200, {
+                    status: 'ok',
+                    results: { data: members },
+                });
+            renderWithProviders(<LeaveOrganizationPanel />, {
+                user: {
+                    abilityRules: [
+                        { action: 'delete', subject: 'Organization' },
+                    ],
+                },
+            });
+            expect(
+                await screen.findByRole('button', {
+                    name: "Leave 'Unnamed organization'",
+                }),
+            ).toBeDisabled();
+            expect(screen.getByText(explanation)).toBeInTheDocument();
+            fireEvent.click(
+                screen.getByRole('button', {
+                    name: "Delete 'Unnamed organization'",
+                }),
+            );
+            expect(
+                await screen.findByRole('textbox', {
+                    name: 'Type DELETE to confirm',
+                }),
+            ).toBeInTheDocument();
+        },
+    );
+
+    it('does not offer organization deletion to a non-admin', async () => {
+        mockOrganization('Jaffle Shop');
+        renderWithProviders(<LeaveOrganizationPanel />, {
+            user: { role: OrganizationMemberRole.MEMBER, abilityRules: [] },
+        });
+        expect(
+            await screen.findByRole('button', { name: "Leave 'Jaffle Shop'" }),
+        ).toBeEnabled();
+        expect(
+            screen.queryByRole('button', { name: /Delete/ }),
+        ).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -337,7 +337,9 @@ const Settings: FC = () => {
                                 </Text>
                             </Box>
                             <Stack gap="sm" align="flex-end">
-                                <LeaveOrganizationPanel />
+                                <LeaveOrganizationPanel
+                                    showDeleteAction={false}
+                                />
                                 {user.ability?.can(
                                     'delete',
                                     'Organization',


### PR DESCRIPTION
Closes: PROD-10518
Closes: PROD-10317
Closes: #27948
Closes: #27633

### Description

A sole member now sees an explicit explanation and an admin-only Delete organization action beside the blocked Leave action in their profile. It opens the existing deletion flow, with warnings covering projects, saved content, users, service accounts, and sign-out. Organizations with other members retain the promote-an-admin guidance.

Unnamed and whitespace-only organization names no longer block confirmation: deletion requires typing DELETE, and leaving requires LEAVE. Named organizations still require their name; Cancel clears confirmation.

This fixes the deletion dead ends. Organization creation/onboarding and backend authorization are unchanged; Leave does not implicitly delete the organization.

### Validation

- Seven component tests passed, covering sole-member and multi-member guidance, non-admin visibility, named/unnamed confirmation, cancellation, and the existing delete/leave endpoints.
- Frontend typecheck, targeted lint, formatting, and whitespace checks passed.
- Browser verification with disposable organizations: confirmed exactly one membership, deleted through the profile action, and returned to registration. Database checks confirmed deletion; the old session returned 401. Also verified unnamed-organization deletion and captured screenshots locally.

### Risk assessment

- [ ] This is a high-risk change

Frontend-only change reusing the existing authorized organization-deletion endpoint. Last-admin protection remains enforced; destructive confirmation is explicit and cannot be submitted with blank input.
