### PR TITLE
fix(frontend): agent data scope copy says schemas and catalogs

### DIFF
--- a/packages/frontend/src/components/Settings/ProjectSettings.tsx
+++ b/packages/frontend/src/components/Settings/ProjectSettings.tsx
@@ -330,7 +330,7 @@ const ProjectSettings: FC<{ externalSourcesEnabled: boolean }> = ({
                           element: (
                               <ProjectSettingsPage
                                   title="Agent data scope"
-                                  description="Limit which schemas an AI agent can read when it writes raw SQL."
+                                  description="Limit which schemas and catalogs an AI agent can read when it writes raw SQL."
                               >
                                   <SettingsAgentDataScope
                                       projectUuid={projectUuid}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -859,7 +859,7 @@ export const AiAgentFormSetup = ({
                                                 className={classes.switchLink}
                                             >
                                                 Configure which schemas and
-                                                tables it can query
+                                                catalogs it can query
                                             </Anchor>
                                         </>
                                     }


### PR DESCRIPTION
The agent setup form linked to data scope with "Configure which schemas and tables it can query", but the form only lets you pick schemas and catalogs — table-level selection isn't supported (listing every table across all catalogs is too expensive at scale, and schemas/catalogs are the usual level of separation).

Copy-only change: the SQL mode link now says "schemas and catalogs", and the Agent data scope settings page description mentions catalogs too.