### PR TITLE
fix(explorer): prevent description preview overlap

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -47,6 +47,8 @@ import FieldIcon from '../../common/Filters/FieldIcon';
 import MantineIcon from '../../common/MantineIcon';
 import classes from './SelectedFieldsSection.module.css';
 import { ItemDetailPreview } from './TableTree/ItemDetailPreview';
+import previewClasses from './TableTree/ItemDetailPreview.module.css';
+import { ITEM_DETAIL_PREVIEW_TRANSITION_PROPS } from './TableTree/itemDetailPreviewTransition';
 import TreeSingleNodeActions from './TableTree/Tree/TreeSingleNodeActions';
 import { type NodeItem } from './TableTree/Tree/types';
 import { useCustomMetricDelete } from './useCustomMetricDelete';
@@ -292,6 +294,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                 disabled={isHoverCardDisabled}
                 position="right"
                 offset={70}
+                transitionProps={ITEM_DETAIL_PREVIEW_TRANSITION_PROPS}
             >
                 <HoverCard.Target>
                     <span className={classes.label} title={label}>
@@ -300,10 +303,11 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
                 </HoverCard.Target>
                 <HoverCard.Dropdown
                     hidden={!isHover}
-                    p="xs"
+                    p="md"
                     miw={400}
                     mah={500}
                     maw={500}
+                    className={previewClasses.previewDropdown}
                     onClick={handleDropdownClick}
                 >
                     <ItemDetailPreview

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.module.css
@@ -14,3 +14,22 @@ table.markdownTable td.markdownCell {
     overflow-wrap: anywhere;
     word-break: break-word;
 }
+
+.previewDropdown {
+    overflow: auto;
+    border-color: var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    box-shadow: var(--mantine-shadow-md);
+}
+
+.markdown {
+    line-height: 1.55;
+}
+
+.markdown > :first-child {
+    margin-top: 0;
+}
+
+.markdown > :last-child {
+    margin-bottom: 0;
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/ItemDetailPreview.tsx
@@ -6,7 +6,6 @@ import {
     type Dimension,
 } from '@lightdash/common';
 import {
-    Anchor,
     Badge,
     Box,
     Button,
@@ -20,7 +19,7 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { IconCode } from '@tabler/icons-react';
+import { IconArrowRight, IconCode } from '@tabler/icons-react';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
 import { Fragment, useState, type FC, type PropsWithChildren } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
@@ -33,6 +32,7 @@ import FieldIcon from '../../../common/Filters/FieldIcon';
 import { filterOperatorLabel } from '../../../common/Filters/FilterInputs/constants';
 import MantineIcon from '../../../common/MantineIcon';
 import classes from './ItemDetailPreview.module.css';
+import { ITEM_DETAIL_PREVIEW_TRANSITION_PROPS } from './itemDetailPreviewTransition';
 
 /**
  * Renders markdown for an item's description, with additional constraints
@@ -43,6 +43,7 @@ export const ItemDetailMarkdown: FC<{ source: string }> = ({ source }) => {
     const theme = useMantineTheme();
     return (
         <ReactMarkdownPreview
+            className={classes.markdown}
             skipHtml
             components={{
                 h1: ({ children }) => <Title order={2}>{children}</Title>,
@@ -102,7 +103,7 @@ export const ItemDetailPreview: FC<{
     const [showCompiled, setShowCompiled] = useState(false);
 
     return (
-        <Stack gap="xs">
+        <Stack gap="sm">
             {metricInfo && (
                 <>
                     <Group gap="xs" justify="space-between">
@@ -171,16 +172,20 @@ export const ItemDetailPreview: FC<{
                 </Box>
             )}
             {isTruncated && (
-                <Box ta={'center'}>
-                    <Anchor
-                        size={'xs'}
-                        onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
+                <Box ta="right">
+                    <Button
+                        variant="subtle"
+                        size="compact-sm"
+                        rightSection={
+                            <MantineIcon icon={IconArrowRight} size="sm" />
+                        }
+                        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                             e.preventDefault();
                             onViewDescription();
                         }}
                     >
                         Read full description
-                    </Anchor>
+                    </Button>
                 </Box>
             )}
             {metricInfo && (
@@ -332,6 +337,7 @@ export const TableItemDetailPreview = ({
             position="right"
             withArrow
             offset={offset}
+            transitionProps={ITEM_DETAIL_PREVIEW_TRANSITION_PROPS}
         >
             <Popover.Target>{children}</Popover.Target>
             <Popover.Dropdown
@@ -340,6 +346,8 @@ export const TableItemDetailPreview = ({
                  * of readability.
                  */
                 maw={500}
+                p="md"
+                className={classes.previewDropdown}
                 /**
                  * If we don't stop propagation, users may unintentionally toggle dimensions/metrics
                  * while interacting with the hovercard.

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeGroupNode.tsx
@@ -19,6 +19,8 @@ import {
 } from '../../../../../features/explorer/store';
 import MantineIcon from '../../../../common/MantineIcon';
 import { ItemDetailPreview } from '../ItemDetailPreview';
+import previewClasses from '../ItemDetailPreview.module.css';
+import { ITEM_DETAIL_PREVIEW_TRANSITION_PROPS } from '../itemDetailPreviewTransition';
 import { buildGroupKey } from '../Virtualization/types';
 import TreeNodes from './TreeNodes';
 import { type GroupNode, type Node } from './types';
@@ -184,6 +186,7 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                          * Ensures the hover card does not overlap with the right-hand menu.
                          */
                         offset={80}
+                        transitionProps={ITEM_DETAIL_PREVIEW_TRANSITION_PROPS}
                     >
                         <HoverCard.Target>
                             <Text
@@ -202,12 +205,13 @@ const TreeGroupNodeComponent: FC<Props> = ({ node }) => {
                         </HoverCard.Target>
                         <HoverCard.Dropdown
                             hidden={!isHover}
-                            p="xs"
+                            p="md"
                             /**
                              * Takes up space to the right, so it's OK to go fairly wide in the interest
                              * of readability.
                              */
                             maw={500}
+                            className={previewClasses.previewDropdown}
                             onClick={handleDropdownClick}
                         >
                             <ItemDetailPreview

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -60,6 +60,8 @@ import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { useCustomMetricDelete } from '../../useCustomMetricDelete';
 import { ItemDetailPreview } from '../ItemDetailPreview';
+import previewClasses from '../ItemDetailPreview.module.css';
+import { ITEM_DETAIL_PREVIEW_TRANSITION_PROPS } from '../itemDetailPreviewTransition';
 import { MAX_GROUP_DEPTH } from './constants';
 import styles from './TreeSingleNode.module.css';
 import TreeSingleNodeActions from './TreeSingleNodeActions';
@@ -469,6 +471,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                          * right at the same offset. Shave ~28px off to align.
                          */
                         offset={isCustomDimension(item) ? 36 : 70}
+                        transitionProps={ITEM_DETAIL_PREVIEW_TRANSITION_PROPS}
                     >
                         <HoverCard.Target>
                             <Text truncate fz="sm" className="ld-grow">
@@ -483,7 +486,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         </HoverCard.Target>
                         <HoverCard.Dropdown
                             hidden={!isHover}
-                            p="xs"
+                            p="md"
                             miw={400}
                             mah={500}
                             /**
@@ -491,7 +494,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                              * of readability.
                              */
                             maw={500}
-                            className={styles.detailPreviewDropdown}
+                            className={`${styles.detailPreviewDropdown} ${previewClasses.previewDropdown}`}
                             onClick={handleDropdownClick}
                         >
                             {isMissing ? (

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/itemDetailPreviewTransition.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/itemDetailPreviewTransition.ts
@@ -1,0 +1,5 @@
+export const ITEM_DETAIL_PREVIEW_TRANSITION_PROPS = {
+    transition: 'fade',
+    duration: 100,
+    exitDuration: 0,
+} as const;


### PR DESCRIPTION
## Summary

- close Explorer description previews synchronously when the cursor leaves, preventing closing portals from stacking during rapid hover
- apply the same compact 100ms entrance and immediate exit across table, group, field, and selected-field previews
- polish preview spacing, typography, border/shadow, and the full-description action

## Root cause

Mantine kept each closing hover/popover portal mounted for its 150ms exit transition. Rapidly traversing sidebar rows accumulated those fading portals, producing overlapping descriptions.

## Proof

The attached recording alternates rapidly between the Orders and Payments model descriptions. Only the active description is ever visible. An 8-cycle browser stress run observed a maximum of one `[role="dialog"]` at all times.

## Validation

- `pnpm -F frontend test src/components/Explorer/ExploreTree/SelectedFieldsSection.test.tsx`
- `pnpm -F frontend typecheck`
- `pnpm -F frontend lint`
- browser stress test: 8 rapid alternating hovers, max visible dialogs = 1

Closes #28980

https://github.com/user-attachments/assets/4a8f9e93-d9f0-4be0-a5e3-5d51622d9f84