### PR TITLE
fix(analytics): correct dashboard chart activity and user summaries

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,20 +113,6 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: depot-ubuntu-24.04-8
-    services:
-      analytics-postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: analytics_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U postgres -d analytics_test"
-          --health-interval 5s
-          --health-timeout 5s
-          --health-retries 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -167,10 +153,6 @@ jobs:
           exit $fail
       - name: Run unit tests
         run: pnpm test
-      - name: Run analytics PostgreSQL regression tests
-        env:
-          ANALYTICS_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/analytics_test
-        run: pnpm -F backend exec vitest run --config vitest.config.analytics.ts src/models/AnalyticsModel.integration.test.ts
 
   # Guards the published SDK bundle against re-introducing eval()/new Function()
   # that breaks consumers on a strict CSP (no 'unsafe-eval'). See issue #21276.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,20 @@ jobs:
   build-and-test:
     name: Build & Test
     runs-on: depot-ubuntu-24.04-8
+    services:
+      analytics-postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: analytics_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d analytics_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -153,6 +167,10 @@ jobs:
           exit $fail
       - name: Run unit tests
         run: pnpm test
+      - name: Run analytics PostgreSQL regression tests
+        env:
+          ANALYTICS_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/analytics_test
+        run: pnpm -F backend exec vitest run --config vitest.config.analytics.ts src/models/AnalyticsModel.integration.test.ts
 
   # Guards the published SDK bundle against re-introducing eval()/new Function()
   # that breaks consumers on a strict CSP (no 'unsafe-eval'). See issue #21276.

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -697,7 +697,7 @@ export class ManagedAgentModel {
     > {
         const membership = await this.database.raw<{
             rows: Array<{ user_uuid: string; role: string }>;
-        }>(usersInProjectSql(projectUuid, organizationUuid));
+        }>(usersInProjectSql(), { projectUuid, organizationUuid });
         const memberUuids = membership.rows.map((row) => row.user_uuid);
         if (memberUuids.length === 0) return [];
 

--- a/packages/backend/src/models/AnalyticsModel.integration.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.integration.test.ts
@@ -21,7 +21,11 @@ type ChartRow = {
 };
 
 type FixtureTables = {
-    projects: { project_id: number; project_uuid: string };
+    projects: {
+        project_id: number;
+        project_uuid: string;
+        organization_id: number;
+    };
     spaces: {
         space_id: number;
         project_id: number;
@@ -117,7 +121,7 @@ describe('AnalyticsModel (PostgreSQL)', () => {
         });
         await database.schema.createSchema(schema);
         await database.raw(`
-            CREATE TABLE projects (project_id integer PRIMARY KEY, project_uuid uuid UNIQUE NOT NULL);
+            CREATE TABLE projects (project_id integer PRIMARY KEY, project_uuid uuid UNIQUE NOT NULL, organization_id integer NOT NULL);
             CREATE TABLE spaces (space_id integer PRIMARY KEY, project_id integer REFERENCES projects, name text, deleted_at timestamp);
             CREATE TABLE dashboards (dashboard_uuid uuid PRIMARY KEY, project_uuid uuid, space_id integer REFERENCES spaces, name text, slug text, deleted_at timestamp);
             CREATE TABLE users (user_uuid uuid PRIMARY KEY, first_name text, last_name text, created_at timestamp);
@@ -130,8 +134,12 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             CREATE TABLE analytics_chart_views (chart_uuid uuid REFERENCES saved_queries(saved_query_uuid), user_uuid uuid REFERENCES users, timestamp timestamp NOT NULL, context jsonb);
         `);
         await table('projects').insert([
-            { project_id: 1, project_uuid: projectUuid },
-            { project_id: 2, project_uuid: otherProjectUuid },
+            { project_id: 1, project_uuid: projectUuid, organization_id: 1 },
+            {
+                project_id: 2,
+                project_uuid: otherProjectUuid,
+                organization_id: 1,
+            },
         ]);
         await table('spaces').insert([
             { space_id: 1, project_id: 1, name: 'Main space' },
@@ -319,6 +327,83 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             ].sort(),
         );
     });
+
+    it.each([
+        ['the same organization', 1],
+        ['another organization', 2],
+    ] as const)(
+        'isolates shared-user activity in another project in %s',
+        async (_description, organizationId) => {
+            await table('projects')
+                .where('project_uuid', otherProjectUuid)
+                .update({ organization_id: organizationId });
+            const queries = [
+                numberWeeklyQueryingUsersSql(userUuids, projectUuid),
+                tableMostQueriesSql(userUuids, projectUuid),
+                tableMostCreatedChartsSql(userUuids, projectUuid),
+                chartWeeklyQueryingUsersSql(userUuids, projectUuid),
+                chartWeeklyAverageQueriesSql(userUuids, projectUuid),
+                chartViewsSql(projectUuid),
+            ];
+            const readActivity = () =>
+                Promise.all(
+                    queries.map(async (sql) =>
+                        (await rows(sql))
+                            .map((row) => JSON.stringify(row))
+                            .sort(),
+                    ),
+                );
+            const before = await readActivity();
+            const otherCharts: ChartRow[] = [
+                {
+                    ...spaceChart,
+                    saved_query_id: 3,
+                    saved_query_uuid: randomUUID(),
+                    project_uuid: otherProjectUuid,
+                    space_id: 2,
+                },
+                {
+                    ...dashboardChart,
+                    saved_query_id: 4,
+                    saved_query_uuid: randomUUID(),
+                    project_uuid: otherProjectUuid,
+                    dashboard_uuid: otherDashboardUuid,
+                },
+            ];
+            await database<ChartRow>('saved_queries').insert(otherCharts);
+            await table('analytics_chart_views').insert(
+                otherCharts.map((chart) => ({
+                    chart_uuid: chart.saved_query_uuid,
+                    user_uuid: spaceViewer,
+                    timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+                })),
+            );
+            await table('saved_queries_versions').insert(
+                otherCharts.map((chart) => ({
+                    saved_query_id: chart.saved_query_id,
+                    updated_by_user_uuid: spaceViewer,
+                    created_at: database.raw("CURRENT_DATE - interval '1 day'"),
+                })),
+            );
+
+            expect(await readActivity()).toEqual(before);
+            const otherActivity = await rows<{
+                user_uuid: string;
+                count: string;
+            }>(tableMostQueriesSql(userUuids, otherProjectUuid));
+            expect(otherActivity).toEqual([
+                expect.objectContaining({ user_uuid: spaceViewer, count: '2' }),
+            ]);
+            const otherViews = await rows<{ uuid: string }>(
+                chartViewsSql(otherProjectUuid),
+            );
+            expect(otherViews.map(({ uuid }) => uuid).sort()).toEqual(
+                otherCharts
+                    .map(({ saved_query_uuid }) => saved_query_uuid)
+                    .sort(),
+            );
+        },
+    );
 
     it('includes anonymous dashboard views only in chart-level totals', async () => {
         await table('analytics_chart_views').insert({

--- a/packages/backend/src/models/AnalyticsModel.integration.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.integration.test.ts
@@ -1,12 +1,17 @@
 import knex, { type Knex } from 'knex';
 import { randomUUID } from 'node:crypto';
+import { AnalyticsModel } from './AnalyticsModel';
 import {
     chartViewsSql,
     chartWeeklyAverageQueriesSql,
     chartWeeklyQueryingUsersSql,
+    dashboardViewsSql,
     numberWeeklyQueryingUsersSql,
     tableMostCreatedChartsSql,
     tableMostQueriesSql,
+    tableNoQueriesSql,
+    userMostViewedDashboardSql,
+    usersInProjectSql,
 } from './AnalyticsModelSql';
 
 type ChartRow = {
@@ -21,6 +26,7 @@ type ChartRow = {
 };
 
 type FixtureTables = {
+    emails: { user_id: number; is_primary: boolean };
     projects: {
         project_id: number;
         project_uuid: string;
@@ -52,6 +58,11 @@ type FixtureTables = {
         timestamp: Date;
         context: { source: 'dashboard'; dashboardUuid: string } | null;
     };
+    analytics_dashboard_views: {
+        dashboard_uuid: string;
+        user_uuid: string | null;
+        timestamp: Date;
+    };
     saved_queries_versions: {
         saved_query_id: number;
         updated_by_user_uuid: string;
@@ -61,8 +72,10 @@ type FixtureTables = {
 
 describe('AnalyticsModel (PostgreSQL)', () => {
     let database: Knex;
+    let model: AnalyticsModel;
     const schema = `analytics_test_${randomUUID().replaceAll('-', '')}`;
     const projectUuid = randomUUID();
+    const organizationUuid = randomUUID();
     const otherProjectUuid = randomUUID();
     const dashboardUuid = randomUUID();
     const otherDashboardUuid = randomUUID();
@@ -90,14 +103,11 @@ describe('AnalyticsModel (PostgreSQL)', () => {
         slug: 'dashboard-chart',
     };
 
-    const rows = async <T>(sql: string): Promise<T[]> => {
-        // Scope the explicitly qualified chart-views query to the fixture schema.
-        const result = await database.raw<{ rows: T[] }>(
-            sql.replaceAll(
-                'public.analytics_chart_views',
-                `${schema}.analytics_chart_views`,
-            ),
-        );
+    const rows = async <T>(
+        sql: string,
+        bindings: Knex.ValueDict = { projectUuid, userUuids, organizationUuid },
+    ): Promise<T[]> => {
+        const result = await database.raw<{ rows: T[] }>(sql, bindings);
         return result.rows;
     };
 
@@ -119,12 +129,19 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             searchPath: [schema],
             pool: { min: 0, max: 2 },
         });
+        model = new AnalyticsModel({ database });
         await database.schema.createSchema(schema);
         await database.raw(`
             CREATE TABLE projects (project_id integer PRIMARY KEY, project_uuid uuid UNIQUE NOT NULL, organization_id integer NOT NULL);
             CREATE TABLE spaces (space_id integer PRIMARY KEY, project_id integer REFERENCES projects, name text, deleted_at timestamp);
             CREATE TABLE dashboards (dashboard_uuid uuid PRIMARY KEY, project_uuid uuid, space_id integer REFERENCES spaces, name text, slug text, deleted_at timestamp);
-            CREATE TABLE users (user_uuid uuid PRIMARY KEY, first_name text, last_name text, created_at timestamp);
+            CREATE TABLE users (user_uuid uuid PRIMARY KEY, user_id serial UNIQUE, first_name text, last_name text, created_at timestamp, is_internal boolean DEFAULT false);
+            CREATE TABLE emails (user_id integer REFERENCES users(user_id), is_primary boolean);
+            CREATE TABLE organizations (organization_id integer PRIMARY KEY, organization_uuid uuid UNIQUE);
+            CREATE TABLE organization_memberships (organization_id integer REFERENCES organizations, user_id integer REFERENCES users(user_id), role text, role_uuid uuid);
+            CREATE TABLE project_memberships (project_id integer REFERENCES projects, user_id integer REFERENCES users(user_id), role text);
+            CREATE TABLE group_memberships (group_uuid uuid, user_id integer REFERENCES users(user_id));
+            CREATE TABLE project_group_access (group_uuid uuid, project_uuid uuid REFERENCES projects(project_uuid), role text);
             CREATE TABLE saved_queries (
                 saved_query_id integer PRIMARY KEY, saved_query_uuid uuid UNIQUE NOT NULL,
                 project_uuid uuid NOT NULL REFERENCES projects(project_uuid), space_id integer REFERENCES spaces,
@@ -132,6 +149,7 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             );
             CREATE TABLE saved_queries_versions (saved_query_id integer REFERENCES saved_queries, updated_by_user_uuid uuid REFERENCES users, created_at timestamp);
             CREATE TABLE analytics_chart_views (chart_uuid uuid REFERENCES saved_queries(saved_query_uuid), user_uuid uuid REFERENCES users, timestamp timestamp NOT NULL, context jsonb);
+            CREATE TABLE analytics_dashboard_views (dashboard_uuid uuid REFERENCES dashboards, user_uuid uuid REFERENCES users, timestamp timestamp NOT NULL);
         `);
         await table('projects').insert([
             { project_id: 1, project_uuid: projectUuid, organization_id: 1 },
@@ -169,12 +187,27 @@ describe('AnalyticsModel (PostgreSQL)', () => {
                 created_at: database.raw("CURRENT_DATE - interval '100 days'"),
             })),
         );
+        await database.raw(
+            'INSERT INTO organizations VALUES (1, :organizationUuid)',
+            { organizationUuid },
+        );
+        await database.raw(`
+            INSERT INTO emails SELECT user_id, true FROM users;
+            INSERT INTO organization_memberships SELECT 1, user_id, 'admin', NULL FROM users;
+        `);
     });
 
     beforeEach(async () => {
         await database.raw(
-            'TRUNCATE analytics_chart_views, saved_queries_versions, saved_queries',
+            'TRUNCATE analytics_chart_views, analytics_dashboard_views, saved_queries_versions, saved_queries',
         );
+        await table('spaces').update({ deleted_at: null });
+        await table('dashboards').update({ deleted_at: null });
+        await table('emails').update({ is_primary: true });
+        await table('users').update({
+            first_name: 'Viewer',
+            created_at: database.raw("CURRENT_DATE - interval '100 days'"),
+        });
         await database<ChartRow>('saved_queries').insert([
             spaceChart,
             dashboardChart,
@@ -221,15 +254,81 @@ describe('AnalyticsModel (PostgreSQL)', () => {
         }
     });
 
-    it('includes dashboard-only viewers in weekly querying users', async () => {
+    const userQueries = [
+        numberWeeklyQueryingUsersSql,
+        tableMostQueriesSql,
+        tableMostCreatedChartsSql,
+        tableNoQueriesSql,
+        chartWeeklyQueryingUsersSql,
+        chartWeeklyAverageQueriesSql,
+    ];
+
+    it.each([
+        ...userQueries,
+        chartViewsSql,
+        dashboardViewsSql,
+        userMostViewedDashboardSql,
+        usersInProjectSql,
+    ])('rejects SQL syntax in the project binding for %s', async (query) => {
+        await expect(
+            rows(query(), {
+                projectUuid: `${projectUuid}' OR '1' = '1`,
+                userUuids,
+                organizationUuid,
+            }),
+        ).rejects.toMatchObject({ code: '22P02' });
+    });
+
+    it.each(userQueries)(
+        'rejects SQL syntax in user bindings for %s',
+        async (query) => {
+            await expect(
+                rows(query(), {
+                    projectUuid,
+                    userUuids: [`${spaceViewer}') OR true --`],
+                }),
+            ).rejects.toMatchObject({ code: '22P02' });
+        },
+    );
+
+    it('rejects SQL syntax in the organization binding', async () => {
+        await expect(
+            model.getUserActivity(
+                projectUuid,
+                `${organizationUuid}' OR true --`,
+            ),
+        ).rejects.toMatchObject({ code: '22P02' });
+    });
+
+    it('executes User Activity with bound parameters and an empty or populated user list', async () => {
+        const activity = await model.getUserActivity(
+            projectUuid,
+            organizationUuid,
+        );
+        expect(activity).toMatchObject({
+            numberUsers: 3,
+            numberWeeklyQueryingUsers: 66,
+        });
+        expect(activity.chartViews).toHaveLength(2);
+        await table('emails').update({ is_primary: false });
         expect(
-            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
-        ).toEqual([{ count: '66' }]);
+            await model.getUserActivity(projectUuid, organizationUuid),
+        ).toMatchObject({
+            numberUsers: 0,
+            numberWeeklyQueryingUsers: 0,
+            tableMostQueries: [],
+        });
+    });
+
+    it('includes dashboard-only viewers in weekly querying users', async () => {
+        expect(await rows(numberWeeklyQueryingUsersSql())).toEqual([
+            { count: '66' },
+        ]);
     });
 
     it('counts repeated chart views for the most-active users', async () => {
         const result = await rows<{ user_uuid: string; count: string }>(
-            tableMostQueriesSql(userUuids, projectUuid),
+            tableMostQueriesSql(),
         );
         expect(
             result.map(({ user_uuid, count }) => ({ user_uuid, count })),
@@ -241,7 +340,7 @@ describe('AnalyticsModel (PostgreSQL)', () => {
 
     it('includes dashboard chart versions in chart-update counts', async () => {
         const result = await rows<{ user_uuid: string; count: string }>(
-            tableMostCreatedChartsSql(userUuids, projectUuid),
+            tableMostCreatedChartsSql(),
         );
         expect(result).toHaveLength(2);
         expect(result).toContainEqual(
@@ -253,10 +352,10 @@ describe('AnalyticsModel (PostgreSQL)', () => {
         const querying = await rows<{
             num_7d_active_users: string;
             percent_7d_active_users: string;
-        }>(chartWeeklyQueryingUsersSql(userUuids, projectUuid));
+        }>(chartWeeklyQueryingUsersSql());
         const averages = await rows<{
             average_number_of_weekly_queries_per_user: string;
-        }>(chartWeeklyAverageQueriesSql(userUuids, projectUuid));
+        }>(chartWeeklyAverageQueriesSql());
         expect(querying[0]).toMatchObject({
             num_7d_active_users: '2',
             percent_7d_active_users: '66',
@@ -309,17 +408,15 @@ describe('AnalyticsModel (PostgreSQL)', () => {
                 timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
             })),
         );
-        expect(
-            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
-        ).toEqual([{ count: '66' }]);
-        expect(
-            await rows(tableMostQueriesSql(userUuids, projectUuid)),
-        ).toHaveLength(2);
+        expect(await rows(numberWeeklyQueryingUsersSql())).toEqual([
+            { count: '66' },
+        ]);
+        expect(await rows(tableMostQueriesSql())).toHaveLength(2);
         const querying = await rows<{ num_7d_active_users: string }>(
-            chartWeeklyQueryingUsersSql(userUuids, projectUuid),
+            chartWeeklyQueryingUsersSql(),
         );
         expect(querying[0].num_7d_active_users).toBe('2');
-        const charts = await rows<{ uuid: string }>(chartViewsSql(projectUuid));
+        const charts = await rows<{ uuid: string }>(chartViewsSql());
         expect(charts.map(({ uuid }) => uuid).sort()).toEqual(
             [
                 spaceChart.saved_query_uuid,
@@ -338,12 +435,12 @@ describe('AnalyticsModel (PostgreSQL)', () => {
                 .where('project_uuid', otherProjectUuid)
                 .update({ organization_id: organizationId });
             const queries = [
-                numberWeeklyQueryingUsersSql(userUuids, projectUuid),
-                tableMostQueriesSql(userUuids, projectUuid),
-                tableMostCreatedChartsSql(userUuids, projectUuid),
-                chartWeeklyQueryingUsersSql(userUuids, projectUuid),
-                chartWeeklyAverageQueriesSql(userUuids, projectUuid),
-                chartViewsSql(projectUuid),
+                numberWeeklyQueryingUsersSql(),
+                tableMostQueriesSql(),
+                tableMostCreatedChartsSql(),
+                chartWeeklyQueryingUsersSql(),
+                chartWeeklyAverageQueriesSql(),
+                chartViewsSql(),
             ];
             const readActivity = () =>
                 Promise.all(
@@ -390,13 +487,16 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             const otherActivity = await rows<{
                 user_uuid: string;
                 count: string;
-            }>(tableMostQueriesSql(userUuids, otherProjectUuid));
+            }>(tableMostQueriesSql(), {
+                projectUuid: otherProjectUuid,
+                userUuids,
+            });
             expect(otherActivity).toEqual([
                 expect.objectContaining({ user_uuid: spaceViewer, count: '2' }),
             ]);
-            const otherViews = await rows<{ uuid: string }>(
-                chartViewsSql(otherProjectUuid),
-            );
+            const otherViews = await rows<{ uuid: string }>(chartViewsSql(), {
+                projectUuid: otherProjectUuid,
+            });
             expect(otherViews.map(({ uuid }) => uuid).sort()).toEqual(
                 otherCharts
                     .map(({ saved_query_uuid }) => saved_query_uuid)
@@ -411,23 +511,23 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             user_uuid: null,
             timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
         });
-        expect(await rows(chartViewsSql(projectUuid))).toContainEqual({
+        expect(await rows(chartViewsSql())).toContainEqual({
             uuid: dashboardChart.saved_query_uuid,
             name: dashboardChart.name,
             slug: dashboardChart.slug,
             count: '3',
         });
-        expect(
-            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
-        ).toEqual([{ count: '66' }]);
+        expect(await rows(numberWeeklyQueryingUsersSql())).toEqual([
+            { count: '66' },
+        ]);
     });
 
     it('keeps historical views when a dashboard chart moves to a space', async () => {
-        const before = await rows(chartViewsSql(projectUuid));
+        const before = await rows(chartViewsSql());
         await database<ChartRow>('saved_queries')
             .where('saved_query_uuid', dashboardChart.saved_query_uuid)
             .update({ space_id: 1, dashboard_uuid: null });
-        expect(await rows(chartViewsSql(projectUuid))).toEqual(before);
+        expect(await rows(chartViewsSql())).toEqual(before);
         expect(before).toHaveLength(2);
     });
 });

--- a/packages/backend/src/models/AnalyticsModel.integration.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.integration.test.ts
@@ -199,7 +199,7 @@ describe('AnalyticsModel (PostgreSQL)', () => {
 
     beforeEach(async () => {
         await database.raw(
-            'TRUNCATE analytics_chart_views, analytics_dashboard_views, saved_queries_versions, saved_queries',
+            'TRUNCATE analytics_chart_views, analytics_dashboard_views, saved_queries_versions, saved_queries, project_memberships, group_memberships, project_group_access',
         );
         await table('spaces').update({ deleted_at: null });
         await table('dashboards').update({ deleted_at: null });
@@ -318,6 +318,163 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             numberWeeklyQueryingUsers: 0,
             tableMostQueries: [],
         });
+    });
+
+    it.each(['direct', 'group'] as const)(
+        'does not use %s membership roles from another project',
+        async (membership) => {
+            if (membership === 'direct') {
+                await database.raw(
+                    `INSERT INTO project_memberships
+                     SELECT 2, user_id, 'viewer' FROM users WHERE user_uuid = :spaceViewer`,
+                    { spaceViewer },
+                );
+            } else {
+                const groupUuid = randomUUID();
+                await database.raw(
+                    `INSERT INTO group_memberships
+                     SELECT :groupUuid, user_id FROM users WHERE user_uuid = :spaceViewer`,
+                    { groupUuid, spaceViewer },
+                );
+                await database.raw(
+                    "INSERT INTO project_group_access VALUES (:groupUuid, :otherProjectUuid, 'viewer')",
+                    { groupUuid, otherProjectUuid },
+                );
+            }
+            expect(
+                await model.getUserActivity(projectUuid, organizationUuid),
+            ).toMatchObject({
+                numberUsers: 3,
+                numberAdmins: 3,
+                numberViewers: 0,
+            });
+        },
+    );
+
+    it.each(['dashboard', 'space'] as const)(
+        'excludes activity with a deleted owning %s throughout User Activity',
+        async (owner) => {
+            await table('analytics_dashboard_views').insert({
+                dashboard_uuid: dashboardUuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+            });
+            if (owner === 'dashboard') {
+                await table('dashboards')
+                    .where('dashboard_uuid', dashboardUuid)
+                    .update({ deleted_at: new Date() });
+            } else {
+                await table('spaces')
+                    .where('space_id', 1)
+                    .update({ deleted_at: new Date() });
+            }
+            const activity = await model.getUserActivity(
+                projectUuid,
+                organizationUuid,
+            );
+            const expectedUsers = owner === 'dashboard' ? [spaceViewer] : [];
+            expect(activity.numberWeeklyQueryingUsers).toBe(
+                owner === 'dashboard' ? 33 : 0,
+            );
+            expect(
+                activity.tableMostQueries.map(({ userUuid }) => userUuid),
+            ).toEqual(expectedUsers);
+            expect(
+                activity.tableMostCreatedCharts.map(({ userUuid }) => userUuid),
+            ).toEqual(expectedUsers);
+            expect(activity.chartViews.map(({ uuid }) => uuid)).toEqual(
+                owner === 'dashboard' ? [spaceChart.saved_query_uuid] : [],
+            );
+            expect(
+                activity.chartWeeklyQueryingUsers[0].num_7d_active_users,
+            ).toBe(owner === 'dashboard' ? '1' : '0');
+            expect(activity.dashboardViews).toEqual([]);
+            expect(activity.userMostViewedDashboards).toEqual([]);
+        },
+    );
+
+    it.each(['space', 'dashboard'] as const)(
+        'rejects chart activity with an owning %s in another project',
+        async (owner) => {
+            await database<ChartRow>('saved_queries')
+                .where('saved_query_uuid', dashboardChart.saved_query_uuid)
+                .update(
+                    owner === 'space'
+                        ? { space_id: 2, dashboard_uuid: null }
+                        : { dashboard_uuid: otherDashboardUuid },
+                );
+            const activity = await model.getUserActivity(
+                projectUuid,
+                organizationUuid,
+            );
+            expect(activity.numberWeeklyQueryingUsers).toBe(33);
+            expect(activity.chartViews.map(({ uuid }) => uuid)).toEqual([
+                spaceChart.saved_query_uuid,
+            ]);
+        },
+    );
+
+    it('keeps favourite dashboards separate for users with the same first name', async () => {
+        await table('analytics_dashboard_views').insert(
+            [spaceViewer, dashboardViewer].map((userUuid) => ({
+                dashboard_uuid: dashboardUuid,
+                user_uuid: userUuid,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+            })),
+        );
+        const activity = await model.getUserActivity(
+            projectUuid,
+            organizationUuid,
+        );
+        expect(
+            activity.userMostViewedDashboards
+                .map(({ userUuid }) => userUuid)
+                .sort(),
+        ).toEqual([spaceViewer, dashboardViewer].sort());
+    });
+
+    it('uses the latest project chart view for inactivity and ignores other projects', async () => {
+        await table('analytics_chart_views')
+            .where('user_uuid', spaceViewer)
+            .update({
+                timestamp: database.raw("CURRENT_DATE - interval '120 days'"),
+            });
+        await table('analytics_chart_views').insert({
+            chart_uuid: dashboardChart.saved_query_uuid,
+            user_uuid: dashboardViewer,
+            timestamp: database.raw("CURRENT_DATE - interval '180 days'"),
+        });
+        const otherChart = {
+            ...spaceChart,
+            saved_query_id: 3,
+            saved_query_uuid: randomUUID(),
+            project_uuid: otherProjectUuid,
+            space_id: 2,
+        };
+        await database<ChartRow>('saved_queries').insert(otherChart);
+        await table('analytics_chart_views').insert({
+            chart_uuid: otherChart.saved_query_uuid,
+            user_uuid: inactiveViewer,
+            timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+        });
+        const inactive = await rows<{ user_uuid: string; count: string }>(
+            tableNoQueriesSql(),
+        );
+        expect(
+            inactive.map(({ user_uuid, count }) => ({ user_uuid, count })),
+        ).toEqual(
+            expect.arrayContaining([
+                { user_uuid: spaceViewer, count: '120' },
+                { user_uuid: inactiveViewer, count: '100' },
+            ]),
+        );
+        expect(inactive).toHaveLength(2);
+        await table('users')
+            .where('user_uuid', inactiveViewer)
+            .update({
+                created_at: database.raw("CURRENT_DATE - interval '10 days'"),
+            });
+        expect(await rows(tableNoQueriesSql())).toHaveLength(1);
     });
 
     it('includes dashboard-only viewers in weekly querying users', async () => {

--- a/packages/backend/src/models/AnalyticsModel.integration.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.integration.test.ts
@@ -1,0 +1,348 @@
+import knex, { type Knex } from 'knex';
+import { randomUUID } from 'node:crypto';
+import {
+    chartViewsSql,
+    chartWeeklyAverageQueriesSql,
+    chartWeeklyQueryingUsersSql,
+    numberWeeklyQueryingUsersSql,
+    tableMostCreatedChartsSql,
+    tableMostQueriesSql,
+} from './AnalyticsModelSql';
+
+type ChartRow = {
+    saved_query_id: number;
+    saved_query_uuid: string;
+    project_uuid: string;
+    space_id: number | null;
+    dashboard_uuid: string | null;
+    deleted_at: Date | null;
+    name: string;
+    slug: string;
+};
+
+type FixtureTables = {
+    projects: { project_id: number; project_uuid: string };
+    spaces: {
+        space_id: number;
+        project_id: number;
+        name: string;
+        deleted_at: Date | null;
+    };
+    dashboards: {
+        dashboard_uuid: string;
+        project_uuid: string;
+        space_id: number;
+        name: string;
+        slug: string;
+        deleted_at: Date | null;
+    };
+    users: {
+        user_uuid: string;
+        first_name: string;
+        last_name: string;
+        created_at: Date;
+    };
+    analytics_chart_views: {
+        chart_uuid: string;
+        user_uuid: string | null;
+        timestamp: Date;
+        context: { source: 'dashboard'; dashboardUuid: string } | null;
+    };
+    saved_queries_versions: {
+        saved_query_id: number;
+        updated_by_user_uuid: string;
+        created_at: Date;
+    };
+};
+
+describe('AnalyticsModel (PostgreSQL)', () => {
+    let database: Knex;
+    const schema = `analytics_test_${randomUUID().replaceAll('-', '')}`;
+    const projectUuid = randomUUID();
+    const otherProjectUuid = randomUUID();
+    const dashboardUuid = randomUUID();
+    const otherDashboardUuid = randomUUID();
+    const spaceViewer = randomUUID();
+    const dashboardViewer = randomUUID();
+    const inactiveViewer = randomUUID();
+    const userUuids = [spaceViewer, dashboardViewer, inactiveViewer];
+    const spaceChart: ChartRow = {
+        saved_query_id: 1,
+        saved_query_uuid: randomUUID(),
+        project_uuid: projectUuid,
+        space_id: 1,
+        dashboard_uuid: null,
+        deleted_at: null,
+        name: 'Space chart',
+        slug: 'space-chart',
+    };
+    const dashboardChart: ChartRow = {
+        ...spaceChart,
+        saved_query_id: 2,
+        saved_query_uuid: randomUUID(),
+        space_id: null,
+        dashboard_uuid: dashboardUuid,
+        name: 'Dashboard chart',
+        slug: 'dashboard-chart',
+    };
+
+    const rows = async <T>(sql: string): Promise<T[]> => {
+        // Scope the explicitly qualified chart-views query to the fixture schema.
+        const result = await database.raw<{ rows: T[] }>(
+            sql.replaceAll(
+                'public.analytics_chart_views',
+                `${schema}.analytics_chart_views`,
+            ),
+        );
+        return result.rows;
+    };
+
+    const table = <T extends keyof FixtureTables>(name: T) =>
+        database<FixtureTables[T]>(name);
+
+    beforeAll(async () => {
+        const connection =
+            process.env.ANALYTICS_TEST_DATABASE_URL ??
+            process.env.PGCONNECTIONURI;
+        if (!connection) {
+            throw new Error(
+                'Set ANALYTICS_TEST_DATABASE_URL or PGCONNECTIONURI for PostgreSQL tests',
+            );
+        }
+        database = knex({
+            client: 'pg',
+            connection,
+            searchPath: [schema],
+            pool: { min: 0, max: 2 },
+        });
+        await database.schema.createSchema(schema);
+        await database.raw(`
+            CREATE TABLE projects (project_id integer PRIMARY KEY, project_uuid uuid UNIQUE NOT NULL);
+            CREATE TABLE spaces (space_id integer PRIMARY KEY, project_id integer REFERENCES projects, name text, deleted_at timestamp);
+            CREATE TABLE dashboards (dashboard_uuid uuid PRIMARY KEY, project_uuid uuid, space_id integer REFERENCES spaces, name text, slug text, deleted_at timestamp);
+            CREATE TABLE users (user_uuid uuid PRIMARY KEY, first_name text, last_name text, created_at timestamp);
+            CREATE TABLE saved_queries (
+                saved_query_id integer PRIMARY KEY, saved_query_uuid uuid UNIQUE NOT NULL,
+                project_uuid uuid NOT NULL REFERENCES projects(project_uuid), space_id integer REFERENCES spaces,
+                dashboard_uuid uuid REFERENCES dashboards, deleted_at timestamp, name text, slug text
+            );
+            CREATE TABLE saved_queries_versions (saved_query_id integer REFERENCES saved_queries, updated_by_user_uuid uuid REFERENCES users, created_at timestamp);
+            CREATE TABLE analytics_chart_views (chart_uuid uuid REFERENCES saved_queries(saved_query_uuid), user_uuid uuid REFERENCES users, timestamp timestamp NOT NULL, context jsonb);
+        `);
+        await table('projects').insert([
+            { project_id: 1, project_uuid: projectUuid },
+            { project_id: 2, project_uuid: otherProjectUuid },
+        ]);
+        await table('spaces').insert([
+            { space_id: 1, project_id: 1, name: 'Main space' },
+            { space_id: 2, project_id: 2, name: 'Other space' },
+        ]);
+        await table('dashboards').insert([
+            {
+                dashboard_uuid: dashboardUuid,
+                project_uuid: projectUuid,
+                space_id: 1,
+                name: 'Dashboard',
+                slug: 'dashboard',
+            },
+            {
+                dashboard_uuid: otherDashboardUuid,
+                project_uuid: otherProjectUuid,
+                space_id: 2,
+                name: 'Other dashboard',
+                slug: 'other-dashboard',
+            },
+        ]);
+        await table('users').insert(
+            userUuids.map((userUuid, index) => ({
+                user_uuid: userUuid,
+                first_name: `Viewer ${index}`,
+                last_name: 'Test',
+                created_at: database.raw("CURRENT_DATE - interval '100 days'"),
+            })),
+        );
+    });
+
+    beforeEach(async () => {
+        await database.raw(
+            'TRUNCATE analytics_chart_views, saved_queries_versions, saved_queries',
+        );
+        await database<ChartRow>('saved_queries').insert([
+            spaceChart,
+            dashboardChart,
+        ]);
+        await table('analytics_chart_views').insert([
+            {
+                chart_uuid: spaceChart.saved_query_uuid,
+                user_uuid: spaceViewer,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+            },
+            {
+                chart_uuid: dashboardChart.saved_query_uuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+                context: { source: 'dashboard', dashboardUuid },
+            },
+            {
+                chart_uuid: dashboardChart.saved_query_uuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw(
+                    "CURRENT_DATE - interval '1 day' + interval '1 second'",
+                ),
+                context: { source: 'dashboard', dashboardUuid },
+            },
+        ]);
+        await table('saved_queries_versions').insert([
+            {
+                saved_query_id: 1,
+                updated_by_user_uuid: spaceViewer,
+                created_at: database.raw("CURRENT_DATE - interval '1 day'"),
+            },
+            {
+                saved_query_id: 2,
+                updated_by_user_uuid: dashboardViewer,
+                created_at: database.raw("CURRENT_DATE - interval '1 day'"),
+            },
+        ]);
+    });
+
+    afterAll(async () => {
+        if (database) {
+            await database.schema.dropSchemaIfExists(schema, true);
+            await database.destroy();
+        }
+    });
+
+    it('includes dashboard-only viewers in weekly querying users', async () => {
+        expect(
+            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
+        ).toEqual([{ count: '66' }]);
+    });
+
+    it('counts repeated chart views for the most-active users', async () => {
+        const result = await rows<{ user_uuid: string; count: string }>(
+            tableMostQueriesSql(userUuids, projectUuid),
+        );
+        expect(
+            result.map(({ user_uuid, count }) => ({ user_uuid, count })),
+        ).toEqual([
+            { user_uuid: dashboardViewer, count: '2' },
+            { user_uuid: spaceViewer, count: '1' },
+        ]);
+    });
+
+    it('includes dashboard chart versions in chart-update counts', async () => {
+        const result = await rows<{ user_uuid: string; count: string }>(
+            tableMostCreatedChartsSql(userUuids, projectUuid),
+        );
+        expect(result).toHaveLength(2);
+        expect(result).toContainEqual(
+            expect.objectContaining({ user_uuid: dashboardViewer, count: '1' }),
+        );
+    });
+
+    it('includes dashboard views in rolling histories without changing distinct-chart counting', async () => {
+        const querying = await rows<{
+            num_7d_active_users: string;
+            percent_7d_active_users: string;
+        }>(chartWeeklyQueryingUsersSql(userUuids, projectUuid));
+        const averages = await rows<{
+            average_number_of_weekly_queries_per_user: string;
+        }>(chartWeeklyAverageQueriesSql(userUuids, projectUuid));
+        expect(querying[0]).toMatchObject({
+            num_7d_active_users: '2',
+            percent_7d_active_users: '66',
+        });
+        expect(averages[0].average_number_of_weekly_queries_per_user).toBe(
+            '1.00',
+        );
+    });
+
+    it('excludes other projects, deleted charts, and ownerless legacy charts', async () => {
+        const excluded: ChartRow[] = [
+            {
+                ...spaceChart,
+                saved_query_id: 3,
+                saved_query_uuid: randomUUID(),
+                project_uuid: otherProjectUuid,
+                space_id: 2,
+            },
+            {
+                ...dashboardChart,
+                saved_query_id: 4,
+                saved_query_uuid: randomUUID(),
+                project_uuid: otherProjectUuid,
+                dashboard_uuid: otherDashboardUuid,
+            },
+            {
+                ...spaceChart,
+                saved_query_id: 5,
+                saved_query_uuid: randomUUID(),
+                deleted_at: new Date(),
+            },
+            {
+                ...dashboardChart,
+                saved_query_id: 6,
+                saved_query_uuid: randomUUID(),
+                deleted_at: new Date(),
+            },
+            {
+                ...spaceChart,
+                saved_query_id: 7,
+                saved_query_uuid: randomUUID(),
+                space_id: null,
+            },
+        ];
+        await database<ChartRow>('saved_queries').insert(excluded);
+        await table('analytics_chart_views').insert(
+            excluded.map((chart) => ({
+                chart_uuid: chart.saved_query_uuid,
+                user_uuid: inactiveViewer,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+            })),
+        );
+        expect(
+            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
+        ).toEqual([{ count: '66' }]);
+        expect(
+            await rows(tableMostQueriesSql(userUuids, projectUuid)),
+        ).toHaveLength(2);
+        const querying = await rows<{ num_7d_active_users: string }>(
+            chartWeeklyQueryingUsersSql(userUuids, projectUuid),
+        );
+        expect(querying[0].num_7d_active_users).toBe('2');
+        const charts = await rows<{ uuid: string }>(chartViewsSql(projectUuid));
+        expect(charts.map(({ uuid }) => uuid).sort()).toEqual(
+            [
+                spaceChart.saved_query_uuid,
+                dashboardChart.saved_query_uuid,
+            ].sort(),
+        );
+    });
+
+    it('includes anonymous dashboard views only in chart-level totals', async () => {
+        await table('analytics_chart_views').insert({
+            chart_uuid: dashboardChart.saved_query_uuid,
+            user_uuid: null,
+            timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+        });
+        expect(await rows(chartViewsSql(projectUuid))).toContainEqual({
+            uuid: dashboardChart.saved_query_uuid,
+            name: dashboardChart.name,
+            slug: dashboardChart.slug,
+            count: '3',
+        });
+        expect(
+            await rows(numberWeeklyQueryingUsersSql(userUuids, projectUuid)),
+        ).toEqual([{ count: '66' }]);
+    });
+
+    it('keeps historical views when a dashboard chart moves to a space', async () => {
+        const before = await rows(chartViewsSql(projectUuid));
+        await database<ChartRow>('saved_queries')
+            .where('saved_query_uuid', dashboardChart.saved_query_uuid)
+            .update({ space_id: 1, dashboard_uuid: null });
+        expect(await rows(chartViewsSql(projectUuid))).toEqual(before);
+        expect(before).toHaveLength(2);
+    });
+});

--- a/packages/backend/src/models/AnalyticsModel.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.test.ts
@@ -52,10 +52,7 @@ describe('AnalyticsModel', () => {
     );
 
     it('includes organization custom-role users in the project population', () => {
-        const sql = usersInProjectSql(projectUuid, organizationUuid).replace(
-            /\s+/g,
-            ' ',
-        );
+        const sql = usersInProjectSql().replace(/\s+/g, ' ');
 
         expect(sql).toContain(
             "organization_memberships.role != 'member' OR organization_memberships.role_uuid IS NOT NULL",
@@ -70,12 +67,10 @@ describe('AnalyticsModel', () => {
             .any(/100 \* COUNT\(DISTINCT\(user_uuid\)\) \/ 0/i)
             .response({ rows: [{ count: '0' }] });
         tracker.on
-            .any(/FROM public\.analytics_dashboard_views dv/i)
+            .any(/FROM analytics_dashboard_views dv/i)
             .response({ rows: [] });
         tracker.on.any(/WITH RankedResults AS/i).response({ rows: [] });
-        tracker.on
-            .any(/FROM public\.analytics_chart_views/i)
-            .response({ rows: [] });
+        tracker.on.any(/FROM analytics_chart_views/i).response({ rows: [] });
         tracker.on.any(() => true).response({ rows: [] });
 
         await expect(

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -221,11 +221,13 @@ export class AnalyticsModel {
         organizationUuid: string,
     ): Promise<UserActivity> {
         const usersInProjectQuery = await this.database.raw(
-            usersInProjectSql(projectUuid, organizationUuid),
+            usersInProjectSql(),
+            { projectUuid, organizationUuid },
         );
         const usersInProject: { user_uuid: string; role: string }[] =
             usersInProjectQuery.rows;
         const userUuids = usersInProject.map((user) => user.user_uuid);
+        const activityBindings = { projectUuid, userUuids };
         const parseUsersWithCount = (
             userData: DbUserWithCount,
         ): UserWithCount => ({
@@ -245,7 +247,8 @@ export class AnalyticsModel {
 
         if (userUuids.length > 0) {
             const numberWeeklyQueryingUsersQuery = await this.database.raw(
-                numberWeeklyQueryingUsersSql(userUuids, projectUuid),
+                numberWeeklyQueryingUsersSql(),
+                activityBindings,
             );
             numberWeeklyQueryingUsers = parseInt(
                 numberWeeklyQueryingUsersQuery.rows[0].count,
@@ -253,36 +256,41 @@ export class AnalyticsModel {
             );
 
             const tableMostQueriesQuery = await this.database.raw(
-                tableMostQueriesSql(userUuids, projectUuid),
+                tableMostQueriesSql(),
+                activityBindings,
             );
             tableMostQueries =
                 tableMostQueriesQuery.rows.map(parseUsersWithCount);
 
             const tableMostCreatedChartsQuery = await this.database.raw(
-                tableMostCreatedChartsSql(userUuids, projectUuid),
+                tableMostCreatedChartsSql(),
+                activityBindings,
             );
             tableMostCreatedCharts =
                 tableMostCreatedChartsQuery.rows.map(parseUsersWithCount);
 
             const tableNoQueriesQuery = await this.database.raw(
-                tableNoQueriesSql(userUuids, projectUuid),
+                tableNoQueriesSql(),
+                activityBindings,
             );
             tableNoQueries = tableNoQueriesQuery.rows.map(parseUsersWithCount);
 
             const chartWeeklyQueryingUsersQuery = await this.database.raw(
-                chartWeeklyQueryingUsersSql(userUuids, projectUuid),
+                chartWeeklyQueryingUsersSql(),
+                activityBindings,
             );
             chartWeeklyQueryingUsers = chartWeeklyQueryingUsersQuery.rows;
 
             const chartWeeklyAverageQueriesQuery = await this.database.raw(
-                chartWeeklyAverageQueriesSql(userUuids, projectUuid),
+                chartWeeklyAverageQueriesSql(),
+                activityBindings,
             );
             chartWeeklyAverageQueries = chartWeeklyAverageQueriesQuery.rows;
         }
 
-        const dashboardViews = await this.database.raw(
-            dashboardViewsSql(projectUuid),
-        );
+        const dashboardViews = await this.database.raw(dashboardViewsSql(), {
+            projectUuid,
+        });
 
         const userMostViewedDashboards = await this.database.raw<{
             rows: {
@@ -294,8 +302,10 @@ export class AnalyticsModel {
                 dashboard_name: string;
                 count: number;
             }[];
-        }>(userMostViewedDashboardSql(projectUuid));
-        const chartViews = await this.database.raw(chartViewsSql(projectUuid));
+        }>(userMostViewedDashboardSql(), { projectUuid });
+        const chartViews = await this.database.raw(chartViewsSql(), {
+            projectUuid,
+        });
 
         return {
             numberUsers: usersInProject.length,

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -2,10 +2,7 @@ import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 
-export const usersInProjectSql = (
-    projectUuid: string,
-    organizationUuid: string,
-) => `
+export const usersInProjectSql = () => `
 SELECT
   DISTINCT ON (users.user_uuid) user_uuid,
   COALESCE(project_memberships.role, project_group_access.role, organization_memberships.role) as role
@@ -23,32 +20,26 @@ WHERE
   AND (
       ((organization_memberships.role != 'member'
         OR organization_memberships.role_uuid IS NOT NULL)
-        AND organization_uuid = '${organizationUuid}')
+        AND organization_uuid = :organizationUuid)
   OR
-      (projects.project_uuid = '${projectUuid}')
+      (projects.project_uuid = :projectUuid)
   OR (
-    project_group_access.project_uuid = '${projectUuid}'
+    project_group_access.project_uuid = :projectUuid
   ))
 `;
 
-export const numberWeeklyQueryingUsersSql = (
-    userUuids: string[],
-    projectUuid: string,
-) => `
+export const numberWeeklyQueryingUsersSql = () => `
 select
-  100 * COUNT(DISTINCT(user_uuid)) / ${userUuids.length} AS count
+  100 * COUNT(DISTINCT(user_uuid)) / NULLIF(cardinality(CAST(:userUuids AS uuid[])), 0) AS count
 from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-WHERE user_uuid in ('${userUuids.join(`','`)}')
-  AND sq.project_uuid = '${projectUuid}'
+WHERE user_uuid = ANY(CAST(:userUuids AS uuid[]))
+  AND sq.project_uuid = :projectUuid
   AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND timestamp between NOW() - interval '7 days' and NOW()
 `;
 
-export const tableMostQueriesSql = (
-    userUuids: string[],
-    projectUuid: string,
-) => `
+export const tableMostQueriesSql = () => `
 select
   users.user_uuid,
   users.first_name,
@@ -57,8 +48,8 @@ select
 from analytics_chart_views
   LEFT JOIN users ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-WHERE users.user_uuid in ('${userUuids.join(`','`)}')
-  AND sq.project_uuid = '${projectUuid}'
+WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[]))
+  AND sq.project_uuid = :projectUuid
   AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND timestamp between NOW() - interval '7 days' and NOW()
 GROUP BY users.user_uuid,
@@ -68,10 +59,7 @@ ORDER BY COUNT(analytics_chart_views.user_uuid) DESC
 
 `;
 
-export const tableMostCreatedChartsSql = (
-    userUuids: string[],
-    projectUuid: string,
-) => `
+export const tableMostCreatedChartsSql = () => `
 select
   users.user_uuid,
   users.first_name,
@@ -80,8 +68,8 @@ select
 from saved_queries_versions
   LEFT JOIN users ON users.user_uuid = saved_queries_versions.updated_by_user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_id = saved_queries_versions.saved_query_id AND sq.deleted_at IS NULL
-WHERE users.user_uuid in ('${userUuids.join(`','`)}')
-  AND sq.project_uuid = '${projectUuid}'
+WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[]))
+  AND sq.project_uuid = :projectUuid
   AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND saved_queries_versions.created_at between NOW() - interval '7 days' and NOW()
 GROUP BY
@@ -92,7 +80,7 @@ ORDER BY COUNT(saved_queries_versions.updated_by_user_uuid) DESC
 limit 10
 `;
 
-export const tableNoQueriesSql = (userUuids: string[], projectUuid: string) => `
+export const tableNoQueriesSql = () => `
 select
   users.user_uuid,
   MIN(users.first_name) as first_name,
@@ -101,11 +89,11 @@ select
 from users
   LEFT JOIN analytics_chart_views ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-WHERE users.user_uuid in ('${userUuids.join(`','`)}') AND users.first_name <> ''
+WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[])) AND users.first_name <> ''
   AND
   (
     (
-      sq.project_uuid = '${projectUuid}'
+      sq.project_uuid = :projectUuid
       AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
       AND analytics_chart_views.timestamp <> null
       AND analytics_chart_views.timestamp < NOW() - interval '90 days'
@@ -120,7 +108,7 @@ GROUP BY users.user_uuid
 
 `;
 
-const dateUserViewsGrid = (userUuids: string[], projectUuid: string) => `
+const dateUserViewsGrid = () => `
 WITH date_grid AS (
   SELECT
     date
@@ -133,9 +121,7 @@ users_date_grid AS (
     users.user_uuid
   FROM (SELECT * FROM date_grid) AS d
     cross join users
-  where users.created_at  < d.date and users.user_uuid in ('${userUuids.join(
-      `','`,
-  )}')
+  where users.created_at  < d.date and users.user_uuid = ANY(CAST(:userUuids AS uuid[]))
 ),
 query_executed AS (
   SELECT
@@ -144,10 +130,10 @@ query_executed AS (
     COUNT(DISTINCT(chart_uuid)) AS num_queries_executed
   FROM analytics_chart_views acv  -- this is a table with one row per query executed
     left join ${SavedChartsTableName} sq on sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
-  WHERE  sq.project_uuid = '${projectUuid}'
+  WHERE  sq.project_uuid = :projectUuid
     AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
     AND acv.timestamp >= CURRENT_DATE - interval '42 days'
-    AND acv.user_uuid in ('${userUuids.join(`','`)}')
+    AND acv.user_uuid = ANY(CAST(:userUuids AS uuid[]))
   GROUP BY 1, 2
 ),
 stg AS (
@@ -158,11 +144,8 @@ stg AS (
   FROM users_date_grid AS grid
   LEFT JOIN query_executed ON query_executed.user_uuid = grid.user_uuid AND query_executed.date = grid.date::date
 )`;
-export const chartWeeklyQueryingUsersSql = (
-    userUuids: string[],
-    projectUuid: string,
-) => `
-${dateUserViewsGrid(userUuids, projectUuid)}
+export const chartWeeklyQueryingUsersSql = () => `
+${dateUserViewsGrid()}
 SELECT
   date,
   COUNT(DISTINCT(
@@ -184,11 +167,8 @@ group by date
 order by date desc
 `;
 
-export const chartWeeklyAverageQueriesSql = (
-    userUuids: string[],
-    projectUuid: string,
-) => `
-${dateUserViewsGrid(userUuids, projectUuid)}
+export const chartWeeklyAverageQueriesSql = () => `
+${dateUserViewsGrid()}
 SELECT
   date,
   ROUND(AVG(num_queries_7d_rolling), 2) AS average_number_of_weekly_queries_per_user
@@ -198,38 +178,38 @@ order by date desc
 
 `;
 
-export const chartViewsSql = (projectUuid: string) => `
+export const chartViewsSql = () => `
 SELECT
   count(chart_uuid) as count,
   chart_uuid as uuid,
   sq.slug,
   sq.name
-FROM public.analytics_chart_views
+FROM analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
-where sq.project_uuid = '${projectUuid}'
+where sq.project_uuid = :projectUuid
   AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
 group by chart_uuid, sq.slug, sq.name
 order by count(chart_uuid) desc
 limit 20
 `;
 
-export const dashboardViewsSql = (projectUuid: string) => `
+export const dashboardViewsSql = () => `
 SELECT
   count(dv.dashboard_uuid) as count,
   dv.dashboard_uuid as uuid,
   d.slug,
   d.name
-FROM public.analytics_dashboard_views dv
+FROM analytics_dashboard_views dv
   left join ${DashboardsTableName} d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
   left join ${SpaceTableName} s on s.space_id  = d.space_id
   left join projects on projects.project_id = s.project_id
-where projects.project_uuid = '${projectUuid}'
+where projects.project_uuid = :projectUuid
 group by dv.dashboard_uuid, d.slug, d.name
 order by count(dv.dashboard_uuid) desc
 limit 20
 `;
 
-export const userMostViewedDashboardSql = (projectUuid: string) => `
+export const userMostViewedDashboardSql = () => `
 WITH RankedResults AS (
   SELECT
       u.user_uuid,
@@ -240,12 +220,12 @@ WITH RankedResults AS (
       d."name" AS dashboard_name,
       COUNT(dv.dashboard_uuid) AS dashboard_count,
       ROW_NUMBER() OVER (PARTITION BY u.first_name ORDER BY COUNT(dv.dashboard_uuid) DESC) AS rank
-  FROM public.analytics_dashboard_views dv
+  FROM analytics_dashboard_views dv
   LEFT JOIN users u ON u.user_uuid = dv.user_uuid
   LEFT JOIN ${DashboardsTableName} d ON dv.dashboard_uuid = d.dashboard_uuid AND d.deleted_at IS NULL
   left join ${SpaceTableName} s on s.space_id  = d.space_id
   left join projects on projects.project_id = s.project_id
-  WHERE projects.project_uuid = '${projectUuid}'
+  WHERE projects.project_uuid = :projectUuid
     AND u.user_uuid IS NOT NULL
   GROUP BY u.user_uuid, u.first_name, u.last_name, d.dashboard_uuid, d.slug, d."name"
 )

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -39,10 +39,9 @@ select
   100 * COUNT(DISTINCT(user_uuid)) / ${userUuids.length} AS count
 from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
-  left join projects on projects.project_id = s.project_id
 WHERE user_uuid in ('${userUuids.join(`','`)}')
-  AND projects.project_uuid = '${projectUuid}'
+  AND sq.project_uuid = '${projectUuid}'
+  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND timestamp between NOW() - interval '7 days' and NOW()
 `;
 
@@ -58,10 +57,9 @@ select
 from analytics_chart_views
   LEFT JOIN users ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
-  left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
-  AND projects.project_uuid = '${projectUuid}'
+  AND sq.project_uuid = '${projectUuid}'
+  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND timestamp between NOW() - interval '7 days' and NOW()
 GROUP BY users.user_uuid,
   users.first_name,
@@ -82,10 +80,9 @@ select
 from saved_queries_versions
   LEFT JOIN users ON users.user_uuid = saved_queries_versions.updated_by_user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_id = saved_queries_versions.saved_query_id AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
-  left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
-  AND projects.project_uuid = '${projectUuid}'
+  AND sq.project_uuid = '${projectUuid}'
+  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
   AND saved_queries_versions.created_at between NOW() - interval '7 days' and NOW()
 GROUP BY
   users.user_uuid,
@@ -104,13 +101,12 @@ select
 from users
   LEFT JOIN analytics_chart_views ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
-  left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}') AND users.first_name <> ''
   AND
   (
     (
-      projects.project_uuid = '${projectUuid}'
+      sq.project_uuid = '${projectUuid}'
+      AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
       AND analytics_chart_views.timestamp <> null
       AND analytics_chart_views.timestamp < NOW() - interval '90 days'
     )
@@ -148,9 +144,8 @@ query_executed AS (
     COUNT(DISTINCT(chart_uuid)) AS num_queries_executed
   FROM analytics_chart_views acv  -- this is a table with one row per query executed
     left join ${SavedChartsTableName} sq on sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
-    left join ${SpaceTableName} s on s.space_id  = sq.space_id
-    left join projects on projects.project_id = s.project_id
-  WHERE  projects.project_uuid = '${projectUuid}'
+  WHERE  sq.project_uuid = '${projectUuid}'
+    AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
     AND acv.timestamp >= CURRENT_DATE - interval '42 days'
     AND acv.user_uuid in ('${userUuids.join(`','`)}')
   GROUP BY 1, 2
@@ -211,9 +206,8 @@ SELECT
   sq.name
 FROM public.analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
-  left join projects on projects.project_id = s.project_id
-where projects.project_uuid = '${projectUuid}'
+where sq.project_uuid = '${projectUuid}'
+  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
 group by chart_uuid, sq.slug, sq.name
 order by count(chart_uuid) desc
 limit 20

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -2,6 +2,24 @@ import { DashboardsTableName } from '../database/entities/dashboards';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
 
+const activeChartOwnerSql = `(
+  sq.space_id IN (
+    SELECT s.space_id
+    FROM ${SpaceTableName} s
+    JOIN projects p ON p.project_id = s.project_id
+    WHERE p.project_uuid = :projectUuid AND s.deleted_at IS NULL
+  )
+  OR (
+    sq.space_id IS NULL AND sq.dashboard_uuid IN (
+      SELECT d.dashboard_uuid
+      FROM ${DashboardsTableName} d
+      JOIN ${SpaceTableName} s ON s.space_id = d.space_id AND s.deleted_at IS NULL
+      JOIN projects p ON p.project_id = s.project_id
+      WHERE p.project_uuid = :projectUuid AND d.deleted_at IS NULL
+    )
+  )
+)`;
+
 export const usersInProjectSql = () => `
 SELECT
   DISTINCT ON (users.user_uuid) user_uuid,
@@ -9,11 +27,18 @@ SELECT
 from users
   left join emails on emails.user_id = users.user_id
   LEFT JOIN organization_memberships ON users.user_id  =  organization_memberships.user_id
+    AND organization_memberships.organization_id IN (
+      SELECT organization_id FROM organizations WHERE organization_uuid = :organizationUuid
+    )
   LEFT JOIN organizations ON organization_memberships.organization_id = organizations.organization_id
   LEFT JOIN project_memberships ON project_memberships.user_id = users.user_id
+    AND project_memberships.project_id IN (
+      SELECT project_id FROM projects WHERE project_uuid = :projectUuid
+    )
   LEFT JOIN projects on project_memberships.project_id = projects.project_id
   LEFT JOIN group_memberships ON group_memberships.user_id = users.user_id
   LEFT JOIN project_group_access ON project_group_access.group_uuid = group_memberships.group_uuid
+    AND project_group_access.project_uuid = :projectUuid
 WHERE
   emails.is_primary = true
   AND users.is_internal = false
@@ -35,7 +60,7 @@ from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
 WHERE user_uuid = ANY(CAST(:userUuids AS uuid[]))
   AND sq.project_uuid = :projectUuid
-  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
+  AND ${activeChartOwnerSql}
   AND timestamp between NOW() - interval '7 days' and NOW()
 `;
 
@@ -50,7 +75,7 @@ from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
 WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[]))
   AND sq.project_uuid = :projectUuid
-  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
+  AND ${activeChartOwnerSql}
   AND timestamp between NOW() - interval '7 days' and NOW()
 GROUP BY users.user_uuid,
   users.first_name,
@@ -70,7 +95,7 @@ from saved_queries_versions
   left join ${SavedChartsTableName} sq on sq.saved_query_id = saved_queries_versions.saved_query_id AND sq.deleted_at IS NULL
 WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[]))
   AND sq.project_uuid = :projectUuid
-  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
+  AND ${activeChartOwnerSql}
   AND saved_queries_versions.created_at between NOW() - interval '7 days' and NOW()
 GROUP BY
   users.user_uuid,
@@ -81,31 +106,25 @@ limit 10
 `;
 
 export const tableNoQueriesSql = () => `
-select
-  users.user_uuid,
-  MIN(users.first_name) as first_name,
-  MIN(users.last_name) as last_name,
-  EXTRACT(DAY FROM  NOW() - COALESCE(MAX(analytics_chart_views.timestamp), MAX(users.created_at) ))   as count
-from users
-  LEFT JOIN analytics_chart_views ON users.user_uuid = analytics_chart_views.user_uuid
-  left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-WHERE users.user_uuid = ANY(CAST(:userUuids AS uuid[])) AND users.first_name <> ''
-  AND
-  (
-    (
-      sq.project_uuid = :projectUuid
-      AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
-      AND analytics_chart_views.timestamp <> null
-      AND analytics_chart_views.timestamp < NOW() - interval '90 days'
-    )
-    OR
-    (
-      analytics_chart_views.timestamp is null
-      AND users.created_at < NOW() - interval '90 days'
-    )
-  )
-GROUP BY users.user_uuid
-
+WITH last_chart_views AS (
+  SELECT acv.user_uuid, MAX(acv.timestamp) AS last_viewed_at
+  FROM analytics_chart_views acv
+  JOIN ${SavedChartsTableName} sq ON sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
+  WHERE acv.user_uuid = ANY(CAST(:userUuids AS uuid[]))
+    AND sq.project_uuid = :projectUuid
+    AND ${activeChartOwnerSql}
+  GROUP BY acv.user_uuid
+)
+SELECT
+  u.user_uuid,
+  u.first_name,
+  u.last_name,
+  EXTRACT(DAY FROM NOW() - COALESCE(v.last_viewed_at, u.created_at)) AS count
+FROM users u
+LEFT JOIN last_chart_views v ON v.user_uuid = u.user_uuid
+WHERE u.user_uuid = ANY(CAST(:userUuids AS uuid[]))
+  AND u.first_name <> ''
+  AND COALESCE(v.last_viewed_at, u.created_at) < NOW() - interval '90 days'
 `;
 
 const dateUserViewsGrid = () => `
@@ -131,7 +150,7 @@ query_executed AS (
   FROM analytics_chart_views acv  -- this is a table with one row per query executed
     left join ${SavedChartsTableName} sq on sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
   WHERE  sq.project_uuid = :projectUuid
-    AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
+    AND ${activeChartOwnerSql}
     AND acv.timestamp >= CURRENT_DATE - interval '42 days'
     AND acv.user_uuid = ANY(CAST(:userUuids AS uuid[]))
   GROUP BY 1, 2
@@ -187,7 +206,7 @@ SELECT
 FROM analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
 where sq.project_uuid = :projectUuid
-  AND (sq.space_id IS NOT NULL OR sq.dashboard_uuid IS NOT NULL)
+  AND ${activeChartOwnerSql}
 group by chart_uuid, sq.slug, sq.name
 order by count(chart_uuid) desc
 limit 20
@@ -201,7 +220,7 @@ SELECT
   d.name
 FROM analytics_dashboard_views dv
   left join ${DashboardsTableName} d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = :projectUuid
 group by dv.dashboard_uuid, d.slug, d.name
@@ -219,11 +238,11 @@ WITH RankedResults AS (
       d.slug AS dashboard_slug,
       d."name" AS dashboard_name,
       COUNT(dv.dashboard_uuid) AS dashboard_count,
-      ROW_NUMBER() OVER (PARTITION BY u.first_name ORDER BY COUNT(dv.dashboard_uuid) DESC) AS rank
+      ROW_NUMBER() OVER (PARTITION BY u.user_uuid ORDER BY COUNT(dv.dashboard_uuid) DESC, d.dashboard_uuid) AS rank
   FROM analytics_dashboard_views dv
   LEFT JOIN users u ON u.user_uuid = dv.user_uuid
   LEFT JOIN ${DashboardsTableName} d ON dv.dashboard_uuid = d.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
   WHERE projects.project_uuid = :projectUuid
     AND u.user_uuid IS NOT NULL

--- a/packages/backend/vitest.config.analytics.ts
+++ b/packages/backend/vitest.config.analytics.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     ...unitConfig,
     test: {
         ...unitConfig.test,
+        name: 'analytics-postgres-tests',
         include: ['src/models/AnalyticsModel.integration.test.ts'],
         exclude: ['node_modules', 'dist'],
         testTimeout: 15_000,

--- a/packages/backend/vitest.config.analytics.ts
+++ b/packages/backend/vitest.config.analytics.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import unitConfig from './vitest.config';
+
+export default defineConfig({
+    ...unitConfig,
+    test: {
+        ...unitConfig.test,
+        include: ['src/models/AnalyticsModel.integration.test.ts'],
+        exclude: ['node_modules', 'dist'],
+        testTimeout: 15_000,
+        hookTimeout: 15_000,
+    },
+});


### PR DESCRIPTION
Related to #28903. CSV export is handled in stacked PR #28965; merge this PR first.

### Description

Charts created directly in dashboards have no `space_id`, so User Activity dropped their recorded views. Filter charts by their project UUID and accept either an active space or an active dashboard in that project. Apply the same ownership rule across weekly activity, rolling histories, chart updates, view totals, and inactivity.

The query review also corrects related reporting problems:

- Bind all project, organization, and user UUID values, including the shared EE caller. Runtime values never become SQL text.
- Exclude deleted owners and spaces, and reject ownership paths into another project.
- Scope membership roles to the requested organization/project so unrelated memberships cannot change role counts.
- Calculate inactivity from the latest eligible project chart view, falling back to account creation when none exists.
- Group favourite dashboards by user UUID so users sharing a first name remain separate.

Organization/project authorization remains in the service. No ingestion, API, or schema changes.

### Validation

- 35 PostgreSQL 16 regression tests passed against the real queries and model. Covers dashboard-only charts, both ownership paths, deleted/mismatched owners, cross-project activity and roles, anonymous/repeated views, ownership moves, inactivity, same-name users, empty populations, and malicious UUID inputs.
- 5 AnalyticsModel/ManagedAgentModel unit tests passed. Backend typecheck, focused lint/formatting, and pre-commit checks passed.
- Compared the review changes with the previous PR version on 5M synthetic events (2.5M in the target project, 80% dashboard-owned): no material slowdown across all seven chart activity queries. Median weekly querying users 126→125 ms, most-active users 192→187 ms, chart totals 392→384 ms, and inactivity 513→507 ms. PostgreSQL 16, 2 CPUs, 2 GiB memory; synthetic timings are not production latency guarantees.

Run the database suite with:
```sh
ANALYTICS_TEST_DATABASE_URL=... pnpm -F backend exec vitest run --config vitest.config.analytics.ts src/models/AnalyticsModel.integration.test.ts
```

### Risk assessment

- [ ] This is a high-risk change

Read-query corrections without a migration. Counts include previously omitted dashboard activity and exclude deleted/mismatched owners. Inactivity, favourite-dashboard, and role summaries change where the previous queries produced incorrect results. CSV remains separately reviewable.
