### PR TITLE
chore: upgrade monorepo to pnpm 12.3.4

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -264,7 +264,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # Force reinstall so pnpm includes optional DuckDB native bindings
         # needed to build both macOS pkg targets from a single runner.
-        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
+        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --config.production=false --force --network-concurrency=16
 
       - name: Cache common build
         id: cache-common
@@ -414,7 +414,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force --network-concurrency=16
+        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --config.production=false --force --network-concurrency=16
 
       - name: Cache common build
         id: cache-common

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,13 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
-      # pnpm 11 publishes natively via OIDC trusted publishing; npm is pinned only
+      # pnpm publishes natively via OIDC trusted publishing; npm is pinned only
       # for the npm version prepare step in release.config.js.
       - name: Pin npm for the versioning step
         run: npm install -g npm@12.0.1
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --config.production=false --network-concurrency=16
 
       # PROD-8359: install oasdiff so the release-safety marker generator can diff
       # the REST API (swagger.json) between the previous tag and HEAD for breaking
@@ -169,7 +169,7 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline --prod=false --network-concurrency=16
+        run: pnpm install --frozen-lockfile --prefer-offline --config.production=false --network-concurrency=16
 
       - name: Generate backend API artifacts
         run: pnpm generate-api:backend

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,7 +4,7 @@ ENV PNPM_HOME="/home/gitpod/.local/share/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
 
 # Keep the bootstrap pnpm aligned with the root packageManager field.
-RUN bash -c '. /home/gitpod/.nvm/nvm.sh && nvm install 24.18 && nvm alias default 24.18 && curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=11.20.0 sh -'
+RUN bash -c '. /home/gitpod/.nvm/nvm.sh && nvm install 24.18 && nvm alias default 24.18 && curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.4 sh -'
 
 # Installing multiple versions of dbt
 # dbt 1.4 is the default

--- a/agent-harness/cloud/cloud-init.yml
+++ b/agent-harness/cloud/cloud-init.yml
@@ -146,14 +146,14 @@ runcmd:
       fnm default 24.18
     '
 
-  # -- Install pnpm 11.20.0 ---------------------------------------------------
+  # -- Install pnpm 12.3.4 ---------------------------------------------------
   - |
     su - lightdash -c '
       export PATH="/home/lightdash/.local/share/fnm:$PATH"
       eval "$(fnm env --shell bash)"
       export PNPM_HOME="/home/lightdash/.local/share/pnpm"
       export PATH="$PNPM_HOME/bin:$PATH"
-      curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=11.20.0 sh -
+      curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=12.3.4 sh -
     '
 
   # -- Install PM2 globally ----------------------------------------------------

--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,7 @@
 FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
 RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
 
-FROM ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm-cli
+FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS pnpm-cli
 
 # -----------------------------
 # Stage 0: pnpm setup base

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -5,7 +5,7 @@
 FROM duckdb/duckdb:1.5.2@sha256:5658472bf45cce867048a17201b9d38d4632507e7df4a69994f8236599f69d45 AS duckdb-extensions
 RUN ["/duckdb", "-c", "INSTALL httpfs; INSTALL aws;"]
 
-FROM ghcr.io/pnpm/pnpm:11.20.0@sha256:d77573aba1649491010d3d252214be47197c0706417793cf393ac47cc324f315 AS pnpm-cli
+FROM ghcr.io/pnpm/pnpm:12.3.4@sha256:b81d53184f670fe19d1a33f9d5041907d314b31d596838e8133cbd83d45be043 AS pnpm-cli
 
 # Optimized Multi-Stage Build for PR Previews
 # Uses parallel build stages and cache mounts for maximum caching

--- a/package.json
+++ b/package.json
@@ -201,5 +201,5 @@
             "pnpm -F formula run formatter"
         ]
     },
-    "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee"
+    "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
### Description:

```diff
 Local development, CI, and application images
- pnpm 11.20.0
+ pnpm 12.3.4 (Rust implementation)
```

- Pins pnpm and its platform binaries with integrity checks; updates both application image digests and Gitpod/cloud bootstrap pins.
- Preserves the three-day package cooldown, reviewed build-script policy, and disabled install-before-run behavior. pnpm 12.3.4 and its platform packages were published September 4; 12.4.0 is excluded because it is younger than three days.
- Keeps application dependency resolutions byte-for-byte unchanged. The new lockfile document pins the package manager itself.
- Uses `--config.production=false` in release installs: 12.3.4 rejects the old `--prod=false` spelling. Node management is the separate stacked PR #28974.

Validation:
- `sfw pnpm install --frozen-lockfile --prefer-offline`; fresh manifest-only installation; all four standalone sandbox frozen lockfile checks.
- `pnpm test:release-safety`; `pnpm -F frontend unused-exports`; Turbo dry-run; changed YAML parsing; `git diff --check`.
- Isolated probes confirm the age gate rejects pnpm 12.4.0 and production-mode installs still include devDependencies with the replacement flag.
- Apple Silicon, warm store, offline, scripts disabled, Socket Firewall: two reinstalls averaged **12.6s → 12.0s**; six no-op installs per version were effectively unchanged (~0.5s). This does not establish CI or cold-download performance.
- Linux amd64/arm64 image manifests verified. Docker builds, actual npm publication, cloud/Gitpod bootstrap, and live application behavior were not exercised; no database or service changes.

### Risk assessment:

- [x] This is a high-risk change

The package manager affects every build and production image. Exact versions/digests, unchanged application resolutions, retained supply-chain controls, and release-script checks limit the change; CI and image builds still need to validate the complete rollout before merge.
