### PR TITLE
fix(analytics): include dashboard charts in usage CSV exports

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.integration.test.ts
+++ b/packages/backend/src/models/AnalyticsModel.integration.test.ts
@@ -40,7 +40,7 @@ type FixtureTables = {
     };
     dashboards: {
         dashboard_uuid: string;
-        project_uuid: string;
+        project_uuid: string | null;
         space_id: number;
         name: string;
         slug: string;
@@ -203,6 +203,12 @@ describe('AnalyticsModel (PostgreSQL)', () => {
         );
         await table('spaces').update({ deleted_at: null });
         await table('dashboards').update({ deleted_at: null });
+        await table('dashboards')
+            .where('dashboard_uuid', dashboardUuid)
+            .update({ project_uuid: projectUuid });
+        await table('dashboards')
+            .where('dashboard_uuid', otherDashboardUuid)
+            .update({ project_uuid: otherProjectUuid });
         await table('emails').update({ is_primary: true });
         await table('users').update({
             first_name: 'Viewer',
@@ -245,6 +251,13 @@ describe('AnalyticsModel (PostgreSQL)', () => {
                 created_at: database.raw("CURRENT_DATE - interval '1 day'"),
             },
         ]);
+        await table('analytics_dashboard_views').insert({
+            dashboard_uuid: dashboardUuid,
+            user_uuid: dashboardViewer,
+            timestamp: database.raw(
+                "CURRENT_DATE - interval '1 day' + interval '2 seconds'",
+            ),
+        });
     });
 
     afterAll(async () => {
@@ -686,5 +699,268 @@ describe('AnalyticsModel (PostgreSQL)', () => {
             .update({ space_id: 1, dashboard_uuid: null });
         expect(await rows(chartViewsSql())).toEqual(before);
         expect(before).toHaveLength(2);
+    });
+
+    describe('raw CSV rows', () => {
+        it('rejects SQL syntax in the project binding', async () => {
+            await expect(
+                model.getViewsRawData(`${projectUuid}' OR true --`),
+            ).rejects.toMatchObject({ code: '22P02' });
+        });
+
+        it('preserves anonymous dashboard views and deduplicates repeated views within one second', async () => {
+            await table('analytics_dashboard_views').insert([
+                {
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: null,
+                    timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+                },
+                ...['2.3', '2.8'].map((seconds) => ({
+                    dashboard_uuid: dashboardUuid,
+                    user_uuid: dashboardViewer,
+                    timestamp: database.raw(
+                        "CURRENT_DATE - interval '1 day' + ? * interval '1 second'",
+                        [seconds],
+                    ),
+                })),
+            ]);
+            const result = await model.getViewsRawData(projectUuid);
+            expect(result).toHaveLength(5);
+            expect(result).toContainEqual(
+                expect.objectContaining({
+                    type: 'dashboard',
+                    uuid: dashboardUuid,
+                    user_uuid: null,
+                    user_first_name: null,
+                    user_last_name: null,
+                }),
+            );
+        });
+
+        it('resolves legacy dashboards through their space when their project UUID is null', async () => {
+            await table('dashboards')
+                .where('dashboard_uuid', dashboardUuid)
+                .update({ project_uuid: null });
+            expect(await model.getViewsRawData(projectUuid)).toHaveLength(4);
+        });
+
+        it('rejects a dashboard owner whose space belongs to another project', async () => {
+            await table('dashboards')
+                .where('dashboard_uuid', otherDashboardUuid)
+                .update({ project_uuid: null });
+            await database<ChartRow>('saved_queries')
+                .where('saved_query_uuid', dashboardChart.saved_query_uuid)
+                .update({ dashboard_uuid: otherDashboardUuid });
+            const result = await model.getViewsRawData(projectUuid);
+            expect(result).toHaveLength(2);
+            expect(
+                result.some(
+                    ({ uuid }) => uuid === dashboardChart.saved_query_uuid,
+                ),
+            ).toBe(false);
+        });
+
+        it('includes space charts, dashboard-only charts, and the dashboard view with existing columns', async () => {
+            const result = await model.getViewsRawData(projectUuid);
+            expect(result).toHaveLength(4);
+            expect(
+                result.filter(
+                    ({ uuid }) => uuid === dashboardChart.saved_query_uuid,
+                ),
+            ).toHaveLength(2);
+            expect(result[0]).toMatchObject({
+                type: 'dashboard',
+                uuid: dashboardUuid,
+            });
+            expect(
+                result.every(({ space_name }) => space_name === 'Main space'),
+            ).toBe(true);
+            expect(Object.keys(result[0])).toEqual([
+                'type',
+                'timestamp',
+                'uuid',
+                'name',
+                'user_uuid',
+                'user_first_name',
+                'user_last_name',
+                'space_name',
+            ]);
+        });
+
+        it('preserves anonymous views and second-level deduplication', async () => {
+            await table('analytics_chart_views').insert([
+                {
+                    chart_uuid: dashboardChart.saved_query_uuid,
+                    user_uuid: null,
+                    timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+                },
+                {
+                    chart_uuid: dashboardChart.saved_query_uuid,
+                    user_uuid: dashboardViewer,
+                    timestamp: database.raw(
+                        "CURRENT_DATE - interval '1 day' + interval '20.1 seconds'",
+                    ),
+                },
+                {
+                    chart_uuid: dashboardChart.saved_query_uuid,
+                    user_uuid: dashboardViewer,
+                    timestamp: database.raw(
+                        "CURRENT_DATE - interval '1 day' + interval '20.9 seconds'",
+                    ),
+                },
+            ]);
+            const result = await model.getViewsRawData(projectUuid);
+            expect(result).toHaveLength(6);
+            expect(result).toContainEqual(
+                expect.objectContaining({
+                    uuid: dashboardChart.saved_query_uuid,
+                    user_uuid: null,
+                    user_first_name: null,
+                    user_last_name: null,
+                }),
+            );
+            expect(
+                result.filter(({ timestamp }) =>
+                    timestamp.endsWith('T00:00:20Z'),
+                ),
+            ).toHaveLength(1);
+        });
+
+        it('excludes other projects and ownerless charts', async () => {
+            const excluded: ChartRow[] = [
+                {
+                    ...spaceChart,
+                    saved_query_id: 3,
+                    saved_query_uuid: randomUUID(),
+                    project_uuid: otherProjectUuid,
+                    space_id: 2,
+                },
+                {
+                    ...dashboardChart,
+                    saved_query_id: 4,
+                    saved_query_uuid: randomUUID(),
+                    project_uuid: otherProjectUuid,
+                    dashboard_uuid: otherDashboardUuid,
+                },
+                {
+                    ...spaceChart,
+                    saved_query_id: 5,
+                    saved_query_uuid: randomUUID(),
+                    space_id: null,
+                },
+            ];
+            await database<ChartRow>('saved_queries').insert(excluded);
+            await table('analytics_chart_views').insert(
+                excluded.map((chart) => ({
+                    chart_uuid: chart.saved_query_uuid,
+                    user_uuid: spaceViewer,
+                    timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+                })),
+            );
+            await table('analytics_dashboard_views').insert({
+                dashboard_uuid: otherDashboardUuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw("CURRENT_DATE - interval '1 day'"),
+            });
+            const result = await model.getViewsRawData(projectUuid);
+            expect(result).toHaveLength(4);
+            expect(
+                result.every(({ space_name }) => space_name === 'Main space'),
+            ).toBe(true);
+        });
+
+        it.each(['chart', 'dashboard', 'space'] as const)(
+            'excludes chart rows when the owning %s is deleted',
+            async (owner) => {
+                if (owner === 'chart') {
+                    await database<ChartRow>('saved_queries')
+                        .where(
+                            'saved_query_uuid',
+                            dashboardChart.saved_query_uuid,
+                        )
+                        .update({ deleted_at: new Date() });
+                } else if (owner === 'dashboard') {
+                    await table('dashboards')
+                        .where('dashboard_uuid', dashboardUuid)
+                        .update({ deleted_at: new Date() });
+                } else {
+                    await table('spaces')
+                        .where('space_id', 1)
+                        .update({ deleted_at: new Date() });
+                }
+                const result = await model.getViewsRawData(projectUuid);
+                const charts = result.filter(({ type }) => type === 'chart');
+                expect(charts.map(({ uuid }) => uuid)).toEqual(
+                    owner === 'space' ? [] : [spaceChart.saved_query_uuid],
+                );
+                const expectedRowCounts = { space: 0, dashboard: 1, chart: 2 };
+                expect(result).toHaveLength(expectedRowCounts[owner]);
+            },
+        );
+
+        it('returns the newest 100,000 distinct events across charts and dashboards', async () => {
+            await database.raw(
+                'TRUNCATE analytics_chart_views, analytics_dashboard_views',
+            );
+            await database.raw(
+                `
+                INSERT INTO analytics_chart_views (chart_uuid, user_uuid, timestamp)
+                SELECT ?::uuid, ?::uuid, CURRENT_DATE - i * interval '1 second'
+                FROM generate_series(1, 100005) i
+            `,
+                [dashboardChart.saved_query_uuid, dashboardViewer],
+            );
+            await database.raw(
+                `
+                INSERT INTO analytics_chart_views (chart_uuid, user_uuid, timestamp)
+                SELECT ?::uuid, ?::uuid, CURRENT_DATE - interval '0.9 seconds'
+                FROM generate_series(1, 100)
+            `,
+                [dashboardChart.saved_query_uuid, dashboardViewer],
+            );
+            await table('analytics_dashboard_views').insert({
+                dashboard_uuid: dashboardUuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw("CURRENT_DATE + interval '1 second'"),
+            });
+            const result = await model.getViewsRawData(projectUuid);
+            const [{ cutoff }] = await rows<{ cutoff: string }>(`
+                SELECT to_char(CURRENT_DATE - 99999 * interval '1 second', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS cutoff
+            `);
+            expect(result).toHaveLength(100000);
+            expect(result[0]).toMatchObject({
+                type: 'dashboard',
+                uuid: dashboardUuid,
+            });
+            expect(result[result.length - 1].timestamp).toBe(cutoff);
+            expect(
+                new Set(
+                    result.map(
+                        ({ type, timestamp, uuid, user_uuid }) =>
+                            `${type}/${timestamp}/${uuid}/${user_uuid}`,
+                    ),
+                ).size,
+            ).toBe(100000);
+            const deletedDashboardUuid = randomUUID();
+            await table('dashboards').insert({
+                dashboard_uuid: deletedDashboardUuid,
+                project_uuid: projectUuid,
+                space_id: 1,
+                name: 'Deleted dashboard',
+                slug: 'deleted-dashboard',
+                deleted_at: new Date(),
+            });
+            await table('analytics_dashboard_views').insert({
+                dashboard_uuid: deletedDashboardUuid,
+                user_uuid: dashboardViewer,
+                timestamp: database.raw("CURRENT_DATE + interval '2 seconds'"),
+            });
+            const afterDeletion = await model.getViewsRawData(projectUuid);
+            expect(afterDeletion).toHaveLength(100000);
+            expect(afterDeletion[0].uuid).toBe(dashboardUuid);
+            expect(afterDeletion[afterDeletion.length - 1].timestamp).toBe(
+                cutoff,
+            );
+        });
     });
 });

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -18,11 +18,8 @@ import {
 } from '../database/entities/analytics';
 import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
-import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SavedSqlTableName } from '../database/entities/savedSql';
-import { SpaceTableName } from '../database/entities/spaces';
-import { UserTableName } from '../database/entities/users';
 import { traceSpan } from '../tracing/tracing';
 import {
     chartViewsSql,
@@ -37,6 +34,7 @@ import {
     unusedDashboardsSql,
     userMostViewedDashboardSql,
     usersInProjectSql,
+    viewsRawDataSql,
 } from './AnalyticsModelSql';
 
 type DbUserWithCountArguments = {
@@ -360,95 +358,17 @@ export class AnalyticsModel {
             timestamp: string; // Convert to ISO string in database
             uuid: string;
             name: string;
-            user_uuid: string;
-            user_first_name: string;
-            user_last_name: string;
+            user_uuid: string | null;
+            user_first_name: string | null;
+            user_last_name: string | null;
             space_name: string;
         };
-        const results = await this.database.transaction(async (trx) => {
-            const chartViews = trx
-                .select<RawViewType[]>(
-                    this.database.raw(`'chart' as type`),
-                    this.database.raw(
-                        `to_char(${AnalyticsChartViewsTableName}.timestamp, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as timestamp`,
-                    ),
-                    `${SavedChartsTableName}.saved_query_uuid as uuid`,
-                    `${SavedChartsTableName}.name as name`,
-                    `${UserTableName}.user_uuid as user_uuid`,
-                    `${UserTableName}.first_name as user_first_name`,
-                    `${UserTableName}.last_name as user_last_name`,
-                    `${SpaceTableName}.name as space_name`,
-                )
-                .from(AnalyticsChartViewsTableName)
-                .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
-                    this.on(
-                        `${SavedChartsTableName}.saved_query_uuid`,
-                        '=',
-                        `${AnalyticsChartViewsTableName}.chart_uuid`,
-                    ).andOnNull(`${SavedChartsTableName}.deleted_at`);
-                })
-                .leftJoin(
-                    UserTableName,
-                    `${UserTableName}.user_uuid`,
-                    `${AnalyticsChartViewsTableName}.user_uuid`,
-                )
-                .leftJoin(
-                    SpaceTableName,
-                    `${SpaceTableName}.space_id`,
-                    `${SavedChartsTableName}.space_id`,
-                )
-                .leftJoin(
-                    ProjectTableName,
-                    `${ProjectTableName}.project_id`,
-                    `${SpaceTableName}.project_id`,
-                )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .whereNull(`${SpaceTableName}.deleted_at`);
-
-            const dashboardViews = trx
-                .select<RawViewType[]>(
-                    this.database.raw(`'dashboard' as type`),
-                    this.database.raw(
-                        `to_char(${AnalyticsDashboardViewsTableName}.timestamp, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as timestamp`,
-                    ),
-                    `${DashboardsTableName}.dashboard_uuid as uuid`,
-                    `${DashboardsTableName}.name as name`,
-                    `${UserTableName}.user_uuid as user_uuid`,
-                    `${UserTableName}.first_name as user_first_name`,
-                    `${UserTableName}.last_name as user_last_name`,
-                    `${SpaceTableName}.name as space_name`,
-                )
-                .from(AnalyticsDashboardViewsTableName)
-                .leftJoin(
-                    DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${AnalyticsDashboardViewsTableName}.dashboard_uuid`,
-                )
-                .leftJoin(
-                    UserTableName,
-                    `${UserTableName}.user_uuid`,
-                    `${AnalyticsDashboardViewsTableName}.user_uuid`,
-                )
-                .leftJoin(
-                    SpaceTableName,
-                    `${SpaceTableName}.space_id`,
-                    `${DashboardsTableName}.space_id`,
-                )
-                .leftJoin(
-                    ProjectTableName,
-                    `${ProjectTableName}.project_id`,
-                    `${SpaceTableName}.project_id`,
-                )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid)
-                .whereNull(`${SpaceTableName}.deleted_at`);
-
-            return chartViews
-                .union(dashboardViews)
-                .orderBy('timestamp', 'desc')
-                .limit(100000); // hard limit to avoid memory issues
-        });
-
-        return results;
+        // Deduplicate and limit event keys before joining metadata or formatting dates.
+        const result = await this.database.raw<{ rows: RawViewType[] }>(
+            viewsRawDataSql(),
+            { projectUuid },
+        );
+        return result.rows;
     }
 
     async getUnusedContent(

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -260,6 +260,50 @@ FROM RankedResults
 WHERE rank = 1;
 `;
 
+export const viewsRawDataSql = () => `
+WITH view_events AS (
+  SELECT
+    'chart'::text AS type,
+    date_trunc('second', cv.timestamp) AS viewed_at,
+    sq.saved_query_uuid AS uuid,
+    cv.user_uuid
+  FROM analytics_chart_views cv
+    JOIN ${SavedChartsTableName} sq ON sq.saved_query_uuid = cv.chart_uuid AND sq.deleted_at IS NULL
+  WHERE sq.project_uuid = :projectUuid AND ${activeChartOwnerSql}
+  UNION
+  SELECT
+    'dashboard'::text,
+    date_trunc('second', dv.timestamp),
+    d.dashboard_uuid,
+    dv.user_uuid
+  FROM analytics_dashboard_views dv
+    JOIN ${DashboardsTableName} d ON d.dashboard_uuid = dv.dashboard_uuid AND d.deleted_at IS NULL
+    JOIN ${SpaceTableName} s ON s.space_id = d.space_id
+    JOIN projects p ON p.project_id = s.project_id
+  WHERE p.project_uuid = :projectUuid AND s.deleted_at IS NULL
+), limited_events AS MATERIALIZED (
+  SELECT * FROM view_events ORDER BY viewed_at DESC LIMIT 100000
+)
+SELECT
+  e.type,
+  to_char(e.viewed_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS timestamp,
+  e.uuid,
+  CASE WHEN e.type = 'chart' THEN sq.name ELSE d.name END AS name,
+  u.user_uuid,
+  u.first_name AS user_first_name,
+  u.last_name AS user_last_name,
+  CASE WHEN e.type = 'chart' THEN chart_space.name ELSE dashboard_space.name END AS space_name
+FROM limited_events e
+  LEFT JOIN users u ON u.user_uuid = e.user_uuid
+  LEFT JOIN ${SavedChartsTableName} sq ON e.type = 'chart' AND sq.saved_query_uuid = e.uuid AND sq.deleted_at IS NULL
+  LEFT JOIN ${DashboardsTableName} owner ON owner.dashboard_uuid = sq.dashboard_uuid
+    AND owner.deleted_at IS NULL
+  LEFT JOIN ${SpaceTableName} chart_space ON chart_space.space_id = COALESCE(sq.space_id, owner.space_id) AND chart_space.deleted_at IS NULL
+  LEFT JOIN ${DashboardsTableName} d ON e.type = 'dashboard' AND d.dashboard_uuid = e.uuid AND d.deleted_at IS NULL
+  LEFT JOIN ${SpaceTableName} dashboard_space ON dashboard_space.space_id = d.space_id AND dashboard_space.deleted_at IS NULL
+ORDER BY timestamp DESC
+`;
+
 /**
  * Parameters: project_uuid, staleness_days, staleness_days, protect_recent_days, limit
  */


### PR DESCRIPTION
Related to #28903. Stacked on #28963; merge the User Activity fix first.

### Description

Usage CSV exports omit charts created directly in dashboards because those charts have no `space_id`. Include their recorded views using the same active-owner and project checks as User Activity, and resolve their exported space through the owning dashboard.

Exclude deleted dashboards, charts, and spaces before deduplication and the row limit. Legacy dashboards with a null `project_uuid` resolve through their owning space. Bind the project UUID and represent anonymous-user fields as nullable.

Preserve the eight CSV columns, timestamp format, anonymous views, second-level deduplication, and the combined 100,000-row limit. Deduplicate and limit event keys before joining display fields or formatting timestamps. No API, ingestion, or schema changes.

### Validation

- 46 PostgreSQL 16 tests passed across the stack, including 11 CSV cases covering legacy/dashboard ownership, project isolation, deleted owners, anonymous chart/dashboard views, deduplication, ordering, bound inputs, and exclusion of deleted dashboards before the 100,000-row cap.
- 5 AnalyticsModel/ManagedAgentModel unit tests passed. Backend typecheck, focused lint/formatting, and pre-commit checks passed.
- On 5M synthetic chart events, the final query and the previous PR version returned 100,000 rows with identical cutoffs and no differences above the cutoff. Ordering among tied timestamps remains unspecified.
- Reusing the active-owner filter improved median export time from 7.1s to 2.8s on the same PostgreSQL 16 fixture (2 CPUs, 2 GiB memory, 4 MiB work_mem; target project 2.5M chart events, 80% dashboard-owned). Synthetic timings are not production latency guarantees.

Run the database suite with:
```sh
ANALYTICS_TEST_DATABASE_URL=... pnpm -F backend exec vitest run --config vitest.config.analytics.ts src/models/AnalyticsModel.integration.test.ts
```

### Risk assessment

- [ ] This is a high-risk change

Read-query correction, isolated from the User Activity PR. Exports include previously omitted activity and exclude deleted content. The existing output cap remains enforced after filtering and deduplication.
