### PR TITLE
fix(auth): resolve preview subject conflicts with latest main

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -90,6 +90,7 @@ import {
     PersistentDownloadFileAccessMode,
     PivotConfig,
     PivotConfiguration,
+    projectAbilitySubject,
     ProjectType,
     QueryExecutionContext,
     QueryHistoryListFilters,
@@ -5145,9 +5146,9 @@ export class AsyncQueryService extends ProjectService {
         const isForbidden =
             auditedAbility.cannot(
                 'view',
-                subject('Project', {
+                projectAbilitySubject({
+                    ...projectSummary,
                     organizationUuid,
-                    projectUuid: args.projectUuid,
                 }),
             ) &&
             auditedAbility.cannot(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -32,6 +32,7 @@ import {
     OrganizationMemberRole,
     OrganizationProject,
     ParameterError,
+    projectAbilitySubject,
     ProjectType,
     SaveOrganizationBrandRequest,
     SessionUser,
@@ -655,9 +656,11 @@ export class OrganizationService extends BaseService {
         const accessResults = auditedAbility.canBulk(
             'view',
             projects.map((project) =>
-                subject('Project', {
+                projectAbilitySubject({
+                    ...project,
                     organizationUuid,
-                    projectUuid: project.projectUuid,
+                    upstreamProjectUuid:
+                        project.upstreamProjectUuid ?? undefined,
                     metadata: {
                         projectUuid: project.projectUuid,
                         projectName: project.name,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -167,6 +167,7 @@ import {
     MIN_RESULTS_CACHE_TTL_SECONDS,
     MissingWarehouseCredentialsError,
     MostPopularAndRecentlyUpdated,
+    newProjectAbilitySubject,
     normalizeIndexColumns,
     normalizeWarehouseCredentials,
     NotFoundError,
@@ -184,6 +185,7 @@ import {
     preAggregateUtils,
     PreviewExpiresAt,
     Project,
+    projectAbilitySubject,
     ProjectCatalog,
     ProjectContextEntry,
     ProjectDbtSource,
@@ -1155,7 +1157,7 @@ export class ProjectService extends BaseService {
                 if (
                     auditedAbility.can(
                         'create',
-                        subject('Project', {
+                        newProjectAbilitySubject({
                             organizationUuid: user.organizationUuid!,
                             type: ProjectType.DEFAULT,
                         }),
@@ -1190,11 +1192,7 @@ export class ProjectService extends BaseService {
                     if (
                         auditedAbility.cannot(
                             'view',
-                            subject('Project', {
-                                organizationUuid:
-                                    upstreamProject.organizationUuid,
-                                projectUuid: upstreamProject.projectUuid,
-                            }),
+                            projectAbilitySubject(upstreamProject),
                         )
                     ) {
                         throw new ForbiddenError(
@@ -1232,7 +1230,7 @@ export class ProjectService extends BaseService {
                         // checks if user has permission to create project from an upstream project on a project level
                         auditedAbility.can(
                             'create',
-                            subject('Project', {
+                            newProjectAbilitySubject({
                                 organizationUuid:
                                     upstreamProject.organizationUuid,
                                 upstreamProjectUuid:
@@ -1254,7 +1252,7 @@ export class ProjectService extends BaseService {
                     // checks if user has permission to create project on an organization level
                     auditedAbility.can(
                         'create',
-                        subject('Project', {
+                        newProjectAbilitySubject({
                             organizationUuid: user.organizationUuid!,
                             type: ProjectType.PREVIEW,
                         }),
@@ -4055,7 +4053,7 @@ export class ProjectService extends BaseService {
                 'Internal analytics configuration is managed by the backend',
             );
         const auditedAbility = this.createAuditedAbility(account);
-        if (auditedAbility.cannot('update', subject('Project', project))) {
+        if (auditedAbility.cannot('update', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
 
@@ -4216,7 +4214,7 @@ export class ProjectService extends BaseService {
             if (
                 auditedAbility.cannot(
                     'update',
-                    subject('Project', updatedProject),
+                    projectAbilitySubject(updatedProject),
                 )
             ) {
                 throw new ForbiddenError();
@@ -4711,7 +4709,9 @@ export class ProjectService extends BaseService {
             const stored = await this.projectModel.getWithSensitiveFields(
                 body.projectUuid,
             );
-            if (auditedAbility.cannot('update', subject('Project', stored))) {
+            if (
+                auditedAbility.cannot('update', projectAbilitySubject(stored))
+            ) {
                 throw new ForbiddenError();
             }
             // A switched-but-unsaved warehouse type can't be merged with stored
@@ -11784,7 +11784,10 @@ export class ProjectService extends BaseService {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
         if (
-            auditedAbility.cannot('manage', subject('Project', projectSummary))
+            auditedAbility.cannot(
+                'manage',
+                projectAbilitySubject(projectSummary),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -11903,7 +11906,7 @@ export class ProjectService extends BaseService {
     ): Promise<UserWarehouseCredentials | undefined> {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('view', subject('Project', project))) {
+        if (auditedAbility.cannot('view', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
         const credentials =
@@ -11926,7 +11929,7 @@ export class ProjectService extends BaseService {
     }> {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('view', subject('Project', project))) {
+        if (auditedAbility.cannot('view', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
         const credentials =
@@ -11948,7 +11951,7 @@ export class ProjectService extends BaseService {
     ): Promise<UserWarehouseCredentials[]> {
         const project = await this.projectModel.getSummary(projectUuid);
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('view', subject('Project', project))) {
+        if (auditedAbility.cannot('view', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
         return this.userWarehouseCredentialsModel.getAllByUserUuidForProject(
@@ -12272,7 +12275,7 @@ export class ProjectService extends BaseService {
         const project = await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('update', subject('Project', project))) {
+        if (auditedAbility.cannot('update', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
 
@@ -12303,7 +12306,7 @@ export class ProjectService extends BaseService {
         const project = await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(account);
-        if (auditedAbility.cannot('update', subject('Project', project))) {
+        if (auditedAbility.cannot('update', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
 
@@ -12318,7 +12321,7 @@ export class ProjectService extends BaseService {
         const project = await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(account);
-        if (auditedAbility.cannot('update', subject('Project', project))) {
+        if (auditedAbility.cannot('update', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
 
@@ -12360,7 +12363,7 @@ export class ProjectService extends BaseService {
         const project = await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('update', subject('Project', project))) {
+        if (auditedAbility.cannot('update', projectAbilitySubject(project))) {
             throw new ForbiddenError();
         }
 

--- a/packages/common/src/authorization/projectAbilitySubject.ts
+++ b/packages/common/src/authorization/projectAbilitySubject.ts
@@ -1,0 +1,25 @@
+import { subject } from '@casl/ability';
+import { type ProjectSummary, type ProjectType } from '../types/projects';
+
+type ExistingProjectAbilitySubject = Pick<
+    ProjectSummary,
+    | 'organizationUuid'
+    | 'projectUuid'
+    | 'type'
+    | 'createdByUserUuid'
+    | 'upstreamProjectUuid'
+>;
+
+type NewProjectAbilitySubject = {
+    organizationUuid: string;
+    type: ProjectType;
+    upstreamProjectUuid?: string;
+};
+
+export const projectAbilitySubject = <T>(
+    project: T & ExistingProjectAbilitySubject,
+) => subject('Project', project);
+
+export const newProjectAbilitySubject = <T>(
+    project: T & NewProjectAbilitySubject,
+) => subject('Project', project);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -58,6 +58,7 @@ export * from './authorization/embedPermissions';
 export { getOrganizationMemberRolePermissions } from './authorization/organizationMemberAbility';
 export { projectMemberAbilities } from './authorization/projectMemberAbility';
 export * from './authorization/parseAccount';
+export * from './authorization/projectAbilitySubject';
 export * from './authorization/roleToScopeMapping';
 export * from './authorization/rolePresets';
 export * from './authorization/scopeAbilityBuilder';


### PR DESCRIPTION
## What changed

## Summary

Reapply PR #27437’s existing preview-aware Project subject patch onto the latest `main`. Resolve the project-listing conflict by retaining bulk authorization auditing, project audit metadata, and the newer analytics-project visibility filter.

Keep the existing helper adoption in project creation, query execution, and selected project service checks. No authorization grants or rules changed, and existing mutation checks retain the complete project data they already used.

## Scope

This is the requested conflict-resolution and test-rerun follow-up, not completion of PROD-10136. The repository-wide backend/frontend subject migration and its remaining acceptance criteria are still outstanding.

## Verification

Base refreshed with fetch_repository, then `git merge --ff-only origin/main` to f853d8634faaf50ffc5ab32ec3a458467222d148. Applied PR #27437 using `git apply --3way /tmp/prod-10136-pr.diff`; resolved the OrganizationService conflict while preserving main's bulk auditing and analytics-project filtering.

Passed:
- `pnpm -F common build`
- `pnpm -F common test`: 183 files; 4,267 passed, 1 skipped.
- `pnpm -F backend test`: 614 files passed, 2 skipped; 10,309 tests passed, 1 expected failure, 3 skipped.
- `pnpm -F frontend test`: 514 files; 3,731 tests passed.
- `pnpm -F common typecheck`
- `pnpm -F backend typecheck`
- `pnpm -F frontend typecheck`
- `pnpm -F warehouses typecheck`
- `pnpm -F common lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm -F backend lint`
- `pnpm -F backend exec oxlint -c .oxlintrc.json --fix src/services/OrganizationService/OrganizationService.ts src/services/ProjectService/ProjectService.ts src/services/AsyncQueryService/AsyncQueryService.ts`
- `pnpm -F common exec oxfmt src/authorization/projectAbilitySubject.ts src/index.ts` and the same command with `--check`.
- `pnpm -F backend exec oxfmt src/services/OrganizationService/OrganizationService.ts src/services/ProjectService/ProjectService.ts src/services/AsyncQueryService/AsyncQueryService.ts` and the same command with `--check`.
- `git diff --check`; independent standards and scope reviews reported no findings. Commit hooks passed, worktree clean.

Environment limitations:
- `pnpm -F cli typecheck` fails on missing vitest/globals; package-local node_modules absent.
- `pnpm -F query-sdk typecheck` fails on missing dependencies including react/vitest and resulting type errors; package-local node_modules absent.
- Both failures reproduced on untouched base f853d8634faaf50ffc5ab32ec3a458467222d148 in a detached /tmp/prod10136-baseline worktree with root node_modules linked. Removed baseline worktree afterward.
- An initial parallel lint/frontend-test invocation reported no projects from /home/exedev; reran both from the checkout and obtained the genuine successful results above.

No browser, live API, or database integration testing was performed; this follow-up resolves the existing five-file patch without changing its scope.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-10136-276ff6d30295.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-10136](https://linear.app/lightdash/issue/PROD-10136)

