### PR TITLE
fix(spaces): keep chart listings working during space deletion

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -137,6 +137,93 @@ describe('SpacePermissionService', () => {
         ).resolves.toBe(false);
     });
 
+    describe('space deletion during access resolution', () => {
+        const survivingSpaceUuid = 'surviving-space';
+        const deletedSpaceUuid = 'deleted-space';
+        const deniedSpaceUuid = 'denied-space';
+        const spaceUuids = [
+            survivingSpaceUuid,
+            deletedSpaceUuid,
+            deniedSpaceUuid,
+        ];
+        const user = {
+            userUuid: 'user-uuid',
+            ability: new Ability<PossibleAbilities>([
+                {
+                    action: 'view',
+                    subject: 'Space',
+                    conditions: { projectUuid: 'allowed-project' },
+                },
+            ]),
+        } as unknown as SessionUser;
+
+        beforeEach(() => {
+            mockPermissionModel.getInheritanceChains.mockResolvedValue(
+                Object.fromEntries(
+                    spaceUuids.map((spaceUuid) => [
+                        spaceUuid,
+                        {
+                            chain: [
+                                {
+                                    spaceUuid,
+                                    spaceName: spaceUuid,
+                                    inheritParentPermissions: true,
+                                },
+                            ],
+                            inheritsFromOrgOrProject: true,
+                        },
+                    ]),
+                ),
+            );
+            mockPermissionModel.getDirectSpaceAccess.mockResolvedValue({});
+            mockPermissionModel.getProjectSpaceAccess.mockResolvedValue({});
+            mockPermissionModel.getOrganizationSpaceAccess.mockResolvedValue(
+                {},
+            );
+            // The deleted space disappeared after the inheritance-chain read.
+            mockPermissionModel.getSpaceInfo.mockResolvedValue({
+                [survivingSpaceUuid]: {
+                    projectUuid: 'allowed-project',
+                    organizationUuid: 'organization-uuid',
+                },
+                [deniedSpaceUuid]: {
+                    projectUuid: 'other-project',
+                    organizationUuid: 'organization-uuid',
+                },
+            });
+        });
+
+        test('lists surviving spaces while respecting project access', async () => {
+            await expect(
+                service.getAccessibleSpaceUuids('view', user, spaceUuids),
+            ).resolves.toEqual([survivingSpaceUuid]);
+        });
+
+        test.each([
+            { requestedSpaceUuids: [deletedSpaceUuid] },
+            { requestedSpaceUuids: [survivingSpaceUuid, deletedSpaceUuid] },
+        ])(
+            'denies access when $requestedSpaceUuids includes a deleted space',
+            async ({ requestedSpaceUuids }) => {
+                await expect(
+                    service.can('view', user, requestedSpaceUuids),
+                ).resolves.toBe(false);
+            },
+        );
+
+        test('direct access-context lookups still reject the deleted space', async () => {
+            await expect(
+                service.getAllSpaceAccessContext(deletedSpaceUuid),
+            ).rejects.toThrow(NotFoundError);
+            await expect(
+                service.resolveAccess(user.userUuid, {
+                    type: 'space',
+                    spaceUuid: deletedSpaceUuid,
+                }),
+            ).rejects.toThrow(NotFoundError);
+        });
+    });
+
     test('uses the provided transaction for every access-context query', async () => {
         const spaceUuid = 'space-uuid';
         const userUuid = 'user-uuid';

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -895,15 +895,17 @@ export class SpacePermissionService extends BaseService {
                 { trx },
             );
 
-        // For each requested space, aggregate access from its chain
+        // Omit spaces deleted between the chain and metadata reads.
+        const existingChains = chains.filter(
+            ({ spaceUuid }) => spaceInfo[spaceUuid] !== undefined,
+        );
         const result: Record<string, SpaceAccessContextForCasl> = {};
-        for (const { spaceUuid, chain, inheritsFromOrgOrProject } of chains) {
+        for (const {
+            spaceUuid,
+            chain,
+            inheritsFromOrgOrProject,
+        } of existingChains) {
             const space = spaceInfo[spaceUuid];
-            if (!space) {
-                throw new NotFoundError(
-                    `Space with uuid ${spaceUuid} not found`,
-                );
-            }
 
             // Build chain-ordered direct access (preserves leaf-to-root ordering)
             const chainDirectAccess = chain.map((item) => ({


### PR DESCRIPTION
Follow-up to #28922.

### Description

Deleting a space while another request lists project charts can make the entire listing return 404. Permission resolution reads inheritance chains and space metadata separately, then throws if a space disappears between those reads. Parallel API tests exposed this in [scheduler setup](https://github.com/lightdash/lightdash/actions/runs/34387427462/job/102589562912).

Omit vanished spaces from the access contexts, matching deletion before the inheritance read. Bulk listing continues through the existing permission checks; single and mixed-space access checks deny missing resources, and explicit access-context lookups still return NotFoundError. Adds no queries or retries.

### Validation

- Added four service regression cases using controlled model responses; reproduced the listing failure and access-check failures before the fix.
- All 282 SpacePermissionService/ProjectService tests passed, including cross-project filtering and missing-resource denial.
- Backend typecheck, focused lint/formatting and pre-commit checks passed.

### Risk assessment

- [ ] This is a high-risk change

Two files: the permission resolver and its tests. Missing spaces receive no access context; existing authorization rules remain in effect.
