### PR TITLE
fix(sql-runner): add series draw order controls

### DIFF
--- a/packages/common/src/visualizations/CartesianChartDataModel.test.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.test.ts
@@ -1,4 +1,5 @@
 import { DimensionType, Format } from '../types/field';
+import { CartesianSeriesType, ChartKind } from '../types/savedCharts';
 import { CartesianChartDataModel } from './CartesianChartDataModel';
 import {
     VizAggregationOptions,
@@ -28,6 +29,124 @@ describe('CartesianChartDataModel formatters', () => {
                 value: { category: 'Jan', value: 1200000 },
             }),
         ).toEqual('1.2M');
+    });
+});
+
+describe('CartesianChartDataModel series draw order', () => {
+    const columns = ['target', 'sales'];
+
+    const getModel = async (references = columns) => {
+        const pivotChartData: PivotChartData = {
+            queryUuid: undefined,
+            fileUrl: undefined,
+            results: [{ month: 'Jan', target: 40, sales: 100 }],
+            indexColumn: { reference: 'month', type: VizIndexType.CATEGORY },
+            valuesColumns: references.map((reference) => ({
+                referenceField: reference.split('__')[0],
+                pivotColumnName: reference,
+                aggregation: VizAggregationOptions.SUM,
+                pivotValues: [],
+            })),
+            columns: [],
+            columnCount: references.length + 1,
+        };
+        const model = new CartesianChartDataModel({
+            type: ChartKind.VERTICAL_BAR,
+            resultsRunner: {
+                getPivotedVisualizationData: async () => pivotChartData,
+                getColumnNames: () => ['month', ...references],
+                getRows: () => [],
+                getPivotQueryDimensions: () => [],
+                getPivotQueryMetrics: () => [],
+                getPivotQueryCustomMetrics: () => [],
+            },
+            fieldConfig: {
+                x: { reference: 'month', type: VizIndexType.CATEGORY },
+                y: columns.map((reference) => ({
+                    reference,
+                    aggregation: VizAggregationOptions.SUM,
+                })),
+                groupBy: undefined,
+            },
+        });
+        await model.getPivotedChartData({
+            sql: 'SELECT 1',
+            limit: 500,
+            sortBy: [],
+            filters: [],
+        });
+        return model;
+    };
+
+    test('brings a line in front of bars without changing its color or settings', async () => {
+        const model = await getModel();
+        const display = {
+            series: {
+                target: {
+                    type: CartesianSeriesType.LINE as const,
+                    label: 'Target',
+                    whichYAxis: 1,
+                    format: Format.PERCENT,
+                },
+                sales: { type: CartesianSeriesType.BAR as const },
+            },
+        };
+        const before = model.getSpec(display);
+        const after = model.getSpec({
+            ...display,
+            seriesOrder: ['sales', 'target'],
+        });
+
+        expect(before.series[0].z).toBeLessThan(before.series[1].z);
+        expect(after.series.map((s: { name: string }) => s.name)).toEqual([
+            'Sales',
+            'Target',
+        ]);
+        expect(after.series[1]).toMatchObject({
+            type: 'line',
+            yAxisIndex: 1,
+            color: before.series[0].color,
+        });
+        expect(after.series[0].color).toEqual(before.series[1].color);
+        expect(after.series[1].z).toBeGreaterThan(after.series[0].z);
+        expect(after.series[1].tooltip.valueFormatter(0.5)).toBe('50%');
+    });
+
+    test('orders pivot series independently, ignoring removed series and retaining new ones', async () => {
+        const model = await getModel([
+            'target__west',
+            'sales__west',
+            'target__east',
+            'sales__east',
+            'profit',
+        ]);
+        const spec = model.getSpec({
+            seriesOrder: [
+                'removed',
+                'sales__west',
+                'sales__east',
+                'target__east',
+                'target__west',
+            ],
+        });
+        expect(
+            spec.series.map((s: { encode: { y: string } }) => s.encode.y),
+        ).toEqual([
+            'sales__west',
+            'sales__east',
+            'target__east',
+            'target__west',
+            'profit',
+        ]);
+    });
+
+    test('keeps the query series order when no order is saved', async () => {
+        const model = await getModel();
+        expect(
+            model
+                .getSpec()
+                .series.map((s: { encode: { y: string } }) => s.encode.y),
+        ).toEqual(columns);
     });
 });
 

--- a/packages/common/src/visualizations/CartesianChartDataModel.ts
+++ b/packages/common/src/visualizations/CartesianChartDataModel.ts
@@ -56,6 +56,7 @@ import {
     type AxisSide,
     type PivotChartData,
     type PivotChartLayout,
+    type PivotValuesColumn,
     type SqlRunnerEChartsSeries,
     type VizCartesianChartConfig,
     type VizCartesianChartOptions,
@@ -414,6 +415,21 @@ export class CartesianChartDataModel {
         };
     }
 
+    static getOrderedSeries(
+        series: PivotValuesColumn[],
+        seriesOrder: string[] | undefined,
+    ): PivotValuesColumn[] {
+        if (!seriesOrder?.length) return series;
+        const positions = new Map(
+            seriesOrder.map((reference, index) => [reference, index]),
+        );
+        return [...series].sort(
+            (a, b) =>
+                (positions.get(a.pivotColumnName) ?? seriesOrder.length) -
+                (positions.get(b.pivotColumnName) ?? seriesOrder.length),
+        );
+    }
+
     static getDefaultColor(index: number, orgColors?: string[]) {
         const colorPalette = orgColors || ECHARTS_DEFAULT_COLORS;
         // This code assigns a color to a series in the chart
@@ -647,8 +663,17 @@ export class CartesianChartDataModel {
               )
             : undefined;
 
+        const originalSeriesIndices = new Map(
+            transformedData.valuesColumns.map((column, index) => [
+                column,
+                index,
+            ]),
+        );
         let series: SqlRunnerEChartsSeries[] =
-            transformedData.valuesColumns.map((seriesColumn, index) => {
+            CartesianChartDataModel.getOrderedSeries(
+                transformedData.valuesColumns,
+                display?.seriesOrder,
+            ).map((seriesColumn) => {
                 const seriesColumnId = seriesColumn.pivotColumnName;
 
                 // NOTE: seriesColumnId is the post pivoted column name and we now store the display based on that.
@@ -770,7 +795,7 @@ export class CartesianChartDataModel {
                     color:
                         seriesColor ||
                         CartesianChartDataModel.getDefaultColor(
-                            index,
+                            originalSeriesIndices.get(seriesColumn) ?? 0,
                             orgColors,
                         ),
                     ...(seriesType === 'bar' ? getBarStyle() : {}),
@@ -1043,6 +1068,8 @@ export class CartesianChartDataModel {
 }
 
 export type CartesianChartDisplay = {
+    // Pivot column names in back-to-front draw order.
+    seriesOrder?: string[];
     xAxis?: {
         label?: string;
         type?: VizIndexType;

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.module.css
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.module.css
@@ -3,10 +3,18 @@
 }
 
 .controlPanel {
-    background-color: light-dark(white, transparent);
+    flex: 1;
+    min-width: 0;
+    background-color: var(--mantine-color-body);
 }
 
 .panel {
-    background-color: light-dark(white, transparent);
+    background-color: var(--mantine-color-body);
     border-radius: var(--mantine-radius-sm);
+}
+
+.seriesCard {
+    background-color: var(--mantine-color-ldGray-0);
+    border-radius: var(--mantine-radius-md);
+    padding: var(--mantine-spacing-xs);
 }

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -18,7 +18,7 @@ import {
     Text,
     useMantineColorScheme,
 } from '@mantine/core';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
     useAppSelector,
     useAppDispatch as useVizDispatch,
@@ -132,24 +132,30 @@ export const CartesianChartSeries = ({
         currentConfig?.display?.seriesOrder,
         groupedSeries,
     ]);
-    const setGroupOrder = (order: string[]) =>
-        dispatch(
-            actions.setSeriesOrder(
-                order.flatMap((reference) =>
-                    groupedSeries[reference].map((s) => s.reference),
+    const setGroupOrder = useCallback(
+        (order: string[]) =>
+            dispatch(
+                actions.setSeriesOrder(
+                    order.flatMap((reference) =>
+                        groupedSeries[reference].map((s) => s.reference),
+                    ),
                 ),
             ),
-        );
-    const setGroupSeriesOrder = (reference: string, order: string[]) =>
-        dispatch(
-            actions.setSeriesOrder(
-                seriesGroups.flatMap((group) =>
-                    group.reference === reference
-                        ? order
-                        : group.series.map((s) => s.reference),
+        [dispatch, actions, groupedSeries],
+    );
+    const setGroupSeriesOrder = useCallback(
+        (reference: string, order: string[]) =>
+            dispatch(
+                actions.setSeriesOrder(
+                    seriesGroups.flatMap((group) =>
+                        group.reference === reference
+                            ? order
+                            : group.series.map((s) => s.reference),
+                    ),
                 ),
             ),
-        );
+        [dispatch, actions, seriesGroups],
+    );
 
     // If any of the series in the groupedSeries have more than one value, then we can stack
     const canStack = useMemo(() => {
@@ -165,78 +171,101 @@ export const CartesianChartSeries = ({
         );
     }, [currentConfig?.fieldConfig?.groupBy]);
 
-    const onColorChange = (reference: string, color: string) => {
-        dispatch(
-            actions.setSeriesColor({
-                reference: reference,
-                color,
-            }),
-        );
-    };
+    const onColorChange = useCallback(
+        (reference: string, color: string) => {
+            dispatch(
+                actions.setSeriesColor({
+                    reference: reference,
+                    color,
+                }),
+            );
+        },
+        [dispatch, actions],
+    );
 
-    const handleLabelChange = (reference: string, label: string) => {
-        dispatch(
-            actions.setSeriesLabel({
-                label,
-                reference,
-            }),
-        );
-    };
+    const handleLabelChange = useCallback(
+        (reference: string, label: string) => {
+            dispatch(
+                actions.setSeriesLabel({
+                    label,
+                    reference,
+                }),
+            );
+        },
+        [dispatch, actions],
+    );
 
-    const handleTypeChange = (
-        reference: string,
-        type: NonNullable<CartesianChartDisplay['series']>[number]['type'],
-    ) => {
-        dispatch(
-            actions.setSeriesChartType({
-                type,
-                reference,
-            }),
-        );
-    };
+    const handleTypeChange = useCallback(
+        (
+            reference: string,
+            type: NonNullable<CartesianChartDisplay['series']>[number]['type'],
+        ) => {
+            dispatch(
+                actions.setSeriesChartType({
+                    type,
+                    reference,
+                }),
+            );
+        },
+        [dispatch, actions],
+    );
 
-    const handleAxisChange = (reference: string, value: AxisSide) => {
-        dispatch(
-            actions.setSeriesYAxis({
-                whichYAxis: value,
-                reference,
-            }),
-        );
-    };
+    const handleAxisChange = useCallback(
+        (reference: string, value: AxisSide) => {
+            dispatch(
+                actions.setSeriesYAxis({
+                    whichYAxis: value,
+                    reference,
+                }),
+            );
+        },
+        [dispatch, actions],
+    );
 
-    const handleValueLabelPositionChange = (
-        reference: string,
-        position: ValueLabelPositionOptions,
-    ) => {
-        dispatch(
-            actions.setSeriesValueLabelPosition({
-                valueLabelPosition: position,
-                reference,
-            }),
-        );
-    };
+    const handleValueLabelPositionChange = useCallback(
+        (reference: string, position: ValueLabelPositionOptions) => {
+            dispatch(
+                actions.setSeriesValueLabelPosition({
+                    valueLabelPosition: position,
+                    reference,
+                }),
+            );
+        },
+        [dispatch, actions],
+    );
 
-    const renderSeries = (
-        series: ConfigurableSeries,
-        dragHandleProps?: DraggableProvidedDragHandleProps | null,
-        drawOrder?: SeriesDrawOrderControl,
-    ) => (
-        <SingleSeriesConfiguration
-            key={series.reference}
-            {...series}
-            color={series.color}
-            type={series.type}
-            valueLabelPosition={series.valueLabelPosition}
-            colors={colors}
-            selectedChartType={selectedChartType}
-            onColorChange={onColorChange}
-            onLabelChange={handleLabelChange}
-            onTypeChange={handleTypeChange}
-            onAxisChange={handleAxisChange}
-            onValueLabelPositionChange={handleValueLabelPositionChange}
-            dragHandleProps={dragHandleProps}
-            drawOrder={drawOrder}
-        />
+    const renderSeries = useCallback(
+        (
+            series: ConfigurableSeries,
+            dragHandleProps?: DraggableProvidedDragHandleProps | null,
+            drawOrder?: SeriesDrawOrderControl,
+        ) => (
+            <SingleSeriesConfiguration
+                key={series.reference}
+                {...series}
+                color={series.color}
+                type={series.type}
+                valueLabelPosition={series.valueLabelPosition}
+                colors={colors}
+                selectedChartType={selectedChartType}
+                onColorChange={onColorChange}
+                onLabelChange={handleLabelChange}
+                onTypeChange={handleTypeChange}
+                onAxisChange={handleAxisChange}
+                onValueLabelPositionChange={handleValueLabelPositionChange}
+                dragHandleProps={dragHandleProps}
+                drawOrder={drawOrder}
+            />
+        ),
+        [
+            colors,
+            selectedChartType,
+            onColorChange,
+            handleLabelChange,
+            handleTypeChange,
+            handleAxisChange,
+            handleValueLabelPositionChange,
+        ],
     );
 
     return (

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -1,4 +1,6 @@
+import { type DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import {
+    CartesianChartDataModel,
     ECHARTS_DEFAULT_COLORS,
     friendlyName,
     StackType,
@@ -10,6 +12,7 @@ import {
 } from '@lightdash/common';
 import {
     Accordion,
+    Group,
     SegmentedControl,
     Stack,
     Text,
@@ -22,11 +25,18 @@ import {
 } from '../../../features/sqlRunner/store/hooks';
 import { selectProjectUuid } from '../../../features/sqlRunner/store/sqlRunnerSlice';
 import { useProjectColorPalette } from '../../../hooks/appearance/useProjectColorPalette';
+import {
+    SeriesDepthControl,
+    type SeriesDrawOrderControl,
+} from '../../VisualizationConfigs/ChartConfigPanel/Series/SeriesDrawOrder';
+import drawOrderStyles from '../../VisualizationConfigs/ChartConfigPanel/Series/seriesDrawOrder.module.css';
 import { Config } from '../../VisualizationConfigs/common/Config';
+import { GrabIcon } from '../../VisualizationConfigs/common/GrabIcon';
 import { type BarChartActionsType } from '../store/barChartSlice';
 import { type LineChartActionsType } from '../store/lineChartSlice';
 import { selectCurrentCartesianChartState } from '../store/selectors';
 import classes from './CartesianChartSeries.module.css';
+import { SeriesOrderList } from './SeriesOrderList';
 import { SingleSeriesConfiguration } from './SingleSeriesConfiguration';
 
 type ConfigurableSeries = {
@@ -63,11 +73,16 @@ export const CartesianChartSeries = ({
             return {};
         }
 
-        return currentConfig.series.reduce<
-            Record<string, ConfigurableSeries[]>
-        >((acc, s, index) => {
+        const originalIndices = new Map(
+            currentConfig.series.map((series, index) => [series, index]),
+        );
+        return CartesianChartDataModel.getOrderedSeries(
+            currentConfig.series,
+            currentConfig.display?.seriesOrder,
+        ).reduce<Record<string, ConfigurableSeries[]>>((acc, s) => {
             const foundSeries =
-                currentConfig?.display?.series?.[s.pivotColumnName];
+                currentConfig?.display?.series?.[s.pivotColumnName] ??
+                currentConfig?.display?.series?.[s.referenceField];
 
             const seriesFormat = foundSeries?.format;
             const seriesLabel = foundSeries?.label;
@@ -80,7 +95,12 @@ export const CartesianChartSeries = ({
                 reference: s.pivotColumnName,
                 format: seriesFormat,
                 label: seriesLabel ?? friendlyName(s.pivotColumnName),
-                color: seriesColor ?? colors[index],
+                color:
+                    seriesColor ??
+                    CartesianChartDataModel.getDefaultColor(
+                        originalIndices.get(s) ?? 0,
+                        colors,
+                    ),
                 type: seriesType,
                 valueLabelPosition: seriesValueLabelPosition,
                 whichYAxis: seriesWhichYAxis,
@@ -92,7 +112,44 @@ export const CartesianChartSeries = ({
                 [s.referenceField]: [...(acc[s.referenceField] || []), config],
             };
         }, {});
-    }, [colors, currentConfig?.display?.series, currentConfig?.series]);
+    }, [
+        colors,
+        currentConfig?.display?.series,
+        currentConfig?.display?.seriesOrder,
+        currentConfig?.series,
+    ]);
+
+    const seriesGroups = useMemo(() => {
+        const orderedSeries = CartesianChartDataModel.getOrderedSeries(
+            currentConfig?.series ?? [],
+            currentConfig?.display?.seriesOrder,
+        );
+        return [...new Set(orderedSeries.map((s) => s.referenceField))].map(
+            (reference) => ({ reference, series: groupedSeries[reference] }),
+        );
+    }, [
+        currentConfig?.series,
+        currentConfig?.display?.seriesOrder,
+        groupedSeries,
+    ]);
+    const setGroupOrder = (order: string[]) =>
+        dispatch(
+            actions.setSeriesOrder(
+                order.flatMap((reference) =>
+                    groupedSeries[reference].map((s) => s.reference),
+                ),
+            ),
+        );
+    const setGroupSeriesOrder = (reference: string, order: string[]) =>
+        dispatch(
+            actions.setSeriesOrder(
+                seriesGroups.flatMap((group) =>
+                    group.reference === reference
+                        ? order
+                        : group.series.map((s) => s.reference),
+                ),
+            ),
+        );
 
     // If any of the series in the groupedSeries have more than one value, then we can stack
     const canStack = useMemo(() => {
@@ -159,6 +216,29 @@ export const CartesianChartSeries = ({
         );
     };
 
+    const renderSeries = (
+        series: ConfigurableSeries,
+        dragHandleProps?: DraggableProvidedDragHandleProps | null,
+        drawOrder?: SeriesDrawOrderControl,
+    ) => (
+        <SingleSeriesConfiguration
+            key={series.reference}
+            {...series}
+            color={series.color}
+            type={series.type}
+            valueLabelPosition={series.valueLabelPosition}
+            colors={colors}
+            selectedChartType={selectedChartType}
+            onColorChange={onColorChange}
+            onLabelChange={handleLabelChange}
+            onTypeChange={handleTypeChange}
+            onAxisChange={handleAxisChange}
+            onValueLabelPositionChange={handleValueLabelPositionChange}
+            dragHandleProps={dragHandleProps}
+            drawOrder={drawOrder}
+        />
+    );
+
     return (
         <Stack mt="sm" gap="xs">
             {Object.keys(groupedSeries).length === 0 && (
@@ -216,86 +296,84 @@ export const CartesianChartSeries = ({
                     </Config>
                 </>
             )}
-            {isGrouped
-                ? Object.entries(groupedSeries).map(
-                      ([referenceField, seriesArray]) => (
-                          <Accordion
-                              key={referenceField}
-                              variant="contained"
-                              className={classes.accordion}
-                          >
-                              <Accordion.Item value={referenceField} m={0}>
-                                  <Accordion.Control
-                                      className={classes.controlPanel}
-                                  >
-                                      <Config.Subheading>
-                                          {friendlyName(referenceField)}
-                                      </Config.Subheading>
-                                  </Accordion.Control>
-                                  <Accordion.Panel className={classes.panel}>
-                                      {seriesArray.map((s, index) => (
-                                          <SingleSeriesConfiguration
-                                              key={`${s.reference}-${index}`}
-                                              reference={s.reference}
-                                              color={s.color ?? colors[index]}
-                                              colors={colors}
-                                              label={s.label}
-                                              type={s.type}
-                                              whichYAxis={s.whichYAxis}
-                                              valueLabelPosition={
-                                                  s.valueLabelPosition
-                                              }
-                                              selectedChartType={
-                                                  selectedChartType
-                                              }
-                                              onColorChange={onColorChange}
-                                              onLabelChange={handleLabelChange}
-                                              onTypeChange={handleTypeChange}
-                                              onAxisChange={handleAxisChange}
-                                              onValueLabelPositionChange={
-                                                  handleValueLabelPositionChange
-                                              }
-                                          />
-                                      ))}
-                                  </Accordion.Panel>
-                              </Accordion.Item>
-                          </Accordion>
-                      ),
-                  )
-                : Object.values(groupedSeries)
-                      .flat()
-                      .map(
-                          (
-                              {
-                                  reference,
-                                  label,
-                                  color,
-                                  type,
-                                  whichYAxis,
-                                  valueLabelPosition,
-                              },
-                              index,
-                          ) => (
-                              <SingleSeriesConfiguration
-                                  key={`${reference}-${index}`}
-                                  reference={reference}
-                                  color={color ?? colors[index]}
-                                  colors={colors}
-                                  label={label}
-                                  type={type}
-                                  whichYAxis={whichYAxis}
-                                  valueLabelPosition={valueLabelPosition}
-                                  selectedChartType={selectedChartType}
-                                  onColorChange={onColorChange}
-                                  onLabelChange={handleLabelChange}
-                                  onTypeChange={handleTypeChange}
-                                  onAxisChange={handleAxisChange}
-                                  onValueLabelPositionChange={
-                                      handleValueLabelPositionChange
-                                  }
-                              />
-                          ),
-                      )}
+            <SeriesOrderList
+                order={seriesGroups.map((group) => group.reference)}
+                onChange={setGroupOrder}
+            >
+                {(reference, dragHandleProps, drawOrder) =>
+                    isGrouped ? (
+                        <Accordion
+                            variant="contained"
+                            className={classes.accordion}
+                        >
+                            <Accordion.Item value={reference} m={0}>
+                                <Group
+                                    gap="xs"
+                                    wrap="nowrap"
+                                    className={drawOrderStyles.seriesHeader}
+                                >
+                                    {dragHandleProps && (
+                                        <GrabIcon
+                                            dragHandleProps={dragHandleProps}
+                                        />
+                                    )}
+                                    <Accordion.Control
+                                        className={classes.controlPanel}
+                                    >
+                                        <Config.Subheading>
+                                            {friendlyName(reference)}
+                                        </Config.Subheading>
+                                    </Accordion.Control>
+                                    {drawOrder && (
+                                        <SeriesDepthControl
+                                            control={drawOrder}
+                                        />
+                                    )}
+                                </Group>
+                                <Accordion.Panel className={classes.panel}>
+                                    <SeriesOrderList
+                                        order={groupedSeries[reference].map(
+                                            (series) => series.reference,
+                                        )}
+                                        onChange={(order) =>
+                                            setGroupSeriesOrder(
+                                                reference,
+                                                order,
+                                            )
+                                        }
+                                    >
+                                        {(
+                                            seriesReference,
+                                            seriesDragHandleProps,
+                                            seriesDrawOrder,
+                                        ) => {
+                                            const series = groupedSeries[
+                                                reference
+                                            ].find(
+                                                (s) =>
+                                                    s.reference ===
+                                                    seriesReference,
+                                            );
+                                            return (
+                                                series &&
+                                                renderSeries(
+                                                    series,
+                                                    seriesDragHandleProps,
+                                                    seriesDrawOrder,
+                                                )
+                                            );
+                                        }}
+                                    </SeriesOrderList>
+                                </Accordion.Panel>
+                            </Accordion.Item>
+                        </Accordion>
+                    ) : (
+                        groupedSeries[reference].map((series) =>
+                            renderSeries(series, dragHandleProps, drawOrder),
+                        )
+                    )
+                }
+            </SeriesOrderList>
         </Stack>
     );
 };

--- a/packages/frontend/src/components/DataViz/config/SeriesOrderList.tsx
+++ b/packages/frontend/src/components/DataViz/config/SeriesOrderList.tsx
@@ -1,0 +1,109 @@
+import {
+    DragDropContext,
+    Draggable,
+    Droppable,
+    type DraggableProvidedDragHandleProps,
+    type DropResult,
+} from '@hello-pangea/dnd';
+import { Box } from '@mantine/core';
+import { useId, type ReactNode } from 'react';
+import {
+    SeriesDrawOrderBar,
+    type SeriesDrawOrderControl,
+} from '../../VisualizationConfigs/ChartConfigPanel/Series/SeriesDrawOrder';
+import { DraggablePortalHandler } from '../../VisualizationConfigs/TreemapConfig/DraggablePortalHandler';
+
+type Props = {
+    order: string[];
+    onChange: (order: string[]) => void;
+    children: (
+        reference: string,
+        dragHandleProps: DraggableProvidedDragHandleProps | null,
+        drawOrder: SeriesDrawOrderControl | undefined,
+    ) => ReactNode;
+};
+
+export const SeriesOrderList = ({ order, onChange, children }: Props) => {
+    const droppableId = useId();
+    const canReorder = order.length > 1;
+    const move = (from: number, to: number) => {
+        const nextOrder = [...order];
+        const [moved] = nextOrder.splice(from, 1);
+        nextOrder.splice(to, 0, moved);
+        onChange(nextOrder);
+    };
+    const onDragEnd = ({ source, destination }: DropResult) => {
+        if (!destination || source.index === destination.index) return;
+        move(source.index, destination.index);
+    };
+
+    return (
+        <>
+            {canReorder && (
+                <SeriesDrawOrderBar
+                    canReorder={canReorder}
+                    onReverse={() => onChange([...order].reverse())}
+                />
+            )}
+            <DragDropContext onDragEnd={onDragEnd}>
+                <Droppable droppableId={droppableId}>
+                    {(dropProps) => (
+                        <Box
+                            {...dropProps.droppableProps}
+                            ref={dropProps.innerRef}
+                        >
+                            {order.map((reference, index) => (
+                                <Draggable
+                                    key={reference}
+                                    draggableId={reference}
+                                    index={index}
+                                    isDragDisabled={!canReorder}
+                                >
+                                    {(
+                                        {
+                                            draggableProps,
+                                            dragHandleProps,
+                                            innerRef,
+                                        },
+                                        snapshot,
+                                    ) => (
+                                        <DraggablePortalHandler
+                                            snapshot={snapshot}
+                                        >
+                                            <Box
+                                                {...draggableProps}
+                                                ref={innerRef}
+                                                mt="xs"
+                                            >
+                                                {children(
+                                                    reference,
+                                                    dragHandleProps,
+                                                    canReorder
+                                                        ? {
+                                                              isFront:
+                                                                  index ===
+                                                                  order.length -
+                                                                      1,
+                                                              onBringToFront:
+                                                                  () =>
+                                                                      move(
+                                                                          index,
+                                                                          order.length -
+                                                                              1,
+                                                                      ),
+                                                          }
+                                                        : undefined,
+                                                )}
+                                            </Box>
+                                        </DraggablePortalHandler>
+                                    )}
+                                </Draggable>
+                            ))}
+                            {dropProps.placeholder}
+                        </Box>
+                    )}
+                </Droppable>
+            </DragDropContext>
+        </>
+    );
+};

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -1,3 +1,4 @@
+import { type DraggableProvidedDragHandleProps } from '@hello-pangea/dnd';
 import {
     AxisSide,
     getEChartsChartTypeFromChartKind,
@@ -16,14 +17,23 @@ import {
 } from '@mantine/core';
 import { IconAlignLeft, IconAlignRight } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
+import {
+    SeriesDepthControl,
+    type SeriesDrawOrderControl,
+} from '../../VisualizationConfigs/ChartConfigPanel/Series/SeriesDrawOrder';
+import drawOrderStyles from '../../VisualizationConfigs/ChartConfigPanel/Series/seriesDrawOrder.module.css';
 import ColorSelector from '../../VisualizationConfigs/ColorSelector';
 import { Config } from '../../VisualizationConfigs/common/Config';
+import { GrabIcon } from '../../VisualizationConfigs/common/GrabIcon';
+import classes from './CartesianChartSeries.module.css';
 import { CartesianChartTypeConfig } from './CartesianChartTypeConfig';
 import { CartesianChartValueLabelConfig } from './CartesianChartValueLabelConfig';
 
 const LABEL_WIDTH = 120;
 
 type SingleSeriesConfigurationProps = {
+    dragHandleProps?: DraggableProvidedDragHandleProps | null;
+    drawOrder?: SeriesDrawOrderControl;
     reference: string;
     color: string | undefined;
     colors: string[];
@@ -47,6 +57,8 @@ type SingleSeriesConfigurationProps = {
 
 export const SingleSeriesConfiguration = ({
     reference,
+    dragHandleProps,
+    drawOrder,
     color,
     colors,
     label,
@@ -62,16 +74,18 @@ export const SingleSeriesConfiguration = ({
 }: SingleSeriesConfigurationProps) => {
     return (
         <Stack key={reference} gap="xs">
-            <Stack
-                pl="sm"
-                gap="xs"
-                style={{
-                    backgroundColor: 'var(--mantine-color-ldGray-0)',
-                    borderRadius: 'var(--mantine-radius-md)',
-                    padding: 'var(--mantine-spacing-xs)',
-                }}
-            >
-                <Config.Subheading>{reference}</Config.Subheading>
+            <Stack gap="xs" className={classes.seriesCard}>
+                <Group
+                    gap="xs"
+                    wrap="nowrap"
+                    className={drawOrderStyles.seriesHeader}
+                >
+                    {dragHandleProps && (
+                        <GrabIcon dragHandleProps={dragHandleProps} />
+                    )}
+                    <Config.Subheading>{reference}</Config.Subheading>
+                    {drawOrder && <SeriesDepthControl control={drawOrder} />}
+                </Group>
                 <Flex justify="flex-start" align="center" wrap="nowrap">
                     <Config.Label w={LABEL_WIDTH}>Label</Config.Label>
                     <Group
@@ -81,14 +95,7 @@ export const SingleSeriesConfiguration = ({
                         grow
                         flex={3}
                     >
-                        <Box
-                            style={{
-                                flex: 1,
-                                display: 'flex',
-                                flexDirection: 'row',
-                                alignItems: 'center',
-                            }}
-                        >
+                        <Group gap={0} flex={1} wrap="nowrap">
                             <Box w="20px">
                                 <ColorSelector
                                     color={color}
@@ -108,13 +115,8 @@ export const SingleSeriesConfiguration = ({
                                 }
                                 flex={1}
                                 ml="xs"
-                                styles={(theme) => ({
-                                    input: {
-                                        border: `1px solid ${theme.colors.ldGray[2]}`,
-                                    },
-                                })}
                             />
-                        </Box>
+                        </Group>
                     </Group>
                 </Flex>
                 <Flex justify="flex-start" align="center" wrap="nowrap">

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.test.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.test.ts
@@ -1,0 +1,75 @@
+import {
+    CartesianSeriesType,
+    ChartKind,
+    VizAggregationOptions,
+    VizIndexType,
+    type VizCartesianChartConfig,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { setChartConfig } from './actions/commonChartActions';
+import { barChartConfigSlice } from './barChartSlice';
+import { lineChartConfigSlice } from './lineChartSlice';
+
+describe.each([
+    { type: ChartKind.VERTICAL_BAR, slice: barChartConfigSlice },
+    { type: ChartKind.LINE, slice: lineChartConfigSlice },
+] as const)('$type series draw order', ({ type, slice }) => {
+    const config: VizCartesianChartConfig = {
+        type,
+        metadata: { version: 1 },
+        fieldConfig: {
+            x: { reference: 'month', type: VizIndexType.CATEGORY },
+            y: ['target', 'sales'].map((reference) => ({
+                reference,
+                aggregation: VizAggregationOptions.SUM,
+            })),
+            groupBy: [],
+        },
+        display: {
+            series: {
+                target: { type: CartesianSeriesType.LINE, color: '#ff0000' },
+                sales: { type: CartesianSeriesType.BAR, label: 'Sales' },
+            },
+        },
+    };
+
+    it('saves the order independently of query fields and series settings', () => {
+        const initial = slice.reducer(undefined, setChartConfig(config));
+        const reordered = slice.reducer(
+            initial,
+            slice.actions.setSeriesOrder(['sales', 'target']),
+        );
+
+        expect(reordered.display?.seriesOrder).toEqual(['sales', 'target']);
+        expect(reordered.display?.series).toEqual(config.display?.series);
+        expect(reordered.fieldConfig).toBe(initial.fieldConfig);
+        expect(initial.display?.seriesOrder).toBeUndefined();
+
+        const reloaded = slice.reducer(
+            undefined,
+            setChartConfig({ ...config, display: reordered.display }),
+        );
+        expect(reloaded.display?.seriesOrder).toEqual(['sales', 'target']);
+
+        const edited = slice.reducer(
+            reloaded,
+            slice.actions.setSeriesLabel({
+                reference: 'target',
+                label: 'Goal',
+            }),
+        );
+        expect(edited.display?.seriesOrder).toEqual(['sales', 'target']);
+    });
+
+    it('initializes display when ordering a chart without saved display settings', () => {
+        const initial = slice.reducer(
+            undefined,
+            setChartConfig({ ...config, display: undefined }),
+        );
+        const reordered = slice.reducer(
+            initial,
+            slice.actions.setSeriesOrder(['sales', 'target']),
+        );
+        expect(reordered.display).toEqual({ seriesOrder: ['sales', 'target'] });
+    });
+});

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -61,6 +61,10 @@ export const cartesianChartConfigSlice = createSlice({
     name: 'cartesianChartBaseConfig',
     initialState,
     reducers: {
+        setSeriesOrder: (state, action: PayloadAction<string[]>) => {
+            state.display = state.display || {};
+            state.display.seriesOrder = action.payload;
+        },
         setXAxisReference: (state, action: PayloadAction<string>) => {
             const xField = state.options.indexLayoutOptions.find(
                 (x) => x.reference === action.payload,


### PR DESCRIPTION
Closes #26386

### Description

SQL Runner mixed charts can draw lines behind bars because series-list position controls paint order, but the builder had no way to change that order.

Reuse Explorer's draw-order controls: drag to reorder, Reverse, Bring to front, and a Front indicator. Both metric groups and individual pivot series can be reordered. Save the order in the chart display config and apply it before assigning series depth, preserving colors and other series settings. Existing charts keep their current order until edited.

Validation:
- 10 focused renderer/reducer tests pass; the rendering regressions failed before the fix.
- Frontend/common typechecks and targeted lint/format checks pass.
- Browser-verified line visibility before/after Bring to front, keyboard dragging, mouse dragging of groups and pivot series, and light/dark themes.
- Save/reload verified in the UI and persisted database configuration.

### Risk assessment

Low risk: optional, backward-compatible display configuration. No database migration. Generated API artifacts were validated locally and are excluded from the commit per repository guidance.

- [ ] This is a high-risk change

### Screenshots and documentation

Docs: https://github.com/lightdash/mintlify-docs/pull/1235 (draft until this ships).

The Target line is at the front of the series list and remains visible across the Sales bars. Existing charts retain their current order until explicitly reordered and saved.

| Light mode | Dark mode |
| --- | --- |
| ![SQL Runner series draw order in light mode](https://raw.githubusercontent.com/lightdash/mintlify-docs/178dd1d45ce9831a31451c2909b34069f1a4164e/images/explore/sql-runner/series-draw-order-light.png) | ![SQL Runner series draw order in dark mode](https://raw.githubusercontent.com/lightdash/mintlify-docs/178dd1d45ce9831a31451c2909b34069f1a4164e/images/explore/sql-runner/series-draw-order-dark.png) |
