### PR TITLE
fix(cli): refresh warehouse credentials when re-running start-preview with an existing name

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -19,14 +19,22 @@ import GlobalState from '../globalState';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
 import * as styles from '../styles';
 import { compileProject } from './compile';
-import { createProject } from './createProject';
+import {
+    createProject,
+    loadWarehouseCredentialsFromProfiles,
+} from './createProject';
 import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
 import { DbtCompileOptions } from './dbt/compile';
+import { getProject } from './dbt/refresh';
 import { deploy } from './deploy';
 import {
     getDisableTimestampConversionFromProject,
     getProjectDisableTimestampConversion,
 } from './timestampConversion';
+import {
+    getWarehouseCredentialsSource,
+    updateProjectWarehouseConnection,
+} from './warehouseConnection';
 
 type PreviewHandlerOptions = DbtCompileOptions & {
     projectDir: string;
@@ -462,6 +470,59 @@ export const previewHandler = async (
     await cleanupProject(executionId, project.projectUuid, previewStartTime);
 };
 
+// Credentials resolved locally (AWS SSO, Snowflake SSO) expire, so a re-run
+// with the same name pushes freshly resolved ones into the existing preview.
+const refreshPreviewWarehouseCredentials = async (
+    projectUuid: string,
+    options: PreviewHandlerOptions,
+): Promise<void> => {
+    const source = getWarehouseCredentialsSource(options);
+    if (source.source === 'organization') {
+        GlobalState.debug(
+            `> Preview uses organization warehouse credentials "${source.name}", nothing to refresh`,
+        );
+        return;
+    }
+    if (source.source === 'none') {
+        GlobalState.debug(
+            '> Skipping warehouse credentials refresh (--no-warehouse-credentials)',
+        );
+        return;
+    }
+    const loaded = await loadWarehouseCredentialsFromProfiles({
+        projectDir: options.projectDir,
+        profilesDir: options.profilesDir,
+        target: options.target,
+        profile: options.profile,
+        startOfWeek: options.startOfWeek,
+        assumeYes: options.assumeYes,
+        targetPath: options.targetPath,
+    });
+    if (!loaded) {
+        console.error(
+            styles.warning(
+                'Keeping the warehouse credentials already stored on the preview.',
+            ),
+        );
+        return;
+    }
+    const spinner = GlobalState.startSpinner(
+        '  Refreshing warehouse credentials...',
+    );
+    try {
+        const project = await getProject(projectUuid);
+        await updateProjectWarehouseConnection(
+            project,
+            loaded.credentials,
+            'Refreshing warehouse credentials',
+        );
+        spinner.succeed('  Warehouse credentials refreshed');
+    } catch (e) {
+        spinner.fail();
+        throw e;
+    }
+};
+
 export const startPreviewHandler = async (
     originalOptions: PreviewHandlerOptions,
 ): Promise<void> => {
@@ -519,6 +580,11 @@ export const startPreviewHandler = async (
             previewProject.projectUuid,
             options.expiresIn,
         );
+
+        await refreshPreviewWarehouseCredentials(previewProject.projectUuid, {
+            ...options,
+            warehouseCredentials: projectTypeConfig.warehouseCredentials,
+        });
 
         // Update
         options.disableTimestampConversion =

--- a/packages/cli/src/handlers/setWarehouse.ts
+++ b/packages/cli/src/handlers/setWarehouse.ts
@@ -1,16 +1,13 @@
-import {
-    AuthorizationError,
-    type ApiJobStartedResults,
-    type UpdateProject,
-} from '@lightdash/common';
+import { AuthorizationError } from '@lightdash/common';
 import inquirer from 'inquirer';
 import { getConfig } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { loadWarehouseCredentialsFromProfiles } from './createProject';
-import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
-import { getFinalJobState, getProject } from './dbt/refresh';
+import { checkLightdashVersion } from './dbt/apiClient';
+import { getProject } from './dbt/refresh';
 import { resolveProjectFlag } from './resolveProjectFlag';
+import { updateProjectWarehouseConnection } from './warehouseConnection';
 
 type SetWarehouseHandlerOptions = {
     projectDir: string;
@@ -92,26 +89,11 @@ export const setWarehouseHandler = async (
     );
 
     try {
-        // Build UpdateProject body — preserve existing fields, override warehouseConnection.
-        // Note: dbtConnection from GET response may have stripped secrets, but the backend's
-        // mergeMissingProjectConfigSecrets fills them back in from the saved project before persisting.
-        const updateBody: UpdateProject = {
-            name: existingProject.name,
-            dbtConnection: existingProject.dbtConnection,
-            dbtVersion: existingProject.dbtVersion,
-            warehouseConnection: credentials,
-        };
-
-        // PATCH project — triggers adaptor test + recompile
-        const result = await lightdashApi<ApiJobStartedResults>({
-            method: 'PATCH',
-            url: `/api/v1/projects/${projectUuid}`,
-            body: JSON.stringify(updateBody),
-        });
-
-        // Poll until job completes (custom spinner prefix)
-        await getFinalJobState(result.jobUuid, 'Updating warehouse connection');
-
+        await updateProjectWarehouseConnection(
+            existingProject,
+            credentials,
+            'Updating warehouse connection',
+        );
         spinner.stop();
     } catch (e) {
         spinner.fail();

--- a/packages/cli/src/handlers/warehouseConnection.test.ts
+++ b/packages/cli/src/handlers/warehouseConnection.test.ts
@@ -1,0 +1,116 @@
+import {
+    DbtProjectType,
+    JobStatusType,
+    SupportedDbtVersions,
+    WarehouseTypes,
+    type CreateWarehouseCredentials,
+} from '@lightdash/common';
+import type { MockedFunction } from 'vitest';
+import { lightdashApi } from './dbt/apiClient';
+import { getFinalJobState } from './dbt/refresh';
+import {
+    getWarehouseCredentialsSource,
+    updateProjectWarehouseConnection,
+} from './warehouseConnection';
+
+vi.mock('./dbt/apiClient', () => ({
+    lightdashApi: vi.fn(),
+}));
+vi.mock('./dbt/refresh', () => ({
+    getFinalJobState: vi.fn(),
+}));
+
+const mockLightdashApi = lightdashApi as MockedFunction<typeof lightdashApi>;
+const mockGetFinalJobState = getFinalJobState as MockedFunction<
+    typeof getFinalJobState
+>;
+
+const PROJECT_UUID = '00000000-0000-0000-0000-000000000001';
+
+const project = {
+    projectUuid: PROJECT_UUID,
+    name: 'my-preview',
+    dbtConnection: { type: DbtProjectType.NONE as const },
+    dbtVersion: SupportedDbtVersions.V1_10,
+};
+
+const credentials: CreateWarehouseCredentials = {
+    type: WarehouseTypes.POSTGRES,
+    host: 'localhost',
+    user: 'refreshed-user',
+    password: 'refreshed-password',
+    port: 5432,
+    dbname: 'db',
+    schema: 'public',
+};
+
+describe('getWarehouseCredentialsSource', () => {
+    it('loads from profiles by default', () => {
+        expect(getWarehouseCredentialsSource({})).toEqual({
+            source: 'profiles',
+        });
+        expect(
+            getWarehouseCredentialsSource({ warehouseCredentials: true }),
+        ).toEqual({ source: 'profiles' });
+    });
+
+    it('skips when --no-warehouse-credentials is set', () => {
+        expect(
+            getWarehouseCredentialsSource({ warehouseCredentials: false }),
+        ).toEqual({ source: 'none' });
+    });
+
+    it('prefers organization credentials over profiles', () => {
+        expect(
+            getWarehouseCredentialsSource({
+                organizationCredentials: 'shared-redshift',
+                warehouseCredentials: false,
+            }),
+        ).toEqual({ source: 'organization', name: 'shared-redshift' });
+    });
+});
+
+describe('updateProjectWarehouseConnection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('patches the project with the new credentials and waits for the job', async () => {
+        mockLightdashApi.mockResolvedValueOnce({ jobUuid: 'job-1' });
+        mockGetFinalJobState.mockResolvedValueOnce({
+            jobStatus: JobStatusType.DONE,
+        } as Awaited<ReturnType<typeof getFinalJobState>>);
+
+        await updateProjectWarehouseConnection(
+            project,
+            credentials,
+            'Refreshing warehouse credentials',
+        );
+
+        expect(mockLightdashApi).toHaveBeenCalledTimes(1);
+        const call = mockLightdashApi.mock.calls[0][0];
+        expect(call.method).toBe('PATCH');
+        expect(call.url).toBe(`/api/v1/projects/${PROJECT_UUID}`);
+        expect(JSON.parse(call.body as string)).toEqual({
+            name: 'my-preview',
+            dbtConnection: { type: DbtProjectType.NONE },
+            dbtVersion: SupportedDbtVersions.V1_10,
+            warehouseConnection: credentials,
+        });
+        expect(mockGetFinalJobState).toHaveBeenCalledWith(
+            'job-1',
+            'Refreshing warehouse credentials',
+        );
+    });
+
+    it('surfaces a failed adapter test', async () => {
+        mockLightdashApi.mockResolvedValueOnce({ jobUuid: 'job-2' });
+        mockGetFinalJobState.mockRejectedValueOnce(
+            new Error('Your Redshift IAM AWS session has expired'),
+        );
+
+        await expect(
+            updateProjectWarehouseConnection(project, credentials, 'label'),
+        ).rejects.toThrow('session has expired');
+    });
+});

--- a/packages/cli/src/handlers/warehouseConnection.ts
+++ b/packages/cli/src/handlers/warehouseConnection.ts
@@ -1,0 +1,53 @@
+import {
+    type ApiJobStartedResults,
+    type CreateWarehouseCredentials,
+    type Project,
+    type UpdateProject,
+} from '@lightdash/common';
+import { lightdashApi } from './dbt/apiClient';
+import { getFinalJobState } from './dbt/refresh';
+
+type WarehouseCredentialsSource =
+    | { source: 'profiles' }
+    | { source: 'organization'; name: string }
+    | { source: 'none' };
+
+export const getWarehouseCredentialsSource = (options: {
+    organizationCredentials?: string;
+    warehouseCredentials?: boolean;
+}): WarehouseCredentialsSource => {
+    if (options.organizationCredentials) {
+        return {
+            source: 'organization',
+            name: options.organizationCredentials,
+        };
+    }
+    if (options.warehouseCredentials === false) {
+        return { source: 'none' };
+    }
+    return { source: 'profiles' };
+};
+
+// Secrets stripped from the GET response are merged back server-side before
+// the project is persisted.
+export const updateProjectWarehouseConnection = async (
+    project: Pick<
+        Project,
+        'projectUuid' | 'name' | 'dbtConnection' | 'dbtVersion'
+    >,
+    credentials: CreateWarehouseCredentials,
+    jobLabel: string,
+): Promise<void> => {
+    const updateBody: UpdateProject = {
+        name: project.name,
+        dbtConnection: project.dbtConnection,
+        dbtVersion: project.dbtVersion,
+        warehouseConnection: credentials,
+    };
+    const result = await lightdashApi<ApiJobStartedResults>({
+        method: 'PATCH',
+        url: `/api/v1/projects/${project.projectUuid}`,
+        body: JSON.stringify(updateBody),
+    });
+    await getFinalJobState(result.jobUuid, jobLabel);
+};

--- a/packages/cli/src/handlers/warehouseConnection.ts
+++ b/packages/cli/src/handlers/warehouseConnection.ts
@@ -28,8 +28,6 @@ export const getWarehouseCredentialsSource = (options: {
     return { source: 'profiles' };
 };
 
-// Secrets stripped from the GET response are merged back server-side before
-// the project is persisted.
 export const updateProjectWarehouseConnection = async (
     project: Pick<
         Project,
@@ -38,12 +36,18 @@ export const updateProjectWarehouseConnection = async (
     credentials: CreateWarehouseCredentials,
     jobLabel: string,
 ): Promise<void> => {
+    // Build UpdateProject body — preserve existing fields, override warehouseConnection.
+    // Note: dbtConnection from GET response may have stripped secrets, but the backend's
+    // mergeMissingProjectConfigSecrets fills them back in from the saved project before persisting.
     const updateBody: UpdateProject = {
         name: project.name,
         dbtConnection: project.dbtConnection,
         dbtVersion: project.dbtVersion,
         warehouseConnection: credentials,
     };
+
+    // PATCH project — triggers adaptor test + recompile. CLI-deployed projects
+    // (dbtConnection type "none") only run the adaptor test and keep their explores.
     const result = await lightdashApi<ApiJobStartedResults>({
         method: 'PATCH',
         url: `/api/v1/projects/${project.projectUuid}`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -740,7 +740,7 @@ program
     )
     .option(
         '--no-warehouse-credentials',
-        'Create preview without warehouse credentials. Copies credentials from upstream project.',
+        'Create preview without warehouse credentials (copied from the upstream project). When updating an existing preview, keep the credentials it already has.',
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
     .option('--no-batched-deploy', 'Use the legacy single-request deploy')

--- a/packages/e2e/cypress/cli/integration/cli.cy.ts
+++ b/packages/e2e/cypress/cli/integration/cli.cy.ts
@@ -85,6 +85,30 @@ describe('preview', () => {
         });
     });
 
+    it('Should refresh warehouse credentials when re-running start-preview with the same name', () => {
+        cy.login();
+        cy.getApiToken().then((apiToken) => {
+            cy.exec(
+                `${cliCommand} start-preview --project-dir ${projectDir} --profiles-dir ${profilesDir} --name "${previewName}"`,
+                {
+                    failOnNonZeroExit: false,
+                    env: {
+                        CI: true,
+                        NODE_ENV: 'development',
+                        LIGHTDASH_API_KEY: apiToken,
+                        LIGHTDASH_URL: lightdashUrl,
+                        LIGHTDASH_PROJECT: SEED_PROJECT.project_uuid,
+                        ...databaseEnvVars,
+                    },
+                },
+            )
+                .its('stderr')
+                .should('contain', 'Updating preview project')
+                .and('contain', 'Warehouse credentials refreshed')
+                .and('contain', 'Project updated');
+        });
+    });
+
     it('Should stop-preview', () => {
         cy.login();
         cy.getApiToken().then((apiToken) => {


### PR DESCRIPTION
## Problem

Re-running `lightdash start-preview --name <name>` for a preview that already exists only extended its expiry and redeployed models. It never touched the warehouse connection. A preview created from short-lived local credentials (AWS SSO for Redshift IAM, Snowflake SSO) therefore kept failing with expired-session errors after the user re-authenticated and re-ran the command, even though the docs and the CLI's own Redshift IAM warning say re-running refreshes them. The only way out was to stop and recreate the preview, which loses anything built inside it.

## Fix

The update branch of `start-preview` now reloads warehouse credentials from `profiles.yml` and PATCHes the preview's connection before compiling and deploying. This reuses the exact path `lightdash set-warehouse` already uses, extracted into a small shared helper.

- `--no-warehouse-credentials` keeps the credentials already stored on the preview (help text updated).
- `--organization-credentials` is left untouched since those live server-side.
- A declined storage prompt keeps the existing credentials and continues.
- A failed adapter test (for example, still-expired credentials) aborts before compile, so the failure points at the credentials rather than surfacing later as a query error.

No backend change. For CLI-deployed projects the PATCH job only runs the adapter test and skips compilation, so deployed explores survive, and secrets stripped from the GET response are merged back server-side before persisting.

## Regression analysis

- **Cost**: every same-name re-run now spends a few seconds on the backend adapter test, including CI runs with static credentials. CI jobs that want to skip it can pass `--no-warehouse-credentials`.
- **Snowflake SSO**: each re-run mints a new one-day programmatic PAT, same as a fresh create does.
- **Interactive prompt**: the credentials-storage consent prompt now also appears on re-run, unless the answer was remembered, `--assume-yes` is set, or the run is non-interactive. This matches the create path.
- `set-warehouse` behaviour is unchanged; it just calls the shared helper.

## Tests

- New unit test for the shared helper covering the PATCH body, job polling, and error propagation.
- New Cypress CLI case (`cypress/cli/integration/cli.cy.ts`, runs in the `cli-tests` job): re-running `start-preview` with the same name must report the credentials refresh and the project update.
- Manual pass against a local API + scheduler with the demo Postgres project: create a named preview, re-run with a wrong password (fails at the adapter test before compile: `step 1/1: Testing adaptor error password authentication failed`), re-run with the right password (refresh succeeds, explores redeploy, a SQL query in the preview returns rows).
- `pnpm -F cli typecheck`, lint, and format pass.

Closes: #28804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HH88SYu6QHbrcW92Cnkdgz
