### PR TITLE
fix(omnibar): keep validation error icons consistently sized

### DIFF
--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -45,6 +45,7 @@ const OmnibarItem: FC<Props> = ({
                 {itemHasValidationError(item) ? (
                     <OmnibarItemIconWithIndicator
                         item={item}
+                        boxSize={26}
                         projectUuid={projectUuid}
                         canUserManageValidation={canUserManageValidation}
                     />

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
@@ -26,15 +26,14 @@ export const OmnibarItemIcon: FC<Props> = ({ item, boxSize }) => {
     );
 };
 
-type OmnibarItemIconWithIndicatorProps = {
-    item: SearchItem;
+type OmnibarItemIconWithIndicatorProps = Props & {
     projectUuid: string;
     canUserManageValidation: boolean;
 };
 
 export const OmnibarItemIconWithIndicator: FC<
     OmnibarItemIconWithIndicatorProps
-> = ({ item, projectUuid, canUserManageValidation }) =>
+> = ({ item, boxSize, projectUuid, canUserManageValidation }) =>
     item.item && 'validationErrors' in item.item ? (
         <ResourceIndicator
             iconProps={{
@@ -77,6 +76,6 @@ export const OmnibarItemIconWithIndicator: FC<
                 )
             }
         >
-            <OmnibarItemIcon item={item} />
+            <OmnibarItemIcon item={item} boxSize={boxSize} />
         </ResourceIndicator>
     ) : null;


### PR DESCRIPTION
### Description

Omnibar rows with validation errors use a 32px icon box, while normal rows use 26px. Forward the row's `boxSize` through the validation wrapper so the icon and its box stay the same size, with the warning badge and tooltip preserved.

Extracted from #28966 so this UI correction can merge independently of the search performance changes. This PR starts from main and changes only the two icon-rendering files.

Validation: the files match the previously browser-verified fix exactly (normal and broken dashboard/chart rows use 26px boxes and 16px icons). Lint, formatting, diff checks and the unused-export check passed on this branch.

### Risk assessment

- [ ] This is a high-risk change
