### PR TITLE
feat(cli): type to search the project selection list

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
     "execa": "5.1.1",
     "google-auth-library": "10.7.0",
     "inquirer": "8.2.7",
+    "inquirer-autocomplete-prompt": "2.0.1",
     "js-yaml": "4.3.0",
     "lodash": "4.18.1",
     "node-fetch": "2.7.0",
@@ -69,8 +70,7 @@
   },
   "devDependencies": {
     "@types/inquirer": "8.2.4",
-    "oxlint": "1.75.0",
-    "oxlint-tsgolint": "7.0.2001",
+    "@types/inquirer-autocomplete-prompt": "3.0.3",
     "@types/js-yaml": "4.0.9",
     "@types/lodash": "4.14.202",
     "@types/node-fetch": "2.6.13",
@@ -81,6 +81,8 @@
     "@vercel/ncc": "0.38.4",
     "@yao-pkg/pkg": "6.7.0",
     "copyfiles": "2.4.1",
+    "oxlint": "1.75.0",
+    "oxlint-tsgolint": "7.0.2001",
     "tsx": "4.19.4",
     "typescript": "7.0.2",
     "vitest": "4.1.6"

--- a/packages/cli/src/handlers/setProject.test.ts
+++ b/packages/cli/src/handlers/setProject.test.ts
@@ -1,12 +1,14 @@
 import { OrganizationProject, ProjectType } from '@lightdash/common';
-import inquirer from 'inquirer';
-import type { Mocked, MockedFunction } from 'vitest';
+import type { MockedFunction } from 'vitest';
 import { setProject as setProjectConfig } from '../config';
 import GlobalState from '../globalState';
+import { promptFuzzySearch } from '../prompts/fuzzySearchPrompt';
 import { lightdashApi } from './dbt/apiClient';
 import { setProjectCommand } from './setProject';
 
-vi.mock('inquirer');
+vi.mock('../prompts/fuzzySearchPrompt', () => ({
+    promptFuzzySearch: vi.fn(),
+}));
 vi.mock('../analytics/analytics');
 vi.mock('./dbt/apiClient', () => ({
     lightdashApi: vi.fn(),
@@ -18,7 +20,9 @@ vi.mock('../config', () => ({
 }));
 
 const mockLightdashApi = lightdashApi as MockedFunction<typeof lightdashApi>;
-const mockInquirer = inquirer as Mocked<typeof inquirer>;
+const mockPromptFuzzySearch = promptFuzzySearch as MockedFunction<
+    typeof promptFuzzySearch
+>;
 const mockSetProjectConfig = setProjectConfig as MockedFunction<
     typeof setProjectConfig
 >;
@@ -54,17 +58,12 @@ describe('setProjectCommand', () => {
 
     it('does not offer preview projects in the interactive list', async () => {
         mockLightdashApi.mockResolvedValueOnce(buildProjects() as never);
-        const promptMock = vi
-            .fn()
-            .mockResolvedValueOnce({ project: MAIN_UUID });
-        mockInquirer.prompt = promptMock as never;
+        mockPromptFuzzySearch.mockResolvedValueOnce(MAIN_UUID as never);
 
         await setProjectCommand();
 
-        const promptArgs = promptMock.mock.calls[0][0];
-        const choices = promptArgs[0].choices.map(
-            (c: { name: string; value: string }) => c.value,
-        );
+        const promptArgs = mockPromptFuzzySearch.mock.calls[0][0];
+        const choices = promptArgs.choices.map((c) => c.value);
         expect(choices).toContain(MAIN_UUID);
         expect(choices).not.toContain(PREVIEW_UUID);
         expect(mockSetProjectConfig).toHaveBeenCalledWith(

--- a/packages/cli/src/handlers/setProject.ts
+++ b/packages/cli/src/handlers/setProject.ts
@@ -1,9 +1,9 @@
 import { OrganizationProject, ProjectType } from '@lightdash/common';
-import inquirer from 'inquirer';
 import { URL } from 'url';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig, setProject, unsetProject } from '../config';
 import GlobalState from '../globalState';
+import { promptFuzzySearch } from '../prompts/fuzzySearchPrompt';
 import { lightdashApi } from './dbt/apiClient';
 
 type SetProjectOptions = {
@@ -57,30 +57,27 @@ export const setProjectCommand = async (
         [selectedProject] = nonPreviewProjects;
     } else {
         const SKIP_VALUE = '__skip__';
-        const answers = await inquirer.prompt([
-            {
-                type: 'list',
-                name: 'project',
-                choices: [
-                    {
-                        name: "Don't select a project",
-                        value: SKIP_VALUE,
-                    },
-                    ...nonPreviewProjects.map((project) => ({
-                        name: project.name,
-                        value: project.projectUuid,
-                    })),
-                ],
-            },
-        ]);
+        const answer = await promptFuzzySearch<string>({
+            message: 'Select a project (type to search)',
+            pinnedChoices: [
+                {
+                    name: "Don't select a project",
+                    value: SKIP_VALUE,
+                },
+            ],
+            choices: nonPreviewProjects.map((project) => ({
+                name: project.name,
+                value: project.projectUuid,
+            })),
+        });
 
-        if (answers.project === SKIP_VALUE) {
+        if (answer === SKIP_VALUE) {
             await unsetProject();
             return 'skipped';
         }
 
         selectedProject = nonPreviewProjects.find(
-            (project) => project.projectUuid === answers.project,
+            (project) => project.projectUuid === answer,
         );
     }
 

--- a/packages/cli/src/prompts/fuzzySearchPrompt.test.ts
+++ b/packages/cli/src/prompts/fuzzySearchPrompt.test.ts
@@ -1,0 +1,64 @@
+import { fuzzyFilterChoices } from './fuzzySearchPrompt';
+
+const buildChoices = (names: string[]) =>
+    names.map((name) => ({ name, value: name }));
+
+describe('fuzzyFilterChoices', () => {
+    it('returns every choice when the search is empty', () => {
+        const choices = buildChoices(['alpha', 'beta']);
+        expect(fuzzyFilterChoices(choices, '')).toEqual(choices);
+        expect(fuzzyFilterChoices(choices, '   ')).toEqual(choices);
+    });
+
+    it('matches case-insensitively on substrings', () => {
+        const choices = buildChoices(['Jaffle Shop', 'Internal analytics']);
+        expect(
+            fuzzyFilterChoices(choices, 'analytics').map((c) => c.name),
+        ).toEqual(['Internal analytics']);
+    });
+
+    it('matches out-of-order tokens', () => {
+        const choices = buildChoices([
+            'production-eu',
+            'production-us',
+            'staging-eu',
+        ]);
+        expect(
+            fuzzyFilterChoices(choices, 'eu prod').map((c) => c.name),
+        ).toEqual(['production-eu']);
+    });
+
+    it('matches subsequences', () => {
+        const choices = buildChoices(['production-europe', 'staging']);
+        expect(fuzzyFilterChoices(choices, 'pdeu').map((c) => c.name)).toEqual([
+            'production-europe',
+        ]);
+    });
+
+    it('ranks prefix matches above substring and subsequence matches', () => {
+        const choices = buildChoices([
+            'my-prod-clone',
+            'production',
+            'p-r-o-d',
+        ]);
+        expect(fuzzyFilterChoices(choices, 'prod').map((c) => c.name)).toEqual([
+            'production',
+            'my-prod-clone',
+            'p-r-o-d',
+        ]);
+    });
+
+    it('keeps the original order between equally-ranked choices', () => {
+        const choices = buildChoices(['prod-a', 'prod-b', 'prod-c']);
+        expect(fuzzyFilterChoices(choices, 'prod').map((c) => c.name)).toEqual([
+            'prod-a',
+            'prod-b',
+            'prod-c',
+        ]);
+    });
+
+    it('returns nothing when a token does not match', () => {
+        const choices = buildChoices(['alpha', 'beta']);
+        expect(fuzzyFilterChoices(choices, 'zzz')).toEqual([]);
+    });
+});

--- a/packages/cli/src/prompts/fuzzySearchPrompt.ts
+++ b/packages/cli/src/prompts/fuzzySearchPrompt.ts
@@ -1,0 +1,111 @@
+import inquirer from 'inquirer';
+import autocompletePrompt from 'inquirer-autocomplete-prompt';
+
+const PROMPT_TYPE = 'autocomplete';
+
+let registered = false;
+const registerPrompt = () => {
+    if (registered) return;
+    inquirer.registerPrompt(PROMPT_TYPE, autocompletePrompt);
+    registered = true;
+};
+
+export type FuzzyChoice<T> = {
+    name: string;
+    value: T;
+};
+
+type ScoredChoice<T> = {
+    choice: FuzzyChoice<T>;
+    score: number;
+};
+
+/**
+ * Scores a choice against a search term. Returns null when it doesn't match.
+ * Lower scores rank higher: exact prefix beats substring beats subsequence.
+ */
+const scoreChoice = (name: string, search: string): number | null => {
+    const haystack = name.toLowerCase();
+    const needle = search.toLowerCase();
+
+    if (needle.length === 0) return 0;
+
+    const index = haystack.indexOf(needle);
+    if (index === 0) return 0;
+    if (index > 0) return 1000 + index;
+
+    // Subsequence match: characters appear in order but not contiguously.
+    let cursor = 0;
+    let firstMatch = -1;
+    let gaps = 0;
+    for (const char of needle) {
+        const found = haystack.indexOf(char, cursor);
+        if (found === -1) return null;
+        if (firstMatch === -1) firstMatch = found;
+        else gaps += found - cursor;
+        cursor = found + 1;
+    }
+    return 100000 + gaps + firstMatch;
+};
+
+/**
+ * Filters and ranks choices by a search term. Every whitespace-separated token
+ * must match, so "prod eu" narrows to names containing both.
+ */
+export const fuzzyFilterChoices = <T>(
+    choices: FuzzyChoice<T>[],
+    search: string,
+): FuzzyChoice<T>[] => {
+    const tokens = search.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return choices;
+
+    return (
+        choices
+            .reduce<ScoredChoice<T>[]>((acc, choice) => {
+                let total = 0;
+                for (const token of tokens) {
+                    const score = scoreChoice(choice.name, token);
+                    if (score === null) return acc;
+                    total += score;
+                }
+                acc.push({ choice, score: total });
+                return acc;
+            }, [])
+            // Array#sort is stable, so equally-scored choices keep their order.
+            .sort((a, b) => a.score - b.score)
+            .map(({ choice }) => choice)
+    );
+};
+
+/**
+ * A list prompt you can type into to narrow down the options.
+ * `pinnedChoices` are shown at the top while nothing has been typed.
+ */
+export const promptFuzzySearch = async <T>({
+    message,
+    choices,
+    pinnedChoices = [],
+}: {
+    message: string;
+    choices: FuzzyChoice<T>[];
+    pinnedChoices?: FuzzyChoice<T>[];
+}): Promise<T> => {
+    registerPrompt();
+    const { answer } = await inquirer.prompt<{ answer: T }>([
+        {
+            type: PROMPT_TYPE,
+            name: 'answer',
+            message,
+            emptyText: 'No matches',
+            // inquirer-autocomplete-prompt passes `undefined` on first render.
+            source: (_answersSoFar: unknown, search: string | undefined) => {
+                const term = search ?? '';
+                return Promise.resolve([
+                    ...(term.trim() === '' ? pinnedChoices : []),
+                    ...fuzzyFilterChoices(choices, term),
+                ]);
+            },
+        },
+    ]);
+    return answer;
+};

--- a/packages/cli/src/prompts/fuzzySearchPrompt.ts
+++ b/packages/cli/src/prompts/fuzzySearchPrompt.ts
@@ -90,6 +90,17 @@ export const promptFuzzySearch = async <T>({
     choices: FuzzyChoice<T>[];
     pinnedChoices?: FuzzyChoice<T>[];
 }): Promise<T> => {
+    const allChoices = [...pinnedChoices, ...choices];
+
+    // Searching needs a terminal to type into: without one the autocomplete
+    // prompt gets the whole piped line at once and never resolves a choice.
+    if (!process.stdin.isTTY) {
+        const { answer } = await inquirer.prompt<{ answer: T }>([
+            { type: 'list', name: 'answer', message, choices: allChoices },
+        ]);
+        return answer;
+    }
+
     registerPrompt();
     const { answer } = await inquirer.prompt<{ answer: T }>([
         {
@@ -100,10 +111,11 @@ export const promptFuzzySearch = async <T>({
             // inquirer-autocomplete-prompt passes `undefined` on first render.
             source: (_answersSoFar: unknown, search: string | undefined) => {
                 const term = search ?? '';
-                return Promise.resolve([
-                    ...(term.trim() === '' ? pinnedChoices : []),
-                    ...fuzzyFilterChoices(choices, term),
-                ]);
+                return Promise.resolve(
+                    term.trim() === ''
+                        ? allChoices
+                        : fuzzyFilterChoices(choices, term),
+                );
             },
         },
     ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,6 +761,9 @@ importers:
       inquirer:
         specifier: 8.2.7
         version: 8.2.7(@types/node@24.13.2)
+      inquirer-autocomplete-prompt:
+        specifier: 2.0.1
+        version: 2.0.1(inquirer@8.2.7(@types/node@24.13.2))
       js-yaml:
         specifier: 4.3.0
         version: 4.3.0
@@ -801,6 +804,9 @@ importers:
       '@types/inquirer':
         specifier: 8.2.4
         version: 8.2.4
+      '@types/inquirer-autocomplete-prompt':
+        specifier: 3.0.3
+        version: 3.0.3
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
@@ -7274,6 +7280,9 @@ packages:
   '@types/http-errors@2.0.1':
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
 
+  '@types/inquirer-autocomplete-prompt@3.0.3':
+    resolution: {integrity: sha512-OQCW09mEECgvhcppbQRgZSmWskWv58l+WwyUvWB1oxTu3CZj8keYSDZR9U8owUzJ5Zeux5kacN9iVPJLXcoLXg==}
+
   '@types/inquirer@8.2.4':
     resolution: {integrity: sha512-Pxxx3i3AyK7vKAj3LRM/vF7ETcHKiLJ/u5CnNgbz/eYj/vB3xGAYtRxI5IKtq0hpe5iFHD22BKV3n6WHUu0k4Q==}
 
@@ -10970,6 +10979,12 @@ packages:
 
   inline-style-prefixer@7.0.1:
     resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
+
+  inquirer-autocomplete-prompt@2.0.1:
+    resolution: {integrity: sha512-jUHrH0btO7j5r8DTQgANf2CBkTZChoVySD8zF/wp5fZCOLIuUbleXhf4ZY5jNBOc1owA3gdfWtfZuppfYBhcUg==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      inquirer: ^8.0.0
 
   inquirer@8.2.7:
     resolution: {integrity: sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==}
@@ -22963,6 +22978,10 @@ snapshots:
 
   '@types/http-errors@2.0.1': {}
 
+  '@types/inquirer-autocomplete-prompt@3.0.3':
+    dependencies:
+      '@types/inquirer': 8.2.4
+
   '@types/inquirer@8.2.4':
     dependencies:
       '@types/through': 0.0.30
@@ -27905,6 +27924,15 @@ snapshots:
   inline-style-prefixer@7.0.1:
     dependencies:
       css-in-js-utils: 3.1.0
+
+  inquirer-autocomplete-prompt@2.0.1(inquirer@8.2.7(@types/node@24.13.2)):
+    dependencies:
+      ansi-escapes: 4.3.2
+      figures: 3.2.0
+      inquirer: 8.2.7(@types/node@24.13.2)
+      picocolors: 1.1.1
+      run-async: 2.4.1
+      rxjs: 7.8.1
 
   inquirer@8.2.7(@types/node@24.13.2):
     dependencies:


### PR DESCRIPTION
### Description:

Adds a new fuzzy search prompt component that enables users to search and filter through projects when selecting one via the CLI. This replaces the basic list prompt in `setProjectCommand` with an interactive autocomplete experience.

**Key changes:**

- **New `fuzzySearchPrompt.ts` module**: Implements fuzzy matching with intelligent ranking (exact prefix > substring > subsequence), multi-token filtering (whitespace-separated), and fallback to basic list prompt when stdin is not a TTY (e.g., piped input).
- **Scoring algorithm**: Prioritizes exact prefix matches (score 0), then substring matches (score 1000+), then subsequence matches (score 100000+), ensuring intuitive result ordering.
- **Multi-token support**: Allows searches like "prod eu" to narrow results to items matching both tokens in any order.
- **Pinned choices**: Supports displaying certain choices (like "Don't select a project") at the top while nothing is typed.
- **Updated `setProjectCommand`**: Replaces `inquirer.prompt()` with the new `promptFuzzySearch()` for better UX when selecting projects.
- **Dependencies**: Added `inquirer-autocomplete-prompt` for the underlying autocomplete functionality.

**Test coverage:**

Comprehensive unit tests in `fuzzySearchPrompt.test.ts` cover:
- Empty search behavior
- Case-insensitive substring matching
- Multi-token filtering
- Subsequence matching
- Ranking of different match types
- Stable sorting of equally-ranked results
- Non-matching token filtering

Updated `setProjectCommand.test.ts` to mock the new prompt function and verify preview projects are excluded from the selection list.

### Risk assessment:

- [x] This is a low-risk change

The change is backwards-compatible and only affects the interactive CLI prompt for project selection. The new prompt gracefully falls back to a basic list when stdin is not a TTY, ensuring non-interactive usage (piped input) continues to work. All existing functionality is preserved with improved UX.

https://claude.ai/code/session_01Qo3WLthdQTdzyNVwew3DjY