### PR TITLE
feat: add Lightdash analytics organization settings

### DIFF
--- a/docs/usage-analytics/local-testing.md
+++ b/docs/usage-analytics/local-testing.md
@@ -29,8 +29,14 @@ Preserve other enabled flags if needed. Explicitly disabling `analytics-project`
 takes precedence. The two org IDs are an intentional local-only binding;
 production must use the authenticated org and reviewed credential isolation.
 
-As a signed-in organization administrator, call the same-origin endpoint from
-the browser console on your assigned local frontend:
+As a signed-in organization administrator, open **Organization settings →
+Lightdash analytics (Beta)** at `/generalSettings/lightdashAnalytics`. Click
+**Create** to provision and open the project, or **Open** if it already exists.
+The page shows the project's creation time, not its model-sync version or data
+freshness. Feature-flag and development-only backend restrictions still apply.
+
+Alternatively, call the same-origin endpoint from the browser console on your
+assigned local frontend:
 
 ```javascript
 const response = await fetch('/api/v1/org/analytics-project', {
@@ -54,7 +60,26 @@ lock. Re-running refreshes both models and repairs a failed model-save attempt
 without replacing the project or deleting saved charts. Analytics previews do
 not expire automatically. They are visible only to enabled org admins in the
 projects API (for slug resolution), and omitted from the normal switcher as
-previews with no upstream. No admin navigation has been added.
+previews with no upstream.
+
+### Status and reset
+
+`GET /api/v1/org/analytics-project` returns `{ project: null }` when absent,
+otherwise project UUID, name, slug, URL, and creation timestamp. This read does
+not access object storage, compile models, or create anything.
+
+The settings page's **Delete** action requires confirmation and calls
+`DELETE /api/v1/org/analytics-project/{projectUuid}`. Only the current org's
+analytics-marked project with that exact UUID can be deleted. Deletion uses the
+same per-org lock as creation. A stale UUID cannot delete a replacement project.
+This permanently removes the project and its saved content, but leaves the
+collected usage events in object storage intact. Afterwards, **Create** provisions
+a new project; it does not restore deleted charts or dashboards.
+
+All three endpoints live in `AnalyticsProjectController`, backed by
+`AnalyticsProjectService`, and require a session-authenticated org administrator
+and the existing analytics flag/local-org guard. Production enablement and
+versioned content sync remain separate follow-ups.
 
 ## Read path and safeguards
 

--- a/packages/backend/src/controllers/analyticsProjectController.ts
+++ b/packages/backend/src/controllers/analyticsProjectController.ts
@@ -1,0 +1,77 @@
+import {
+    AnalyticsProjectStatus,
+    ApiErrorPayload,
+    ApiSuccess,
+    ApiSuccessEmpty,
+    assertRegisteredAccount,
+    EnsureAnalyticsProjectResult,
+    UUID,
+} from '@lightdash/common';
+import {
+    Delete,
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Post,
+    Request,
+    Response,
+    Route,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { toSessionUser } from '../auth/account';
+import { isAuthenticated, unauthorisedInDemo } from './authentication';
+import { BaseController } from './baseController';
+
+@Route('/api/v1/org/analytics-project')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('Analytics project')
+export class AnalyticsProjectController extends BaseController {
+    /** @summary Get internal analytics project status */
+    @Get()
+    @Middlewares([isAuthenticated])
+    @OperationId('GetAnalyticsProjectStatus')
+    async getAnalyticsProjectStatus(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<AnalyticsProjectStatus>> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getAnalyticsProjectService()
+                .getStatus(toSessionUser(req.account)),
+        };
+    }
+
+    /** @summary Ensure internal analytics project */
+    @Post()
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @OperationId('EnsureAnalyticsProject')
+    async ensure(
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<EnsureAnalyticsProjectResult>> {
+        assertRegisteredAccount(req.account);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getAnalyticsProjectService()
+                .ensure(toSessionUser(req.account)),
+        };
+    }
+
+    /** @summary Delete the organization's internal analytics project */
+    @Delete('/{projectUuid}')
+    @Middlewares([isAuthenticated, unauthorisedInDemo])
+    @OperationId('DeleteAnalyticsProject')
+    async delete(
+        @Request() req: express.Request,
+        @Path() projectUuid: UUID,
+    ): Promise<ApiSuccessEmpty> {
+        assertRegisteredAccount(req.account);
+        await this.services
+            .getAnalyticsProjectService()
+            .delete(toSessionUser(req.account), projectUuid);
+        return { status: 'ok', results: undefined };
+    }
+}

--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -74,27 +74,6 @@ import { BaseController } from './baseController';
 @Tags('Organizations')
 export class OrganizationController extends BaseController {
     /**
-     * Create or refresh the current organization's internal analytics preview.
-     * @summary Ensure internal analytics project
-     */
-    @Middlewares([isAuthenticated, unauthorisedInDemo])
-    @Post('/analytics-project')
-    @OperationId('EnsureAnalyticsProject')
-    async ensureAnalyticsProject(
-        @Request() req: express.Request,
-    ): Promise<
-        ApiSuccess<{ projectUuid: string; url: string; created: boolean }>
-    > {
-        assertRegisteredAccount(req.account);
-        return {
-            status: 'ok',
-            results: await this.services
-                .getProjectService()
-                .ensureAnalyticsProject(toSessionUser(req.account)),
-        };
-    }
-
-    /**
      * Get the current user's organization
      * @summary Get current organization
      * @param req express request

--- a/packages/backend/src/services/AnalyticsProjectService/AnalyticsProjectService.test.ts
+++ b/packages/backend/src/services/AnalyticsProjectService/AnalyticsProjectService.test.ts
@@ -1,0 +1,132 @@
+import { ForbiddenError, NotFoundError } from '@lightdash/common';
+import {
+    user as baseUser,
+    defaultProject,
+} from '../ProjectService/ProjectService.mock';
+import { AnalyticsProjectService } from './AnalyticsProjectService';
+
+describe('AnalyticsProjectService', () => {
+    const user = {
+        ...baseUser,
+        organizationUuid: 'org',
+        organizationName: 'Example',
+        organizationCreatedAt: new Date('2026-01-01'),
+    };
+    const analyticsProject = {
+        ...defaultProject,
+        projectUuid: 'analytics-project',
+        slug: 'lightdash-analytics-1',
+        provisioningSource: 'analytics',
+        createdAt: new Date('2026-09-10T00:00:00Z'),
+    };
+    const getAllByOrganizationUuid = vi.fn();
+    const assertAnalyticsProjectAccess = vi.fn();
+    const ensureAnalyticsProject = vi.fn();
+    const deleteProject = vi.fn();
+    const invalidateSessionUserCache = vi.fn();
+    const lock = vi.fn();
+    const service = new AnalyticsProjectService({
+        projectModel: {
+            getAllByOrganizationUuid,
+            runInAnalyticsProvisioningLock: async <T>(
+                org: string,
+                callback: () => Promise<T>,
+            ): Promise<T> => {
+                lock(org);
+                return callback();
+            },
+        },
+        projectService: {
+            assertAnalyticsProjectAccess,
+            ensureAnalyticsProject,
+            delete: deleteProject,
+        },
+        userModel: { invalidateSessionUserCache },
+    });
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        getAllByOrganizationUuid.mockResolvedValue([
+            defaultProject,
+            analyticsProject,
+        ]);
+    });
+
+    it('returns only safe metadata for the org-owned analytics project, including its actual slug', async () => {
+        const result = await service.getStatus(user);
+        expect(assertAnalyticsProjectAccess).toHaveBeenCalledWith(user, {
+            organizationUuid: user.organizationUuid,
+            provisioningSource: 'analytics',
+        });
+        expect(getAllByOrganizationUuid).toHaveBeenCalledWith(
+            user.organizationUuid,
+        );
+        expect(result).toEqual({
+            project: {
+                projectUuid: analyticsProject.projectUuid,
+                name: analyticsProject.name,
+                slug: 'lightdash-analytics-1',
+                url: '/projects/lightdash-analytics-1/tables',
+                createdAt: '2026-09-10T00:00:00.000Z',
+            },
+        });
+        expect(ensureAnalyticsProject).not.toHaveBeenCalled();
+    });
+
+    it('returns null without provisioning when no analytics project exists', async () => {
+        getAllByOrganizationUuid.mockResolvedValue([defaultProject]);
+        await expect(service.getStatus(user)).resolves.toEqual({
+            project: null,
+        });
+        expect(ensureAnalyticsProject).not.toHaveBeenCalled();
+    });
+
+    it('preserves create-or-get behavior by delegating to the guarded provisioner', async () => {
+        const result = {
+            projectUuid: 'analytics-project',
+            url: '/projects/lightdash-analytics-1/tables',
+            created: false,
+        };
+        ensureAnalyticsProject.mockResolvedValue(result);
+        await expect(service.ensure(user)).resolves.toEqual(result);
+        expect(ensureAnalyticsProject).toHaveBeenCalledWith(user);
+    });
+
+    it.each(['getStatus', 'delete'] as const)(
+        'rejects %s before reads or writes when the existing feature/admin guard denies access',
+        async (operation) => {
+            assertAnalyticsProjectAccess.mockRejectedValue(
+                new ForbiddenError('disabled'),
+            );
+            await expect(
+                operation === 'getStatus'
+                    ? service.getStatus(user)
+                    : service.delete(user, analyticsProject.projectUuid),
+            ).rejects.toThrow(ForbiddenError);
+            expect(getAllByOrganizationUuid).not.toHaveBeenCalled();
+            expect(lock).not.toHaveBeenCalled();
+            expect(deleteProject).not.toHaveBeenCalled();
+        },
+    );
+
+    it('deletes the exact analytics project under the org provisioning lock and invalidates user abilities', async () => {
+        await service.delete(user, analyticsProject.projectUuid);
+        expect(lock).toHaveBeenCalledWith(user.organizationUuid);
+        expect(deleteProject).toHaveBeenCalledWith(
+            analyticsProject.projectUuid,
+            user,
+        );
+        expect(invalidateSessionUserCache).toHaveBeenCalledWith(user.userUuid);
+    });
+
+    it.each(['other-org-project', 'stale-project', defaultProject.projectUuid])(
+        'rejects deletion of %s rather than deleting a different or ordinary project',
+        async (projectUuid) => {
+            await expect(service.delete(user, projectUuid)).rejects.toThrow(
+                NotFoundError,
+            );
+            expect(deleteProject).not.toHaveBeenCalled();
+            expect(invalidateSessionUserCache).not.toHaveBeenCalled();
+        },
+    );
+});

--- a/packages/backend/src/services/AnalyticsProjectService/AnalyticsProjectService.ts
+++ b/packages/backend/src/services/AnalyticsProjectService/AnalyticsProjectService.ts
@@ -1,0 +1,98 @@
+import {
+    AnalyticsProjectStatus,
+    EnsureAnalyticsProjectResult,
+    ForbiddenError,
+    isUserWithOrg,
+    NotFoundError,
+    SessionUser,
+} from '@lightdash/common';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { UserModel } from '../../models/UserModel';
+import { BaseService } from '../BaseService';
+import { ProjectService } from '../ProjectService/ProjectService';
+
+type Dependencies = {
+    projectModel: Pick<
+        ProjectModel,
+        'getAllByOrganizationUuid' | 'runInAnalyticsProvisioningLock'
+    >;
+    projectService: Pick<
+        ProjectService,
+        'assertAnalyticsProjectAccess' | 'ensureAnalyticsProject' | 'delete'
+    >;
+    userModel: Pick<UserModel, 'invalidateSessionUserCache'>;
+};
+
+export class AnalyticsProjectService extends BaseService {
+    constructor(private readonly dependencies: Dependencies) {
+        super();
+    }
+
+    private async authorize(user: SessionUser): Promise<string> {
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
+        }
+        await this.dependencies.projectService.assertAnalyticsProjectAccess(
+            user,
+            {
+                organizationUuid: user.organizationUuid,
+                provisioningSource: 'analytics',
+            },
+        );
+        return user.organizationUuid;
+    }
+
+    async getStatus(user: SessionUser): Promise<AnalyticsProjectStatus> {
+        const organizationUuid = await this.authorize(user);
+        const projects =
+            await this.dependencies.projectModel.getAllByOrganizationUuid(
+                organizationUuid,
+            );
+        const project = projects.find(
+            (candidate) => candidate.provisioningSource === 'analytics',
+        );
+        return {
+            project: project
+                ? {
+                      projectUuid: project.projectUuid,
+                      name: project.name,
+                      slug: project.slug ?? null,
+                      url: `/projects/${project.slug ?? project.projectUuid}/tables`,
+                      createdAt: new Date(project.createdAt).toISOString(),
+                  }
+                : null,
+        };
+    }
+
+    async ensure(user: SessionUser): Promise<EnsureAnalyticsProjectResult> {
+        return this.dependencies.projectService.ensureAnalyticsProject(user);
+    }
+
+    async delete(user: SessionUser, projectUuid: string): Promise<void> {
+        const organizationUuid = await this.authorize(user);
+        await this.dependencies.projectModel.runInAnalyticsProvisioningLock(
+            organizationUuid,
+            async () => {
+                const projects =
+                    await this.dependencies.projectModel.getAllByOrganizationUuid(
+                        organizationUuid,
+                    );
+                const project = projects.find(
+                    (candidate) =>
+                        candidate.projectUuid === projectUuid &&
+                        candidate.provisioningSource === 'analytics',
+                );
+                if (!project) {
+                    throw new NotFoundError('Analytics project not found');
+                }
+                await this.dependencies.projectService.delete(
+                    project.projectUuid,
+                    user,
+                );
+                this.dependencies.userModel.invalidateSessionUserCache(
+                    user.userUuid,
+                );
+            },
+        );
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -19,6 +19,7 @@ import { ModelRepository } from '../models/ModelRepository';
 import PrometheusMetrics from '../prometheus/PrometheusMetrics';
 import type { UtilRepository } from '../utils/UtilRepository';
 import { AdminNotificationService } from './AdminNotificationService/AdminNotificationService';
+import { AnalyticsProjectService } from './AnalyticsProjectService/AnalyticsProjectService';
 import { AnalyticsService } from './AnalyticsService/AnalyticsService';
 import { AsyncQueryService } from './AsyncQueryService/AsyncQueryService';
 import { ComposeEngineClient } from './AsyncQueryService/ComposeEngineClient';
@@ -141,6 +142,7 @@ interface ServiceManifest {
     pinningService: PinningService;
     pivotTableService: PivotTableService;
     projectService: ProjectService;
+    analyticsProjectService: AnalyticsProjectService;
     promptService: PromptService;
     savedChartService: SavedChartService;
     schedulerService: SchedulerService;
@@ -889,6 +891,18 @@ export class ServiceRepository
                         this.getPersistentDownloadFileService(),
                     organizationSettingsModel:
                         this.models.getOrganizationSettingsModel(),
+                }),
+        );
+    }
+
+    public getAnalyticsProjectService(): AnalyticsProjectService {
+        return this.getService(
+            'analyticsProjectService',
+            () =>
+                new AnalyticsProjectService({
+                    projectModel: this.models.getProjectModel(),
+                    projectService: this.getProjectService(),
+                    userModel: this.models.getUserModel(),
                 }),
         );
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1240,4 +1240,5 @@ export * from './compiler/compileLightdashModels';
 
 export * from './lightdash/LightdashModelEditor';
 export * from './lightdash/convertCustomMetricToLightdash';
+export * from './types/analyticsProject';
 export * from './types/recentContent';

--- a/packages/common/src/types/analyticsProject.ts
+++ b/packages/common/src/types/analyticsProject.ts
@@ -1,0 +1,15 @@
+export type AnalyticsProjectStatus = {
+    project: {
+        projectUuid: string;
+        name: string;
+        slug: string | null;
+        url: string;
+        createdAt: string;
+    } | null;
+};
+
+export type EnsureAnalyticsProjectResult = {
+    projectUuid: string;
+    url: string;
+    created: boolean;
+};

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -110,6 +110,10 @@ import {
     type UserActivity,
     type ViewStatistics,
 } from './analytics';
+import {
+    type AnalyticsProjectStatus,
+    type EnsureAnalyticsProjectResult,
+} from './analyticsProject';
 import { type AnyType } from './any';
 import {
     type ApiCreateComment,
@@ -1265,6 +1269,8 @@ type ApiResults =
     | BigqueryProjectRecommendation
     | ApiScimRequestLogListResponse['results']
     | EnsurePlaygroundProjectResults
+    | AnalyticsProjectStatus
+    | EnsureAnalyticsProjectResult
     | CreateTrainingPreviewResults
     | ApiWarehouseConnectCodeResponse['results']
     | ApiWarehouseConnectCodeClaimResponse['results']

--- a/packages/frontend/src/components/Settings/SettingsNavigation.tsx
+++ b/packages/frontend/src/components/Settings/SettingsNavigation.tsx
@@ -6,6 +6,7 @@ import {
     type SettingsNavigationItem,
     type SettingsNavigationSection,
 } from '../../hooks/settings/types';
+import { BetaBadge } from '../common/BetaBadge';
 import MantineIcon from '../common/MantineIcon';
 import RouterNavLink from '../common/RouterNavLink';
 
@@ -44,6 +45,7 @@ const SettingsNavigation: FC<SettingsNavigationProps> = ({
                     exact={item.exact}
                     onClick={item.onClick}
                     leftSection={leftSection}
+                    rightSection={item.isBeta ? <BetaBadge /> : undefined}
                 />
             );
         }

--- a/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.test.tsx
+++ b/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.test.tsx
@@ -34,7 +34,12 @@ const renderPanel = () =>
     );
 
 describe('LightdashAnalyticsPanel', () => {
-    beforeEach(() => vi.resetAllMocks());
+    beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) =>
+            url.includes('/dashboards?') ? [] : { project },
+        );
+    });
 
     it('creates only on click and redirects using the server URL', async () => {
         vi.mocked(lightdashApi).mockResolvedValue({ project: null });
@@ -64,10 +69,9 @@ describe('LightdashAnalyticsPanel', () => {
     });
 
     it('opens an existing project without recreating or refreshing it', async () => {
-        vi.mocked(lightdashApi).mockResolvedValue({ project });
         renderPanel();
         expect(
-            await screen.findByRole('link', { name: 'Open' }),
+            await screen.findByRole('link', { name: 'Explore' }),
         ).toHaveAttribute('href', project.url);
         expect(
             screen.queryByRole('button', { name: 'Create' }),
@@ -95,8 +99,39 @@ describe('LightdashAnalyticsPanel', () => {
         ).toBeVisible();
     });
 
+    it('refreshes dashboard shortcuts for the analytics project', async () => {
+        renderPanel();
+        expect(await screen.findByText(/No dashboards yet/)).toBeVisible();
+        expect(lightdashApi).toHaveBeenCalledWith({
+            url: '/projects/analytics-project/dashboards?includePrivate=true',
+            method: 'GET',
+            body: undefined,
+        });
+        vi.mocked(lightdashApi).mockImplementation(async ({ url }) =>
+            url.includes('/dashboards?')
+                ? [
+                      {
+                          uuid: 'dashboard',
+                          slug: 'ai-usage-overview',
+                          name: 'AI usage overview',
+                          description: 'Daily AI usage',
+                          updatedAt: '2026-09-10T10:00:00Z',
+                      },
+                  ]
+                : { project },
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+        expect(
+            await screen.findByRole('link', { name: 'AI usage overview' }),
+        ).toHaveAttribute(
+            'href',
+            '/projects/lightdash-analytics-1/dashboards/ai-usage-overview/view',
+        );
+        expect(screen.getByText('Daily AI usage')).toBeVisible();
+        expect(screen.getByText(/^Updated /)).toBeVisible();
+    });
+
     it('requires confirmation before deleting and returns to Create', async () => {
-        vi.mocked(lightdashApi).mockResolvedValue({ project });
         renderPanel();
         await userEvent.click(
             await screen.findByRole('button', { name: 'Delete' }),

--- a/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.test.tsx
+++ b/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.test.tsx
@@ -1,0 +1,133 @@
+import { type AnalyticsProjectStatus } from '@lightdash/common';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../api';
+import { renderWithProviders } from '../../testing/testUtils';
+import LightdashAnalyticsPanel from './LightdashAnalyticsPanel';
+
+vi.mock('../../api', () => ({ lightdashApi: vi.fn() }));
+vi.mock('../../hooks/organization/useOrganization', () => ({
+    useOrganization: () => ({ data: { organizationUuid: 'org' } }),
+}));
+
+const project: NonNullable<AnalyticsProjectStatus['project']> = {
+    projectUuid: 'analytics-project',
+    name: 'Lightdash analytics',
+    slug: 'lightdash-analytics-1',
+    url: '/projects/lightdash-analytics-1/tables',
+    createdAt: '2026-09-10T00:00:00Z',
+};
+
+const renderPanel = () =>
+    renderWithProviders(
+        <MemoryRouter initialEntries={['/settings']}>
+            <Routes>
+                <Route path="/settings" element={<LightdashAnalyticsPanel />} />
+                <Route
+                    path={project.url}
+                    element={<div>Analytics explores</div>}
+                />
+            </Routes>
+        </MemoryRouter>,
+    );
+
+describe('LightdashAnalyticsPanel', () => {
+    beforeEach(() => vi.resetAllMocks());
+
+    it('creates only on click and redirects using the server URL', async () => {
+        vi.mocked(lightdashApi).mockResolvedValue({ project: null });
+        renderPanel();
+        const create = await screen.findByRole('button', {
+            name: 'Create',
+        });
+        expect(lightdashApi).not.toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST' }),
+        );
+        vi.mocked(lightdashApi).mockImplementation(async ({ method }) =>
+            method === 'POST'
+                ? {
+                      projectUuid: project.projectUuid,
+                      url: project.url,
+                      created: true,
+                  }
+                : { project },
+        );
+        await userEvent.click(create);
+        expect(await screen.findByText('Analytics explores')).toBeVisible();
+        expect(lightdashApi).toHaveBeenCalledWith({
+            url: '/org/analytics-project',
+            method: 'POST',
+            body: undefined,
+        });
+    });
+
+    it('opens an existing project without recreating or refreshing it', async () => {
+        vi.mocked(lightdashApi).mockResolvedValue({ project });
+        renderPanel();
+        expect(
+            await screen.findByRole('link', { name: 'Open' }),
+        ).toHaveAttribute('href', project.url);
+        expect(
+            screen.queryByRole('button', { name: 'Create' }),
+        ).not.toBeInTheDocument();
+        expect(lightdashApi).not.toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST' }),
+        );
+    });
+
+    it('does not show Create when status fails and allows retry', async () => {
+        vi.mocked(lightdashApi).mockRejectedValue({
+            error: { message: 'Unavailable' },
+        });
+        renderPanel();
+        expect(
+            await screen.findByText('Unable to load analytics project'),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('button', { name: 'Create' }),
+        ).not.toBeInTheDocument();
+        vi.mocked(lightdashApi).mockResolvedValue({ project: null });
+        await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(
+            await screen.findByRole('button', { name: 'Create' }),
+        ).toBeVisible();
+    });
+
+    it('requires confirmation before deleting and returns to Create', async () => {
+        vi.mocked(lightdashApi).mockResolvedValue({ project });
+        renderPanel();
+        await userEvent.click(
+            await screen.findByRole('button', { name: 'Delete' }),
+        );
+        expect(
+            await screen.findByRole('dialog', {
+                name: 'Delete analytics project?',
+            }),
+        ).toBeVisible();
+        expect(lightdashApi).not.toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'DELETE' }),
+        );
+        vi.mocked(lightdashApi).mockResolvedValue({ project: null });
+        await userEvent.click(
+            within(
+                screen.getByRole('dialog', {
+                    name: 'Delete analytics project?',
+                }),
+            ).getByRole('button', {
+                name: 'Delete',
+            }),
+        );
+        await waitFor(() =>
+            expect(lightdashApi).toHaveBeenCalledWith({
+                url: '/org/analytics-project/analytics-project',
+                method: 'DELETE',
+                body: undefined,
+            }),
+        );
+        expect(
+            await screen.findByRole('button', { name: 'Create' }),
+        ).toBeVisible();
+    });
+});

--- a/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.tsx
@@ -1,0 +1,158 @@
+import { Button, Group, Stack, Text, Title } from '@mantine/core';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import {
+    useAnalyticsProject,
+    useCreateAnalyticsProject,
+    useDeleteAnalyticsProject,
+} from '../../hooks/organization/useAnalyticsProject';
+import { useDeleteActiveProjectMutation } from '../../hooks/useActiveProject';
+import Callout from '../common/Callout';
+import EmptyStateLoader from '../common/EmptyStateLoader';
+import MantineModal from '../common/MantineModal';
+import { SettingsCard } from '../common/Settings/SettingsCard';
+import { SettingsPage } from '../common/Settings/SettingsPage';
+
+const LightdashAnalyticsPanel = ({
+    activeProjectUuid,
+}: {
+    activeProjectUuid?: string;
+}) => {
+    const navigate = useNavigate();
+    const status = useAnalyticsProject();
+    const createProject = useCreateAnalyticsProject();
+    const deleteProject = useDeleteAnalyticsProject();
+    const { mutate: clearActiveProject } = useDeleteActiveProjectMutation();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const analyticsProject = status.data?.project;
+
+    return (
+        <SettingsPage
+            title="Lightdash analytics"
+            isBeta
+            description="Explore your organization's AI usage and query activity."
+        >
+            <SettingsCard>
+                {status.isLoading ? (
+                    <EmptyStateLoader title="Loading analytics project" />
+                ) : status.isError ? (
+                    <Stack gap="md">
+                        <Callout
+                            variant="danger"
+                            title="Unable to load analytics project"
+                        >
+                            {status.error.error.message}
+                        </Callout>
+                        <Group>
+                            <Button
+                                variant="default"
+                                onClick={() => void status.refetch()}
+                            >
+                                Retry
+                            </Button>
+                        </Group>
+                    </Stack>
+                ) : (
+                    <Stack gap="md">
+                        <Stack gap="xs">
+                            <Title order={5}>
+                                {analyticsProject
+                                    ? 'Your analytics project'
+                                    : 'Create your analytics project'}
+                            </Title>
+                            <Text fz="sm" c="dimmed">
+                                {analyticsProject
+                                    ? 'Open your dedicated project to explore AI usage and query events.'
+                                    : 'Create a dedicated project with built-in AI usage and query event models. No connection setup is needed.'}
+                            </Text>
+                        </Stack>
+                        {analyticsProject && (
+                            <Text fz="xs" c="dimmed">
+                                Created{' '}
+                                {new Date(
+                                    analyticsProject.createdAt,
+                                ).toLocaleString()}
+                            </Text>
+                        )}
+                        {createProject.isError && (
+                            <Callout
+                                variant="danger"
+                                title="Unable to create analytics project"
+                            >
+                                {createProject.error.error.message}
+                            </Callout>
+                        )}
+                        <Group>
+                            {analyticsProject ? (
+                                <>
+                                    <Button
+                                        component={Link}
+                                        to={analyticsProject.url}
+                                    >
+                                        Open
+                                    </Button>
+                                    <Button
+                                        variant="subtle"
+                                        color="red"
+                                        onClick={() => {
+                                            deleteProject.reset();
+                                            setDeleteTarget(
+                                                analyticsProject.projectUuid,
+                                            );
+                                        }}
+                                    >
+                                        Delete
+                                    </Button>
+                                </>
+                            ) : (
+                                <Button
+                                    loading={createProject.isLoading}
+                                    onClick={() =>
+                                        createProject.mutate(undefined, {
+                                            onSuccess: ({ url }) =>
+                                                navigate(url),
+                                        })
+                                    }
+                                >
+                                    Create
+                                </Button>
+                            )}
+                        </Group>
+                    </Stack>
+                )}
+            </SettingsCard>
+            <MantineModal
+                opened={deleteTarget !== null}
+                onClose={() => {
+                    if (!deleteProject.isLoading) setDeleteTarget(null);
+                }}
+                title="Delete analytics project?"
+                variant="delete"
+                description="This permanently deletes the analytics project and its saved charts and dashboards. The collected usage events in storage are not deleted. You can create a new analytics project afterwards."
+                confirmLoading={deleteProject.isLoading}
+                onConfirm={() => {
+                    if (deleteTarget)
+                        deleteProject.mutate(deleteTarget, {
+                            onSuccess: () => {
+                                if (deleteTarget === activeProjectUuid)
+                                    clearActiveProject();
+                                setDeleteTarget(null);
+                                createProject.reset();
+                            },
+                        });
+                }}
+            >
+                {deleteProject.isError && (
+                    <Callout
+                        variant="danger"
+                        title="Unable to delete analytics project"
+                    >
+                        {deleteProject.error.error.message}
+                    </Callout>
+                )}
+            </MantineModal>
+        </SettingsPage>
+    );
+};
+
+export default LightdashAnalyticsPanel;

--- a/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.tsx
+++ b/packages/frontend/src/components/UserSettings/LightdashAnalyticsPanel.tsx
@@ -1,6 +1,15 @@
-import { Button, Group, Stack, Text, Title } from '@mantine/core';
+import {
+    Anchor,
+    Button,
+    Divider,
+    Group,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
+import { useDashboards } from '../../hooks/dashboard/useDashboards';
 import {
     useAnalyticsProject,
     useCreateAnalyticsProject,
@@ -25,6 +34,11 @@ const LightdashAnalyticsPanel = ({
     const { mutate: clearActiveProject } = useDeleteActiveProjectMutation();
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const analyticsProject = status.data?.project;
+    const dashboards = useDashboards(
+        analyticsProject?.projectUuid,
+        { enabled: status.isSuccess, refetchOnMount: 'always' },
+        true,
+    );
 
     return (
         <SettingsPage
@@ -89,7 +103,7 @@ const LightdashAnalyticsPanel = ({
                                         component={Link}
                                         to={analyticsProject.url}
                                     >
-                                        Open
+                                        Explore
                                     </Button>
                                     <Button
                                         variant="subtle"
@@ -121,6 +135,62 @@ const LightdashAnalyticsPanel = ({
                     </Stack>
                 )}
             </SettingsCard>
+            {status.isSuccess && analyticsProject && (
+                <SettingsCard>
+                    <Stack gap="md">
+                        <Group justify="space-between">
+                            <Title order={5}>Dashboards</Title>
+                            <Button
+                                variant="subtle"
+                                size="xs"
+                                loading={dashboards.isFetching}
+                                onClick={() => void dashboards.refetch()}
+                            >
+                                Refresh
+                            </Button>
+                        </Group>
+                        {dashboards.isLoading ? (
+                            <EmptyStateLoader title="Loading dashboards" />
+                        ) : dashboards.isError ? (
+                            <Callout
+                                variant="danger"
+                                title="Unable to load dashboards"
+                            >
+                                {dashboards.error.error.message}
+                            </Callout>
+                        ) : dashboards.data?.length ? (
+                            dashboards.data.map((dashboard, index) => (
+                                <Stack key={dashboard.uuid} gap="xs">
+                                    {index > 0 && <Divider />}
+                                    <Anchor
+                                        component={Link}
+                                        to={`/projects/${analyticsProject.slug ?? analyticsProject.projectUuid}/dashboards/${dashboard.slug}/view`}
+                                    >
+                                        {dashboard.name}
+                                    </Anchor>
+                                    {dashboard.description && (
+                                        <Text fz="sm" c="dimmed">
+                                            {dashboard.description}
+                                        </Text>
+                                    )}
+                                    <Text fz="xs" c="dimmed">
+                                        Updated{' '}
+                                        {new Date(
+                                            dashboard.updatedAt,
+                                        ).toLocaleString()}
+                                    </Text>
+                                </Stack>
+                            ))
+                        ) : (
+                            <Text fz="sm" c="dimmed">
+                                No dashboards yet. Save a dashboard in your
+                                analytics project, then refresh this list to see
+                                it here.
+                            </Text>
+                        )}
+                    </Stack>
+                </SettingsCard>
+            )}
             <MantineModal
                 opened={deleteTarget !== null}
                 onClose={() => {

--- a/packages/frontend/src/hooks/organization/useAnalyticsProject.ts
+++ b/packages/frontend/src/hooks/organization/useAnalyticsProject.ts
@@ -1,0 +1,61 @@
+import {
+    type AnalyticsProjectStatus,
+    type EnsureAnalyticsProjectResult,
+    type ApiError,
+} from '@lightdash/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+import { useOrganization } from './useOrganization';
+
+export const useAnalyticsProject = () => {
+    const { data: organization } = useOrganization();
+    return useQuery<AnalyticsProjectStatus, ApiError>({
+        queryKey: ['analytics-project', organization?.organizationUuid],
+        queryFn: () =>
+            lightdashApi<AnalyticsProjectStatus>({
+                url: '/org/analytics-project',
+                method: 'GET',
+            }),
+        enabled: !!organization?.organizationUuid,
+        retry: false,
+    });
+};
+
+const useRefreshAnalyticsProject = () => {
+    const queryClient = useQueryClient();
+    return () =>
+        Promise.all([
+            queryClient.invalidateQueries(['analytics-project']),
+            queryClient.invalidateQueries(['projects']),
+            queryClient.invalidateQueries(['user']),
+        ]);
+};
+
+export const useCreateAnalyticsProject = () => {
+    const refresh = useRefreshAnalyticsProject();
+    return useMutation<EnsureAnalyticsProjectResult, ApiError>(
+        () =>
+            lightdashApi<EnsureAnalyticsProjectResult>({
+                url: '/org/analytics-project',
+                method: 'POST',
+                body: undefined,
+            }),
+        {
+            retry: false,
+            onSuccess: refresh,
+        },
+    );
+};
+
+export const useDeleteAnalyticsProject = () => {
+    const refresh = useRefreshAnalyticsProject();
+    return useMutation<undefined, ApiError, string>(
+        (projectUuid) =>
+            lightdashApi<undefined>({
+                url: `/org/analytics-project/${projectUuid}`,
+                method: 'DELETE',
+                body: undefined,
+            }),
+        { retry: false, onSuccess: refresh },
+    );
+};

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -27,6 +27,7 @@ export type SettingsNavigationItem = {
     icon: TablerIcon;
     /** Render the gradient AI orb instead of `icon` in the sidebar. */
     aiAgentIcon?: boolean;
+    isBeta?: boolean;
     /** Hidden search aliases so e.g. "sso" finds "Single Sign-On". */
     keywords: string[];
     /**
@@ -62,6 +63,8 @@ export type SettingsContext = {
     showImpersonationPanel: boolean | undefined;
     isCustomRolesEnabled: boolean | undefined;
     isProLimitsEnabled: boolean;
+    canAccessAnalyticsSettings: boolean;
+    isAnalyticsProjectFlagLoading: boolean;
     isOrganizationRoadmapEnabled: boolean;
     isOrganizationRoadmapLoading: boolean;
     isSsoOrganizationSettingsEnabled: boolean;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -142,6 +142,18 @@ export const useSettingsContext = (): SettingsContext => {
     // out, matching what the backend actually authorizes.
     const { data: projects } = useProjects();
     const organizationUuid = organization?.organizationUuid;
+    const {
+        data: analyticsProjectFlag,
+        isInitialLoading: isAnalyticsProjectFlagLoading,
+    } = useServerFeatureFlag(FeatureFlags.AnalyticsProject);
+    const canAccessAnalyticsSettings =
+        analyticsProjectFlag?.enabled === true &&
+        !!organizationUuid &&
+        (user?.ability.can(
+            'manage',
+            subject('Organization', { organizationUuid }),
+        ) ??
+            false);
     const canManageOrgAiAgent =
         user?.ability?.can(
             'manage',
@@ -195,6 +207,8 @@ export const useSettingsContext = (): SettingsContext => {
         showImpersonationPanel,
         isCustomRolesEnabled,
         isProLimitsEnabled,
+        canAccessAnalyticsSettings,
+        isAnalyticsProjectFlagLoading,
         isOrganizationRoadmapEnabled,
         isOrganizationRoadmapLoading:
             organizationRoadmapFlagQuery.isInitialLoading,

--- a/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsNavigation.ts
@@ -77,6 +77,7 @@ export const useSettingsNavigation = (
         hasSocialLogin,
         isGroupManagementEnabled,
         isProLimitsEnabled,
+        canAccessAnalyticsSettings,
         isOrganizationRoadmapEnabled,
         isCustomRolesEnabled,
         isSsoOrganizationSettingsEnabled,
@@ -444,6 +445,18 @@ export const useSettingsNavigation = (
                 to: '/generalSettings/projectManagement',
                 icon: IconDatabase,
                 keywords: ['projects', 'manage'],
+                children: [],
+                exact: true,
+            });
+        }
+
+        if (canAccessAnalyticsSettings) {
+            organizationItems.push({
+                label: 'Lightdash analytics',
+                to: '/generalSettings/lightdashAnalytics',
+                icon: IconReportAnalytics,
+                isBeta: true,
+                keywords: ['usage', 'analytics', 'tokens', 'queries'],
                 children: [],
                 exact: true,
             });
@@ -1063,6 +1076,7 @@ export const useSettingsNavigation = (
         hasSocialLogin,
         isGroupManagementEnabled,
         isProLimitsEnabled,
+        canAccessAnalyticsSettings,
         isOrganizationRoadmapEnabled,
         isCustomRolesEnabled,
         isSsoOrganizationSettingsEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -47,6 +47,7 @@ import GithubUserSettingsPanel from '../components/UserSettings/GithubUserSettin
 import GitlabSettingsPanel from '../components/UserSettings/GitlabSettingsPanel';
 import ImpersonationPanel from '../components/UserSettings/ImpersonationPanel';
 import { LeaveOrganizationPanel } from '../components/UserSettings/LeaveOrganizationPanel';
+import LightdashAnalyticsPanel from '../components/UserSettings/LightdashAnalyticsPanel';
 import LimitsPanel from '../components/UserSettings/LimitsPanel';
 import MyAppsPanel from '../components/UserSettings/MyAppsPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
@@ -163,6 +164,8 @@ const Settings: FC = () => {
         showImpersonationPanel,
         isCustomRolesEnabled,
         isProLimitsEnabled,
+        canAccessAnalyticsSettings,
+        isAnalyticsProjectFlagLoading,
         isOrganizationRoadmapEnabled,
         isOrganizationRoadmapLoading,
         isSsoOrganizationSettingsEnabled,
@@ -379,6 +382,16 @@ const Settings: FC = () => {
                             <ExportingPanel />
                         </SettingsGridCard>
                     </SettingsPage>
+                ),
+            });
+        }
+        if (canAccessAnalyticsSettings) {
+            allowedRoutes.push({
+                path: '/lightdashAnalytics',
+                element: (
+                    <LightdashAnalyticsPanel
+                        activeProjectUuid={project?.projectUuid}
+                    />
                 ),
             });
         }
@@ -776,6 +789,7 @@ const Settings: FC = () => {
         dataAppsFlag?.enabled,
         externalSourcesFlag?.enabled,
         isProLimitsEnabled,
+        canAccessAnalyticsSettings,
         isOrganizationRoadmapEnabled,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
@@ -921,6 +935,11 @@ const Settings: FC = () => {
     const isAwaitingDataAppsRoute =
         isDataAppsFlagLoading &&
         Boolean(matchPath('/generalSettings/dataApps/*', location.pathname));
+    const isAwaitingAnalyticsRoute =
+        isAnalyticsProjectFlagLoading &&
+        Boolean(
+            matchPath('/generalSettings/lightdashAnalytics', location.pathname),
+        );
 
     if (
         isHealthLoading ||
@@ -930,7 +949,8 @@ const Settings: FC = () => {
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
         isAwaitingRoadmapRoute ||
-        isAwaitingDataAppsRoute
+        isAwaitingDataAppsRoute ||
+        isAwaitingAnalyticsRoute
     ) {
         return <PageSpinner />;
     }


### PR DESCRIPTION
![CleanShot 2026-09-10 at 10.27.04.png](https://app.graphite.com/user-attachments/assets/e90a222b-d34a-4271-acd4-18c5d07793fd.png)





## Summary

- add a feature-flagged **Lightdash analytics (Beta)** page to organization settings
- show safe status metadata for the current organization's managed analytics project and provide Create/Open actions
- add a confirmed reset action that deletes only the exact analytics-marked project while retaining collected event files
- move analytics-project endpoints into a dedicated controller/service so status, provisioning, reset, and future sync share one authorization boundary

## Security

- every status/create/delete operation reuses the existing analytics feature, development-environment, organization, and org-admin guard
- organization and storage scope are derived on the server from the authenticated session; the client cannot provide an organization UUID or object path
- deletion is performed under the per-organization provisioning lock and requires an exact UUID match on a project marked with `provisioningSource: analytics`
- no credentials, bucket names, or object paths are returned by the status endpoint

## Verification

- common, backend, and frontend typechecks
- focused backend tests: 15 passed
- focused frontend tests: 4 passed
- focused common/backend/frontend lint and formatting checks
- generated API route validation
- local browser smoke test for settings visibility, status rendering, and opening the real analytics project URL

Stacked on #28929, which keeps all-history Parquet queries within the expected interactive latency.

Closes: PROD-11153
Relates: PROD-8603