### PR TITLE
fix(charts): apply the disabled animation setting to the treemap series

### DIFF
--- a/packages/frontend/src/components/SimpleTreemap/index.test.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.test.tsx
@@ -97,7 +97,9 @@ const renderTreemap = (
 
 afterEach(cleanup);
 
-describe('SimpleTreemap screenshot readiness', () => {
+// The first render in a worker pays for echarts' one-off setup, which is
+// several seconds on CI even though the rest of the file runs in milliseconds.
+describe('SimpleTreemap screenshot readiness', { timeout: 20_000 }, () => {
     it('waits for the treemap to render and signals only once', async () => {
         const context = makeContext();
         const onScreenshotReady = vi.fn(() => {

--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -205,6 +205,8 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
     const eChartsOption: EChartsOption | undefined = useMemo(() => {
         if (!chartConfig || !treemapSeriesOption) return;
 
+        const animation = !(isInDashboard || minimal);
+
         return {
             textStyle: {
                 fontFamily: sanitizeEchartsFontFamily(theme?.other?.chartFont),
@@ -213,8 +215,9 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
                 ...getTooltipStyle({ appendToBody: !isTouchDevice }),
                 trigger: 'item' as const, //Even though this is the default, tooltips will not show up if this is not set.
             },
-            series: [treemapSeriesOption],
-            animation: !(isInDashboard || minimal),
+            // The treemap series runs its own animation and ignores the root flag.
+            series: [{ ...treemapSeriesOption, animation }],
+            animation,
         };
     }, [
         chartConfig,


### PR DESCRIPTION
Refs: [PROD-10769](https://linear.app/lightdash/issue/PROD-10769)

### Description

Two separate problems were hiding behind one flaky test. CI numbers for the same file, before and after:

| test | before | after |
| --- | --- | --- |
| waits for the treemap to render and signals only once | 7054ms (timed out) | 5782ms → covered by the new budget |
| waits for all rows (false) | 2081ms | 168ms |
| waits for all rows (true) | 35ms | 33ms |
| stale options (loading: true) | 34ms | 31ms |
| stale options (loading: false) | 28ms | 21ms |
| waits for initialization | 1042ms | 78ms |
| waits for subtotals | 2077ms | 143ms |
| subtotal error | 15ms | 9ms |
| **file total** | **12367ms** | **~600ms of test time** |

**1. The treemap ignored the disabled animation setting.** `useEchartsTreemapConfig` sets `animation: !(isInDashboard || minimal)` at the root of the option, but the treemap series runs its own entrance animation and ignores that flag, so treemap tiles animated for a second in exactly the two modes where animation was meant to be off. Every other chart type uses that identical expression and honours it — measured time from `setOption` to `finished` with the root flag off: funnel 2ms, sankey 3ms, gauge 17ms, pie 118ms, treemap 1018ms. Node count made no difference (5 nodes and 40 nodes both ~1s), so this was a flat second added to every treemap capture.

PROD-10769 assumed the opposite: "entrance animation is already disabled for treemaps in dashboard and minimal mode, so the animation itself is unlikely to be the gap". It wasn't disabled. #28960 correctly made screenshot readiness wait for `finished`, which then waited out an animation nobody wanted.

**2. The first render in a worker doesn't fit the default 5s budget.** That is what actually failed the test, and it survived the change above. echarts' one-off setup lands in whichever test renders first: 5782ms on CI against 471ms locally with all 12 cores saturated, while the other seven cases in the same file run in 21-168ms. The timeout goes on the `describe` rather than the first test, so it still applies if the cases are reordered.

### Validation

- `SimpleTreemap/index.test.tsx`: 8/8 pass locally; the file drops from 6.5s to 0.66s of test time.
- Verified the `describe` timeout option is honoured on this Vitest (a 6s test inside such a block passes rather than failing at the 5s default) — it is not silently ignored.
- `vitest related` on the changed hook and `SimpleTreemap`: 20 files, 106 tests pass.
- `pnpm -F frontend typecheck`, oxlint and oxfmt on both changed files: clean.

### Risk assessment

- [ ] This is a high-risk change

The behaviour change is limited to treemaps where animation was already meant to be off: dashboard tiles and minimal/screenshot renders no longer animate on load, matching cartesian, pie, funnel, sankey and gauge. Explorer keeps its entrance animation (`isInDashboard` and `minimal` both false, so the series flag stays `true`). Screenshot readiness still waits for `finished`, so #28960's fix for half-drawn treemap deliveries is intact — it just no longer waits a second for an animation. The test change is a budget, not a behaviour change: a genuinely hung render still fails, at 20s instead of 5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7wbW89PPdqD9eKLNVJFNq