### PR TITLE
fix(spaces): allow sharing restricted spaces with service accounts

### DIFF
--- a/packages/api-tests/tests/serviceAccountSpaceSharing.test.ts
+++ b/packages/api-tests/tests/serviceAccountSpaceSharing.test.ts
@@ -1,0 +1,328 @@
+import {
+    SEED_ORG_1_EDITOR,
+    SEED_ORG_1_VIEWER,
+    SEED_PROJECT,
+    ServiceAccount,
+    ServiceAccountScope,
+    Space,
+    SpaceShare,
+} from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { ApiClient, Body } from '../helpers/api-client';
+import {
+    anotherLogin,
+    login,
+    loginAsEditor,
+    loginAsViewer,
+} from '../helpers/auth';
+import { uniqueName } from '../helpers/test-isolation';
+
+const spacesUrl = `/api/v1/projects/${SEED_PROJECT.project_uuid}/spaces`;
+const accountsUrl = '/api/v1/service-accounts';
+const allowFailure = { failOnStatusCode: false };
+
+describe('Direct service account access to restricted spaces', () => {
+    let admin: ApiClient;
+    let editor: ApiClient;
+    let viewer: ApiClient;
+    let otherAdmin: ApiClient;
+    const spaces: string[] = [];
+    const accounts: { client: ApiClient; uuid: string }[] = [];
+
+    const createSpace = async (parentSpaceUuid?: string) => {
+        const response = await admin.post<Body<Space>>(spacesUrl, {
+            name: uniqueName('service-account-sharing'),
+            inheritParentPermissions: Boolean(parentSpaceUuid),
+            parentSpaceUuid,
+        });
+        spaces.push(response.body.results.uuid);
+        return response.body.results;
+    };
+
+    const createAccount = async (
+        client = admin,
+        scope = ServiceAccountScope.SYSTEM_EDITOR,
+    ) => {
+        const description = uniqueName('space-sharing-account');
+        const response = await client.post<Body<{ token: string }>>(
+            accountsUrl,
+            {
+                description,
+                scopes: [scope],
+                ...(scope === ServiceAccountScope.SYSTEM_MEMBER
+                    ? {
+                          projectAccess: [
+                              {
+                                  projectUuid: SEED_PROJECT.project_uuid,
+                                  role: 'editor',
+                              },
+                          ],
+                      }
+                    : {}),
+                expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+            },
+        );
+        const listing = await client.get<Body<ServiceAccount[]>>(accountsUrl);
+        const account = listing.body.results.find(
+            (candidate) => candidate.description === description,
+        );
+        if (!account) {
+            throw new Error('Created service account was absent from listing');
+        }
+        accounts.push({ client, uuid: account.uuid });
+        return {
+            ...account,
+            options: {
+                ...allowFailure,
+                headers: {
+                    Authorization: `Bearer ${response.body.results.token}`,
+                },
+            },
+        };
+    };
+
+    beforeAll(async () => {
+        [admin, editor, viewer, otherAdmin] = await Promise.all([
+            login(),
+            loginAsEditor(),
+            loginAsViewer(),
+            anotherLogin(),
+        ]);
+    });
+
+    afterAll(async () => {
+        for (const spaceUuid of [...spaces].reverse()) {
+            await admin.delete(`${spacesUrl}/${spaceUuid}`, allowFailure);
+        }
+        for (const account of accounts) {
+            await account.client.delete(
+                `${accountsUrl}/${account.uuid}`,
+                allowFailure,
+            );
+        }
+    });
+
+    it.each(['viewer', 'editor', 'admin'] as const)(
+        'applies the %s grant, inherits into children, and revokes access',
+        async (spaceRole) => {
+            const account = await createAccount();
+            const space = await createSpace();
+            const child = await createSpace(space.uuid);
+            const sibling = await createSpace();
+            const path = `${spacesUrl}/${space.uuid}`;
+            const serviceClient = new ApiClient();
+
+            expect(
+                (await serviceClient.get(path, account.options)).status,
+            ).toBe(403);
+            await admin.post(`${path}/share`, {
+                userUuid: account.userUuid,
+                spaceRole,
+            });
+            expect(
+                (await serviceClient.get(path, account.options)).status,
+            ).toBe(200);
+            expect(
+                (
+                    await serviceClient.get(
+                        `${spacesUrl}/${child.uuid}`,
+                        account.options,
+                    )
+                ).status,
+            ).toBe(200);
+            expect(
+                (
+                    await serviceClient.get(
+                        `${spacesUrl}/${sibling.uuid}`,
+                        account.options,
+                    )
+                ).status,
+            ).toBe(403);
+
+            const access = await admin.get<Body<{ data: SpaceShare[] }>>(
+                `${path}/access?directOnly=true`,
+            );
+            expect(access.body.results.data).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        userUuid: account.userUuid,
+                        role: spaceRole,
+                        isInternal: true,
+                        firstName: account.description,
+                    }),
+                ]),
+            );
+
+            const dashboard = await serviceClient.post(
+                `/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`,
+                {
+                    name: uniqueName('service-account-dashboard'),
+                    description: '',
+                    tiles: [],
+                    tabs: [],
+                    spaceUuid: space.uuid,
+                },
+                account.options,
+            );
+            expect(dashboard.status).toBe(spaceRole === 'viewer' ? 403 : 201);
+
+            const manage = await serviceClient.post(
+                `${path}/share`,
+                { userUuid: SEED_ORG_1_VIEWER.user_uuid, spaceRole: 'viewer' },
+                account.options,
+            );
+            expect(manage.status).toBe(spaceRole === 'admin' ? 200 : 403);
+
+            await admin.post(`${path}/share`, {
+                userUuid: account.userUuid,
+                spaceRole: 'viewer',
+            });
+            const updated = await admin.get<Body<{ data: SpaceShare[] }>>(
+                `${path}/access?directOnly=true`,
+            );
+            expect(
+                updated.body.results.data.find(
+                    (row) => row.userUuid === account.userUuid,
+                )?.role,
+            ).toBe('viewer');
+            await admin.delete(`${path}/share/${account.userUuid}`);
+            expect(
+                (await serviceClient.get(path, account.options)).status,
+            ).toBe(403);
+            expect(
+                (
+                    await serviceClient.get(
+                        `${spacesUrl}/${child.uuid}`,
+                        account.options,
+                    )
+                ).status,
+            ).toBe(403);
+        },
+    );
+
+    it('allows a human space manager to discover minimal candidates without exposing them in the human directory', async () => {
+        const account = await createAccount();
+        const space = await createSpace();
+        const path = `${spacesUrl}/${space.uuid}`;
+        await admin.post(`${path}/share`, {
+            userUuid: SEED_ORG_1_EDITOR.user_uuid,
+            spaceRole: 'admin',
+        });
+        await admin.post(`${path}/share`, {
+            userUuid: SEED_ORG_1_VIEWER.user_uuid,
+            spaceRole: 'viewer',
+        });
+        expect((await editor.get(accountsUrl, allowFailure)).status).toBe(403);
+        const candidates = await editor.get<
+            Body<Pick<ServiceAccount, 'userUuid' | 'description'>[]>
+        >(`${path}/share/service-accounts`);
+        expect(candidates.body.results).toContainEqual({
+            userUuid: account.userUuid,
+            description: account.description,
+        });
+        candidates.body.results.forEach((candidate) => {
+            expect(Object.keys(candidate).sort()).toEqual([
+                'description',
+                'userUuid',
+            ]);
+        });
+        expect(
+            (await viewer.get(`${path}/share/service-accounts`, allowFailure))
+                .status,
+        ).toBe(403);
+        const users = await admin.get<Body<{ data: { userUuid: string }[] }>>(
+            `/api/v1/org/users?searchQuery=${encodeURIComponent(account.description)}`,
+        );
+        expect(users.body.results.data).toEqual([]);
+    });
+
+    it('rejects foreign, deleted, and missing recipients without adding grants', async () => {
+        const foreign = await createAccount(otherAdmin);
+        const deleted = await createAccount();
+        await admin.delete(`${accountsUrl}/${deleted.uuid}`);
+        const space = await createSpace();
+        const path = `${spacesUrl}/${space.uuid}`;
+        const before = await admin.get<Body<{ data: SpaceShare[] }>>(
+            `${path}/access?directOnly=true`,
+        );
+        for (const userUuid of [
+            foreign.userUuid,
+            deleted.userUuid,
+            randomUUID(),
+        ]) {
+            const response = await admin.post(
+                `${path}/share`,
+                { userUuid, spaceRole: 'viewer' },
+                allowFailure,
+            );
+            expect(response.status).toBe(404);
+        }
+        const after = await admin.get<Body<{ data: SpaceShare[] }>>(
+            `${path}/access?directOnly=true`,
+        );
+        expect(after.body.results.data).toEqual(before.body.results.data);
+        const candidates = await admin.get<Body<{ userUuid: string }[]>>(
+            `${path}/share/service-accounts`,
+        );
+        expect(
+            candidates.body.results.map((row) => row.userUuid),
+        ).not.toContain(foreign.userUuid);
+        expect(
+            candidates.body.results.map((row) => row.userUuid),
+        ).not.toContain(deleted.userUuid);
+    });
+
+    it('does not discover candidates through a mismatched project or missing space', async () => {
+        const space = await createSpace();
+        const paths = [
+            `/api/v1/projects/${randomUUID()}/spaces/${space.uuid}/share/service-accounts`,
+            `${spacesUrl}/${randomUUID()}/share/service-accounts`,
+        ];
+        for (const path of paths) {
+            expect((await admin.get(path, allowFailure)).status).toBe(404);
+        }
+    });
+
+    it('allows direct sharing with a project-scoped service account', async () => {
+        const account = await createAccount(
+            admin,
+            ServiceAccountScope.SYSTEM_MEMBER,
+        );
+        const space = await createSpace();
+        const path = `${spacesUrl}/${space.uuid}`;
+        const serviceClient = new ApiClient();
+        expect((await serviceClient.get(path, account.options)).status).toBe(
+            403,
+        );
+        await admin.post(`${path}/share`, {
+            userUuid: account.userUuid,
+            spaceRole: 'viewer',
+        });
+        expect((await serviceClient.get(path, account.options)).status).toBe(
+            200,
+        );
+    });
+
+    it('does not let a space admin grant override the account viewer capability limit', async () => {
+        const account = await createAccount(
+            admin,
+            ServiceAccountScope.SYSTEM_VIEWER,
+        );
+        const space = await createSpace();
+        const path = `${spacesUrl}/${space.uuid}`;
+        await admin.post(`${path}/share`, {
+            userUuid: account.userUuid,
+            spaceRole: 'admin',
+        });
+        const serviceClient = new ApiClient();
+        expect((await serviceClient.get(path, account.options)).status).toBe(
+            200,
+        );
+        const sharing = await serviceClient.post(
+            `${path}/share`,
+            { userUuid: SEED_ORG_1_VIEWER.user_uuid, spaceRole: 'viewer' },
+            account.options,
+        );
+        expect(sharing.status).toBe(403);
+    });
+});

--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -8,6 +8,7 @@ import {
     ApiSpaceAsCodeUpsertResponse,
     ApiSpaceDeleteImpactResponse,
     ApiSpaceResponse,
+    ApiSpaceServiceAccountCandidatesResponse,
     ApiSuccessEmpty,
     assertRegisteredAccount,
     CreateSpace,
@@ -45,6 +46,31 @@ import { BaseController } from './baseController';
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('Spaces')
 export class SpaceController extends BaseController {
+    /**
+     * List service accounts eligible for direct access to this space.
+     * @summary List service account candidates
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{spaceUuid}/share/service-accounts')
+    @OperationId('GetSpaceServiceAccountCandidates')
+    @Tags('Roles & Permissions')
+    async getSpaceServiceAccountCandidates(
+        @Path() projectUuid: UUID,
+        @Path() spaceUuid: UUID,
+        @Request() req: express.Request,
+    ): Promise<ApiSpaceServiceAccountCandidatesResponse> {
+        assertRegisteredAccount(req.account);
+        const results = await this.services
+            .getSpaceService()
+            .getSpaceServiceAccountCandidates(
+                req.account,
+                projectUuid,
+                spaceUuid,
+            );
+        return { status: 'ok', results };
+    }
+
     /**
      * Get the current user's personal space in a project, if they have one
      * @summary Get personal space

--- a/packages/backend/src/ee/models/ServiceAccountModel.test.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.test.ts
@@ -56,6 +56,41 @@ describe('ServiceAccountModel token lookup', () => {
         vi.clearAllMocks();
     });
 
+    test('space sharing discovers only linked non-SCIM accounts in the requested organization', async () => {
+        const candidates = [
+            { userUuid: 'sa-user-uuid', description: 'Automation' },
+        ];
+        tracker.on.select('service_accounts').responseOnce(candidates);
+
+        await expect(
+            model.getSpaceShareCandidates('org-uuid'),
+        ).resolves.toEqual(candidates);
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain('"organization_uuid" = $1');
+        expect(query.sql).toContain('"service_account_user_uuid" is not null');
+        expect(query.sql).toContain('NOT (scopes @> $2)');
+        expect(query.bindings).toEqual(['org-uuid', ['scim:manage']]);
+        expect(query.sql).not.toContain('is_active');
+        expect(query.sql).not.toContain('token_hash');
+    });
+
+    test('space sharing validates backing user UUIDs rather than token UUIDs', async () => {
+        tracker.on.select('service_accounts').responseOnce([]);
+
+        await expect(
+            model.getSpaceShareCandidates('org-uuid', ['missing-user-uuid']),
+        ).resolves.toEqual([]);
+
+        const [query] = tracker.history.select;
+        expect(query.sql).toContain('"service_account_user_uuid" in ($3)');
+        expect(query.bindings).toEqual([
+            'org-uuid',
+            ['scim:manage'],
+            'missing-user-uuid',
+        ]);
+    });
+
     test('an active-hash match performs one bcrypt hash and one query', async () => {
         tracker.on
             .select('service_accounts')

--- a/packages/backend/src/ee/models/ServiceAccountModel.ts
+++ b/packages/backend/src/ee/models/ServiceAccountModel.ts
@@ -485,6 +485,24 @@ export class ServiceAccountModel {
         };
     }
 
+    async getSpaceShareCandidates(
+        organizationUuid: string,
+        userUuids?: string[],
+    ): Promise<Pick<ServiceAccount, 'userUuid' | 'description'>[]> {
+        const query = this.database(ServiceAccountsTableName)
+            .where('organization_uuid', organizationUuid)
+            .whereNotNull('service_account_user_uuid')
+            .whereRaw('NOT (scopes @> ?)', [[ServiceAccountScope.SCIM_MANAGE]])
+            .select<Pick<ServiceAccount, 'userUuid' | 'description'>[]>({
+                userUuid: 'service_account_user_uuid',
+                description: 'description',
+            });
+        if (userUuids) {
+            void query.whereIn('service_account_user_uuid', userUuids);
+        }
+        return query;
+    }
+
     async getAllForOrganization(
         organizationUuid: string,
         scopes?: ServiceAccountScope[],

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -12,6 +12,7 @@ import {
     mergePullRequest,
 } from '../clients/github/Github';
 import { LightdashConfig } from '../config/parseConfig';
+import type { ServiceAccountModel } from '../ee/models/ServiceAccountModel';
 import { AppGenerateService } from '../ee/services/AppGenerateService/AppGenerateService';
 import { PreAggregateMaterializationService } from '../ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService';
 import { seedPlaygroundContent } from '../ee/services/ProjectService/seedPlaygroundContent';
@@ -1293,6 +1294,9 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     savedChartService: this.getSavedChartService(),
                     dashboardService: this.getDashboardService(),
+                    serviceAccountModel: this.providers.serviceAccountService
+                        ? this.models.getServiceAccountModel<ServiceAccountModel>()
+                        : undefined,
                     // Only wired when EE license is active. Core builds get
                     // undefined and the delete cascade skips apps.
                     appGenerateService: this.providers.appGenerateService

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -9,7 +9,9 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { fromSession } from '../../auth/account';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import type { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
@@ -1712,6 +1714,9 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
 });
 
 describe('SpaceService - space share target validation', () => {
+    const mockServiceAccountModel = {
+        getSpaceShareCandidates: vi.fn(),
+    };
     const mockUser = createTestUser({
         organizationRole: OrganizationMemberRole.ADMIN,
     });
@@ -1740,6 +1745,8 @@ describe('SpaceService - space share target validation', () => {
             analytics: analyticsMock,
             lightdashConfig: lightdashConfigMock,
             projectModel: mockProjectModel as unknown as ProjectModel,
+            serviceAccountModel:
+                mockServiceAccountModel as unknown as ServiceAccountModel,
             spaceModel: mockSpaceModel as unknown as SpaceModel,
             organizationModel: {} as OrganizationModel,
             organizationMemberProfileModel:
@@ -1753,6 +1760,7 @@ describe('SpaceService - space share target validation', () => {
         });
 
         mockSpacePermissionService.can.mockResolvedValue(true);
+        mockServiceAccountModel.getSpaceShareCandidates.mockResolvedValue([]);
         mockSpaceModel.getSpaceSummary.mockResolvedValue({
             uuid: 'test-space-uuid',
             organizationUuid: 'test-org-uuid',
@@ -1761,6 +1769,76 @@ describe('SpaceService - space share target validation', () => {
     });
 
     describe('addSpaceUserAccess', () => {
+        it.each(Object.values(SpaceMemberRole))(
+            'grants a live service account %s access using its backing user UUID',
+            async (role) => {
+                mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
+                    [],
+                );
+                mockServiceAccountModel.getSpaceShareCandidates.mockResolvedValue(
+                    [
+                        {
+                            userUuid: 'service-account-user',
+                            description: 'Automation',
+                        },
+                    ],
+                );
+
+                await service.addSpaceUserAccess(
+                    mockUser as SessionUser,
+                    'test-space-uuid',
+                    'service-account-user',
+                    role,
+                );
+
+                expect(
+                    mockServiceAccountModel.getSpaceShareCandidates,
+                ).toHaveBeenCalledWith('test-org-uuid', [
+                    'service-account-user',
+                ]);
+                expect(mockSpaceModel.addSpaceAccess).toHaveBeenCalledWith(
+                    'test-space-uuid',
+                    'service-account-user',
+                    role,
+                );
+            },
+        );
+
+        it.each([
+            'foreign-account-user',
+            'deleted-account-user',
+            'missing-account-user',
+        ])('rejects an ineligible recipient %s', async (userUuid) => {
+            mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
+                [],
+            );
+            await expect(
+                service.addSpaceUserAccess(
+                    mockUser as SessionUser,
+                    'test-space-uuid',
+                    userUuid,
+                    SpaceMemberRole.VIEWER,
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(mockSpaceModel.addSpaceAccess).not.toHaveBeenCalled();
+        });
+
+        it('rejects callers who cannot manage the space before looking up recipients', async () => {
+            mockSpacePermissionService.can.mockResolvedValue(false);
+            await expect(
+                service.addSpaceUserAccess(
+                    mockUser as SessionUser,
+                    'test-space-uuid',
+                    'service-account-user',
+                    SpaceMemberRole.VIEWER,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(
+                mockServiceAccountModel.getSpaceShareCandidates,
+            ).not.toHaveBeenCalled();
+            expect(mockSpaceModel.addSpaceAccess).not.toHaveBeenCalled();
+        });
+
         it('adds access when the target user is a member of the organization', async () => {
             mockOrganizationMemberProfileModel.findOrganizationMemberUuids.mockResolvedValue(
                 ['target-user-uuid'],
@@ -1795,6 +1873,66 @@ describe('SpaceService - space share target validation', () => {
             ).rejects.toThrowError(NotFoundError);
 
             expect(mockSpaceModel.addSpaceAccess).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getSpaceServiceAccountCandidates', () => {
+        const account = fromSession({
+            ...mockUser,
+            abilityRules: mockUser.ability.rules,
+        } as SessionUser);
+
+        it('returns the eligible accounts for the actual space organization', async () => {
+            const candidates = [
+                { userUuid: 'service-account-user', description: 'Automation' },
+            ];
+            mockServiceAccountModel.getSpaceShareCandidates.mockResolvedValue(
+                candidates,
+            );
+            await expect(
+                service.getSpaceServiceAccountCandidates(
+                    account,
+                    'test-project-uuid',
+                    'test-space-uuid',
+                ),
+            ).resolves.toEqual(candidates);
+            expect(mockSpaceModel.getSpaceSummary).toHaveBeenCalledWith(
+                'test-space-uuid',
+                { projectUuid: 'test-project-uuid' },
+            );
+            expect(
+                mockServiceAccountModel.getSpaceShareCandidates,
+            ).toHaveBeenCalledWith('test-org-uuid');
+        });
+
+        it('rejects a space outside the requested project before disclosing accounts', async () => {
+            mockSpaceModel.getSpaceSummary.mockRejectedValue(
+                new NotFoundError('Space not found'),
+            );
+            await expect(
+                service.getSpaceServiceAccountCandidates(
+                    account,
+                    'other-project-uuid',
+                    'test-space-uuid',
+                ),
+            ).rejects.toThrow(NotFoundError);
+            expect(
+                mockServiceAccountModel.getSpaceShareCandidates,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('requires permission to manage the space', async () => {
+            mockSpacePermissionService.can.mockResolvedValue(false);
+            await expect(
+                service.getSpaceServiceAccountCandidates(
+                    account,
+                    'test-project-uuid',
+                    'test-space-uuid',
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(
+                mockServiceAccountModel.getSpaceShareCandidates,
+            ).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     AbilityAction,
+    ApiSpaceServiceAccountCandidatesResponse,
     BulkActionable,
     CreateSpace,
     ForbiddenError,
@@ -8,6 +9,7 @@ import {
     NotFoundError,
     ParameterError,
     PersonalSpaceSummary,
+    RegisteredAccount,
     SessionUser,
     Space,
     SpaceDeleteImpact,
@@ -15,6 +17,7 @@ import {
     SpaceShare,
     SpaceSummary,
     UpdateSpace,
+    UUID,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type SpaceAccess,
@@ -22,7 +25,9 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import { toSessionUser } from '../../auth/account';
 import { LightdashConfig } from '../../config/parseConfig';
+import type { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
 import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberProfileModel';
 import { OrganizationModel } from '../../models/OrganizationModel';
@@ -52,6 +57,7 @@ type SpaceServiceArguments = {
     // EE-only. When the license isn't active the repository leaves this
     // undefined and the cascade skips data apps (there are none to delete).
     appGenerateService: AppGenerateService | undefined;
+    serviceAccountModel?: ServiceAccountModel;
 };
 
 export const hasDirectAccessToSpace = (
@@ -106,6 +112,8 @@ export class SpaceService
 
     private readonly appGenerateService: AppGenerateService | undefined;
 
+    private readonly serviceAccountModel: ServiceAccountModel | undefined;
+
     constructor(args: SpaceServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -120,6 +128,7 @@ export class SpaceService
         this.savedChartService = args.savedChartService;
         this.dashboardService = args.dashboardService;
         this.appGenerateService = args.appGenerateService;
+        this.serviceAccountModel = args.serviceAccountModel;
     }
 
     /** @internal For unit testing only */
@@ -294,6 +303,7 @@ export class SpaceService
     private async validateSpaceShareTargetUsers(
         organizationUuid: string,
         userUuids: string[],
+        includeServiceAccounts = false,
     ): Promise<void> {
         const uniqueUserUuids = [...new Set(userUuids)];
         const memberUuids = new Set(
@@ -302,7 +312,24 @@ export class SpaceService
                 uniqueUserUuids,
             ),
         );
-        if (uniqueUserUuids.some((userUuid) => !memberUuids.has(userUuid))) {
+        const missingUserUuids = uniqueUserUuids.filter(
+            (userUuid) => !memberUuids.has(userUuid),
+        );
+        const serviceAccounts =
+            includeServiceAccounts && missingUserUuids.length > 0
+                ? await this.serviceAccountModel?.getSpaceShareCandidates(
+                      organizationUuid,
+                      missingUserUuids,
+                  )
+                : [];
+        const serviceAccountUserUuids = new Set(
+            serviceAccounts?.map(({ userUuid }) => userUuid),
+        );
+        if (
+            missingUserUuids.some(
+                (userUuid) => !serviceAccountUserUuids.has(userUuid),
+            )
+        ) {
             throw new NotFoundError(
                 'Cannot share space: user is not a member of this organization',
             );
@@ -958,6 +985,30 @@ export class SpaceService
         await this.spaceModel.permanentDelete(spaceUuid);
     }
 
+    async getSpaceServiceAccountCandidates(
+        account: RegisteredAccount,
+        projectUuid: UUID,
+        spaceUuid: UUID,
+    ): Promise<ApiSpaceServiceAccountCandidatesResponse['results']> {
+        const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
+            projectUuid,
+        });
+        if (
+            !(await this.spacePermissionService.can(
+                'manage',
+                toSessionUser(account),
+                space.uuid,
+            ))
+        ) {
+            throw new ForbiddenError();
+        }
+        return (
+            this.serviceAccountModel?.getSpaceShareCandidates(
+                space.organizationUuid,
+            ) ?? []
+        );
+    }
+
     async addSpaceUserAccess(
         user: SessionUser,
         spaceUuid: string,
@@ -971,9 +1022,11 @@ export class SpaceService
         }
 
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
-        await this.validateSpaceShareTargetUsers(space.organizationUuid, [
-            shareWithUserUuid,
-        ]);
+        await this.validateSpaceShareTargetUsers(
+            space.organizationUuid,
+            [shareWithUserUuid],
+            true,
+        );
 
         await this.spaceModel.addSpaceAccess(
             spaceUuid,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -1,3 +1,4 @@
+import { type ServiceAccount } from '../ee/serviceAccounts/types';
 // eslint-disable-next-line import/no-cycle
 import { type SpaceDashboard } from './dashboard';
 import { type KnexPaginatedData } from './knex-paginate';
@@ -216,6 +217,11 @@ export type SpaceAccessListFilters = {
     userUuids?: string[];
     /** Only entries with direct access (user access or space group access) */
     directOnly?: boolean;
+};
+
+export type ApiSpaceServiceAccountCandidatesResponse = {
+    status: 'ok';
+    results: Pick<ServiceAccount, 'userUuid' | 'description'>[];
 };
 
 export type ApiSpaceAccessListResponse = {

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.test.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.test.tsx
@@ -1,5 +1,6 @@
 import {
     OrganizationMemberRole,
+    SpaceMemberRole,
     type OrganizationMemberProfile,
     type Space,
 } from '@lightdash/common';
@@ -13,6 +14,19 @@ const organizationUsers: OrganizationMemberProfile[] = [];
 const organizationUsersData = { pages: [{ data: organizationUsers }] };
 const organizationGroupsData = { pages: [{ data: [] }] };
 const spaceAccessByUserUuid = new Map();
+const serviceAccounts = [
+    { userUuid: 'automation-user', description: 'Warehouse automation' },
+];
+const shareSpace = vi.fn();
+
+vi.mock('../../../hooks/useSpaceServiceAccounts', () => ({
+    useSpaceServiceAccounts: () => ({
+        data: serviceAccounts,
+        isFetching: false,
+        isError: false,
+        refetch: vi.fn(),
+    }),
+}));
 
 vi.mock('../../../hooks/useOrganizationGroups', () => ({
     useInfiniteOrganizationGroups: () => ({
@@ -46,7 +60,7 @@ vi.mock('../../../hooks/useSpaceAccess', () => ({
 
 vi.mock('../../../hooks/useSpaces', () => ({
     useAddGroupSpaceShareMutation: () => ({ mutateAsync: vi.fn() }),
-    useAddSpaceShareMutation: () => ({ mutateAsync: vi.fn() }),
+    useAddSpaceShareMutation: () => ({ mutateAsync: shareSpace }),
     useUpdateMutation: () => ({ mutateAsync: vi.fn() }),
 }));
 
@@ -94,6 +108,8 @@ const space: Space = {
 
 describe('ShareSpaceAddUser', () => {
     beforeEach(() => {
+        spaceAccessByUserUuid.clear();
+        shareSpace.mockReset();
         organizationUsers.splice(
             0,
             organizationUsers.length,
@@ -136,5 +152,74 @@ describe('ShareSpaceAddUser', () => {
         expect(
             screen.queryByText('member@example.com'),
         ).not.toBeInTheDocument();
+    });
+
+    it('finds and shares a service account by description using its backing user UUID', async () => {
+        renderWithProviders(
+            <ShareSpaceAddUser space={space} projectUuid="project-uuid" />,
+        );
+        await userEvent.type(
+            screen.getByPlaceholderText(
+                'Select groups or users to share this space with',
+            ),
+            'Warehouse',
+        );
+        const option = await screen.findByRole('option', {
+            name: /Warehouse automation/,
+        });
+        expect(screen.getByText('Service account')).toBeInTheDocument();
+        await userEvent.click(option);
+        await userEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+        expect(shareSpace).toHaveBeenCalledWith([
+            'automation-user',
+            SpaceMemberRole.VIEWER,
+        ]);
+    });
+
+    it('does not offer an account already shared directly', async () => {
+        spaceAccessByUserUuid.set('automation-user', {
+            hasDirectAccess: true,
+            role: SpaceMemberRole.EDITOR,
+        });
+        renderWithProviders(
+            <ShareSpaceAddUser space={space} projectUuid="project-uuid" />,
+        );
+        await userEvent.click(
+            screen.getByPlaceholderText(
+                'Select groups or users to share this space with',
+            ),
+        );
+
+        expect(
+            screen.queryByRole('option', { name: /Warehouse automation/ }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('preserves the inherited role when adding a direct service-account grant', async () => {
+        spaceAccessByUserUuid.set('automation-user', {
+            hasDirectAccess: true,
+            inheritedFrom: 'parent_space',
+            role: SpaceMemberRole.EDITOR,
+        });
+        renderWithProviders(
+            <ShareSpaceAddUser space={space} projectUuid="project-uuid" />,
+        );
+        await userEvent.click(
+            screen.getByPlaceholderText(
+                'Select groups or users to share this space with',
+            ),
+        );
+        await userEvent.click(
+            await screen.findByRole('option', {
+                name: /Warehouse automation/,
+            }),
+        );
+        await userEvent.click(screen.getByRole('button', { name: 'Share' }));
+
+        expect(shareSpace).toHaveBeenCalledWith([
+            'automation-user',
+            SpaceMemberRole.EDITOR,
+        ]);
     });
 });

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -37,9 +37,12 @@ import {
     useAddSpaceShareMutation,
     useUpdateMutation,
 } from '../../../hooks/useSpaces';
+import { useSpaceServiceAccounts } from '../../../hooks/useSpaceServiceAccounts';
 import { LightdashUserAvatar } from '../../Avatar';
+import InlineErrorState from '../InlineErrorState';
 import MantineIcon from '../MantineIcon';
 import { DEFAULT_PAGE_SIZE } from '../Table/constants';
+import { ServiceAccountBadge } from './ServiceAccountBadge';
 import styles from './ShareSpaceAddUser.module.css';
 import { getAccessColor } from './ShareSpaceModalUtils';
 import { UserAccessOptions } from './ShareSpaceSelect';
@@ -69,6 +72,12 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     const [searchQuery, setSearchQuery] = useState<string>('');
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
     const { data: projectAccess } = useProjectAccess(projectUuid);
+    const {
+        data: serviceAccounts,
+        isFetching: isServiceAccountsFetching,
+        isError: isServiceAccountsError,
+        refetch: refetchServiceAccounts,
+    } = useSpaceServiceAccounts(projectUuid, space.uuid, !disabled);
     const viewportRef = useRef<HTMLDivElement>(null);
 
     const { mutateAsync: shareSpaceMutation } = useAddSpaceShareMutation(
@@ -176,8 +185,13 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
     );
 
     const candidateUserUuids = useMemo(
-        () => uniq([...userUuids, ...selectedItems.users]),
-        [userUuids, selectedItems.users],
+        () =>
+            uniq([
+                ...userUuids,
+                ...(serviceAccounts?.map((account) => account.userUuid) ?? []),
+                ...selectedItems.users,
+            ]),
+        [userUuids, serviceAccounts, selectedItems.users],
     );
 
     const {
@@ -285,6 +299,31 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         if (usersSet.length > 0) {
             result.push({ group: 'Users', items: usersSet });
         }
+        const serviceAccountItems = (serviceAccounts ?? [])
+            .filter((account) => {
+                const access = spaceAccessByUserUuid.get(account.userUuid);
+                return (
+                    !(
+                        access?.hasDirectAccess &&
+                        access.inheritedFrom !== 'parent_space'
+                    ) &&
+                    (!debouncedSearchQuery ||
+                        selectedItems.users.includes(account.userUuid) ||
+                        account.description
+                            .toLowerCase()
+                            .includes(debouncedSearchQuery.toLowerCase()))
+                );
+            })
+            .map((account) => ({
+                value: account.userUuid,
+                label: account.description,
+            }));
+        if (serviceAccountItems.length > 0) {
+            result.push({
+                group: 'Service accounts',
+                items: serviceAccountItems,
+            });
+        }
 
         return result;
     }, [
@@ -298,9 +337,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         debouncedSearchQuery,
         currentSearchUserUuids,
         currentSearchGroupUuids,
+        serviceAccounts,
     ]);
 
-    const isFetching = isUsersFetching || isGroupsFetching;
+    const isFetching =
+        isUsersFetching || isGroupsFetching || isServiceAccountsFetching;
 
     const handleScrollPositionChange = useCallback(
         ({ y }: { x: number; y: number }) => {
@@ -339,6 +380,26 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                         <Text size="sm" fw={500}>
                             {option.label}
                         </Text>
+                    </Group>
+                );
+            }
+
+            const serviceAccount = serviceAccounts?.find(
+                (account) => account.userUuid === option.value,
+            );
+            if (serviceAccount) {
+                return (
+                    <Group gap="sm" wrap="nowrap">
+                        <LightdashUserAvatar
+                            name={serviceAccount.description}
+                            size="sm"
+                            radius="xl"
+                            userUuid={serviceAccount.userUuid}
+                        />
+                        <Text size="sm" fw={500}>
+                            {serviceAccount.description}
+                        </Text>
+                        <ServiceAccountBadge />
                     </Group>
                 );
             }
@@ -414,7 +475,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 </Group>
             );
         },
-        [spaceAccessByUserUuid, groupUuidsSet],
+        [spaceAccessByUserUuid, groupUuidsSet, serviceAccounts],
     );
 
     const handleSelectionChange = useCallback(
@@ -512,6 +573,12 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
             >
                 Share
             </Button>
+            {isServiceAccountsError && (
+                <InlineErrorState
+                    message="Unable to load service accounts"
+                    onRetry={() => void refetchServiceAccounts()}
+                />
+            )}
         </Group>
     );
 };

--- a/packages/frontend/src/hooks/useSpaceServiceAccounts.ts
+++ b/packages/frontend/src/hooks/useSpaceServiceAccounts.ts
@@ -1,0 +1,21 @@
+import {
+    type ApiError,
+    type ApiSpaceServiceAccountCandidatesResponse,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+export const useSpaceServiceAccounts = (
+    projectUuid: string,
+    spaceUuid: string,
+    enabled: boolean,
+) =>
+    useQuery<ApiSpaceServiceAccountCandidatesResponse['results'], ApiError>({
+        queryKey: ['space_service_accounts', projectUuid, spaceUuid],
+        queryFn: () =>
+            lightdashApi<ApiSpaceServiceAccountCandidatesResponse['results']>({
+                url: `/projects/${projectUuid}/spaces/${spaceUuid}/share/service-accounts`,
+                method: 'GET',
+            }),
+        enabled,
+    });


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1935

## Summary

Allow space managers to grant service accounts direct access to restricted spaces through the Share dialog and API, including role changes and revocation.

## Root cause

Sharing discovers and validates recipients through the human-only organization directory. Service accounts have internal backing users without email addresses, so they never appear in the picker and valid grant requests return 404.

## Fix

Add a manager-authorized candidate lookup exposing only live, same-organization service-account names and backing user UUIDs. Use those identities in the existing sharing flow while keeping human directory and SCIM exclusions intact.

```text
Space manager
  -> project-bound space authorization
  -> live service-account candidate
  -> existing user-backed space grant
       -> Viewer / Editor / Admin
       -> descendant inheritance
       -> existing project and token capability limits
```

The picker groups service accounts separately and displays their existing badge. Deleted and foreign accounts remain invalid recipients. Access-as-code, grant storage, and permission scopes are unchanged.

## Before

Local Share search returns no service-account candidate. Posting a direct grant for a valid service-account backing user returns 404.

## After

The same account appears in Share search. Sharing creates a Can view grant, changing to Can edit and Full access succeeds, and removal deletes the grant. Browser checks and Postgres confirm each transition. The picker renders correctly in light and dark modes.

## Test plan

- [x] 94 backend unit tests and 4 picker tests.
- [x] 8 real API tests: grant roles, token access, role changes, revocation, inheritance, sibling isolation, capability limits, non-admin space managers, minimal metadata, invalid recipients, and project binding.
- [x] Backend, frontend, and API-test typechecks; common/backend/frontend lint and focused API-test lint.
- [x] Common build and API/schema generation; generated files excluded from commit.
- [x] Browser grant/change/revoke lifecycle, database verification, light/dark visual checks.
- [x] Five review lenses approved without unresolved findings.
