### PR TITLE
fix(tables): only show totals loading and error cells under columns the warehouse can total

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -69,6 +69,7 @@ import {
     formatCellContent,
     getFormattedValueCell,
 } from '../../../hooks/useColumns';
+import { canHaveWarehouseTotal } from '../../../utils/canHaveWarehouseTotal';
 import {
     getColorFromRange,
     transformColorsForDarkMode,
@@ -604,7 +605,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                 if (
                                     subtotalValue === undefined &&
                                     subtotalError &&
-                                    (isRowTotal || isNumericItem(item))
+                                    (isRowTotal || canHaveWarehouseTotal(item))
                                 ) {
                                     return (
                                         <TotalCalculationErrorCell
@@ -618,7 +619,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                     (isRowTotal
                                         ? isRowSubtotalsLoading
                                         : isSubtotalsLoading) &&
-                                    isNumericItem(item)
+                                    canHaveWarehouseTotal(item)
                                 ) {
                                     return (
                                         <Skeleton

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -5,7 +5,6 @@ import {
     isCustomDimension,
     isDimension,
     isField,
-    isNumericItem,
     normalizePivotMatchRaw,
     type ItemsMap,
     type GroupedPivotRowSubtotals,
@@ -27,6 +26,7 @@ import {
     type TableColumn,
     type TableHeader,
 } from '../../components/common/Table/types';
+import { canHaveWarehouseTotal } from '../../utils/canHaveWarehouseTotal';
 import { getFormattedValueCell } from '../useColumns';
 
 type Args = {
@@ -268,14 +268,14 @@ const getDataAndColumns = ({
                                 parameters,
                             );
                         }
-                        if (totalsError && isNumericItem(item)) {
+                        if (totalsError && canHaveWarehouseTotal(item)) {
                             return (
                                 <TotalCalculationErrorCell
                                     error={totalsError}
                                 />
                             );
                         }
-                        if (totalsLoading && isNumericItem(item)) {
+                        if (totalsLoading && canHaveWarehouseTotal(item)) {
                             return (
                                 <Skeleton
                                     height={16}
@@ -335,7 +335,7 @@ const getDataAndColumns = ({
                             if (
                                 subtotalValue === undefined &&
                                 subtotalsError &&
-                                isNumericItem(item)
+                                canHaveWarehouseTotal(item)
                             ) {
                                 return (
                                     <TotalCalculationErrorCell
@@ -347,7 +347,7 @@ const getDataAndColumns = ({
                             if (
                                 subtotalValue === undefined &&
                                 subtotalsLoading &&
-                                isNumericItem(item)
+                                canHaveWarehouseTotal(item)
                             ) {
                                 return (
                                     <Skeleton

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -68,6 +68,7 @@ import {
 import provenanceStyles from '../features/mergeQuery/components/MergeColumnProvenance.module.css';
 import { useMergeSafe } from '../features/mergeQuery/context/useMerge';
 import { getMergeFieldProvenance } from '../features/mergeQuery/utils/getMergeFieldProvenance';
+import { canHaveWarehouseTotal } from '../utils/canHaveWarehouseTotal';
 import { getFieldColors } from '../utils/fieldColors';
 import { TableCellBar } from './TableCellBar';
 import {
@@ -768,14 +769,17 @@ export const useColumns = (): TableColumn[] => {
                                 timezone,
                             );
                         }
-                        if (totalsError && isNumericItem(item)) {
+                        if (totalsError && canHaveWarehouseTotal(item)) {
                             return (
                                 <TotalCalculationErrorCell
                                     error={totalsError}
                                 />
                             );
                         }
-                        if (isCalculatingTotals && isNumericItem(item)) {
+                        if (
+                            isCalculatingTotals &&
+                            canHaveWarehouseTotal(item)
+                        ) {
                             return (
                                 <Skeleton
                                     height={16}

--- a/packages/frontend/src/utils/canHaveWarehouseTotal.test.ts
+++ b/packages/frontend/src/utils/canHaveWarehouseTotal.test.ts
@@ -1,0 +1,78 @@
+import {
+    BinType,
+    CustomDimensionType,
+    DimensionType,
+    FieldType,
+    MetricType,
+    TableCalculationType,
+    type CustomBinDimension,
+    type Dimension,
+    type Metric,
+    type TableCalculation,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { canHaveWarehouseTotal } from './canHaveWarehouseTotal';
+
+const numberDimension: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    name: 'mrr_usd',
+    label: 'MRR',
+    table: 'billing_customers',
+    tableLabel: 'Billing customers',
+    sql: '${TABLE}.mrr_usd',
+    hidden: false,
+};
+
+const sumMetric: Metric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    name: 'total_mrr',
+    label: 'Total MRR',
+    table: 'billing_customers',
+    tableLabel: 'Billing customers',
+    sql: '${TABLE}.mrr_usd',
+    hidden: false,
+};
+
+const numericTableCalculation: TableCalculation = {
+    name: 'mrr_x12',
+    displayName: 'ARR',
+    sql: '${billing_customers.total_mrr} * 12',
+    type: TableCalculationType.NUMBER,
+};
+
+const customBinDimension: CustomBinDimension = {
+    id: 'mrr_bin',
+    name: 'MRR bin',
+    type: CustomDimensionType.BIN,
+    dimensionId: 'billing_customers_mrr_usd',
+    table: 'billing_customers',
+    binType: BinType.FIXED_NUMBER,
+    binNumber: 5,
+};
+
+describe('canHaveWarehouseTotal', () => {
+    it('is true for numeric metrics', () => {
+        expect(canHaveWarehouseTotal(sumMetric)).toBe(true);
+    });
+
+    it('is true for numeric table calculations', () => {
+        expect(canHaveWarehouseTotal(numericTableCalculation)).toBe(true);
+    });
+
+    it('is false for numeric dimensions', () => {
+        expect(canHaveWarehouseTotal(numberDimension)).toBe(false);
+    });
+
+    it('is false for custom dimensions', () => {
+        expect(canHaveWarehouseTotal(customBinDimension)).toBe(false);
+    });
+
+    it('is false for string metrics and missing items', () => {
+        expect(
+            canHaveWarehouseTotal({ ...sumMetric, type: MetricType.STRING }),
+        ).toBe(false);
+        expect(canHaveWarehouseTotal(undefined)).toBe(false);
+    });
+});

--- a/packages/frontend/src/utils/canHaveWarehouseTotal.ts
+++ b/packages/frontend/src/utils/canHaveWarehouseTotal.ts
@@ -1,0 +1,21 @@
+import {
+    isCustomDimension,
+    isDimension,
+    isNumericItem,
+    type AdditionalMetric,
+    type CustomDimension,
+    type Field,
+    type TableCalculation,
+} from '@lightdash/common';
+
+// Warehouse totals and subtotals only re-aggregate metrics and table calcs.
+// A numeric dimension is a group key, so it never gets a total.
+export const canHaveWarehouseTotal = (
+    item:
+        | Field
+        | AdditionalMetric
+        | TableCalculation
+        | CustomDimension
+        | undefined,
+): boolean =>
+    isNumericItem(item) && !isDimension(item) && !isCustomDimension(item);


### PR DESCRIPTION
### Description

A table with column totals enabled shows a loading skeleton, and then the totals error cell, under every **numeric** column while the totals query runs or fails. That gate includes numeric dimensions, but the warehouse totals and subtotals queries only re-aggregate metrics and table calculations. A numeric dimension is a group key, so it can never receive a total. The spinner promises something that will not arrive, and when the totals query fails the error lands under a column that had nothing to do with it.

This was visible on a dimension-only table (a list of accounts with a numeric revenue dimension and no metrics): the revenue column and the Total row showed `Syntax error: SELECT list must not be empty` from the empty totals query described in #28874.

**Change**

- New helper `canHaveWarehouseTotal(item)` in `packages/frontend/src/utils/canHaveWarehouseTotal.ts`: numeric and not a dimension or custom dimension.
- The footer and grouped-subtotal cells in the chart table (`getDataAndColumns.tsx`), the explorer results table (`useColumns.tsx`) and the pivot table (`PivotTable/index.tsx`) gate the skeleton and the error cell on that helper instead of `isNumericItem`.
- Numeric dimension columns now render a blank footer, which is what they rendered before totals errors were surfaced in cells.

The totals request itself is unchanged: a metric-less table still sends one and the backend still compiles an empty SELECT. That is the backend half of #28874 and is handled in #28991, stacked on this PR, so this one stays a rendering fix.

### Regression analysis

Summing numeric dimension columns was a deliberate feature of the original client-side totals (2022, `isSummable` listed number dimensions). When totals moved to the warehouse in 2023 (#8058), only metrics were requested and the client-side sums were removed from chart and explorer tables, with no recorded decision about dimensions. The skeleton and error gate kept using `isNumericItem`, so dimension columns kept pretending a total was on its way. The error became user-visible when #26126 started rendering totals errors in cells instead of logging them. Pivot tables never totalled dimensions.

Behaviour that stays the same:

- Metrics and numeric table calculations still show the skeleton while loading and the error cell on failure.
- The underlying-data table still sums numeric dimensions client-side; it does not use these gates.
- `isSummable` is untouched.

### Testing

- Unit test for the helper: numeric metric and numeric table calc are totalable; number dimension, custom bin dimension, string metric and `undefined` are not.
- `pnpm -F frontend typecheck`, oxlint and oxfmt clean on the touched files.

Relates: #28874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RSNnPPK369vYN8E5guiWH
