### PR TITLE
fix: show loading feedback during project navigation

### DIFF
--- a/packages/frontend/src/components/common/ProjectLayout/ProjectLayout.module.css
+++ b/packages/frontend/src/components/common/ProjectLayout/ProjectLayout.module.css
@@ -1,0 +1,17 @@
+.loading {
+    position: fixed;
+    inset: 0;
+    z-index: var(--mantine-z-index-overlay);
+    background-color: var(--ld-color-page);
+}
+
+:global(#navbar-header[data-has-visible-fixed-navbar='true']) ~ .loading {
+    top: var(--navbar-height);
+}
+
+:global(
+        #navbar-header[data-has-visible-fixed-navbar='true'][data-has-banner='true']
+    )
+    ~ .loading {
+    top: calc(var(--navbar-height) + var(--banner-height));
+}

--- a/packages/frontend/src/components/common/ProjectLayout/index.test.tsx
+++ b/packages/frontend/src/components/common/ProjectLayout/index.test.tsx
@@ -1,0 +1,247 @@
+import { Box, Button, MantineProvider, Text, TextInput } from '@mantine/core';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ReactNode } from 'react';
+import {
+    createMemoryRouter,
+    Link,
+    RouterProvider,
+    useBlocker,
+    type LoaderFunction,
+    type RouteObject,
+} from 'react-router';
+import ProjectLayout from '.';
+
+vi.mock('../../../features/scopeTours/ScopeTourHost', () => ({
+    default: () => null,
+}));
+
+vi.mock(
+    '../../../features/sourceCodeEditor/components/SourceCodeDrawer',
+    () => ({
+        default: () => null,
+    }),
+);
+
+vi.mock('../../NavBar', () => ({
+    default: () => (
+        <Box component="nav">
+            <Link to="/home">Home</Link>
+        </Box>
+    ),
+}));
+
+const renderLayout = ({
+    home = <TextInput aria-label="Draft" defaultValue="Unsaved draft" />,
+    loader,
+    additionalRoutes = [],
+}: {
+    home?: ReactNode;
+    loader?: LoaderFunction;
+    additionalRoutes?: RouteObject[];
+} = {}) => {
+    const pendingModule = Promise.withResolvers<void>();
+    const loadDestination = vi.fn(async () => {
+        await pendingModule.promise;
+        return { Component: () => <Text>Destination page</Text> };
+    });
+    const router = createMemoryRouter(
+        [
+            {
+                element: <ProjectLayout />,
+                errorElement: <Text>Unable to load page</Text>,
+                children: [
+                    { path: '/home', element: home, loader },
+                    {
+                        path: '/destination',
+                        lazy: loadDestination,
+                    },
+                    ...additionalRoutes,
+                ],
+            },
+        ],
+        { initialEntries: ['/home'] },
+    );
+
+    render(
+        <MantineProvider env="test">
+            <RouterProvider router={router} />
+        </MantineProvider>,
+    );
+
+    return { router, pendingModule, loadDestination };
+};
+
+describe('ProjectLayout navigation feedback', () => {
+    it('shows loading before the route module resolves and clears it on arrival', async () => {
+        const { router, pendingModule } = renderLayout();
+
+        await act(async () => {
+            void router.navigate('/destination');
+        });
+
+        expect(screen.getByRole('status')).toHaveTextContent('Loading page');
+        expect(screen.getByTestId('page-spinner')).toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/home');
+        expect(screen.queryByText('Destination page')).not.toBeInTheDocument();
+
+        await act(async () => pendingModule.resolve());
+
+        expect(await screen.findByText('Destination page')).toBeVisible();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/destination');
+    });
+
+    it('preserves the current page and edits when pending navigation is cancelled', async () => {
+        const user = userEvent.setup();
+        const { router, pendingModule } = renderLayout();
+        const draft = screen.getByRole('textbox', { name: 'Draft' });
+        await user.type(draft, ' with changes');
+
+        await act(async () => {
+            void router.navigate('/destination');
+        });
+
+        expect(draft).toBeInTheDocument();
+        expect(draft.closest('[inert]')).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Home' })).toBeVisible();
+
+        await user.click(screen.getByRole('link', { name: 'Home' }));
+
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(screen.getByRole('textbox', { name: 'Draft' })).toBe(draft);
+        expect(draft).toHaveValue('Unsaved draft with changes');
+        expect(draft.closest('[inert]')).toBeNull();
+
+        await act(async () => pendingModule.resolve());
+
+        expect(router.state.location.pathname).toBe('/home');
+        expect(screen.queryByText('Destination page')).not.toBeInTheDocument();
+    });
+
+    it('clears loading when the route module fails so the error remains accessible', async () => {
+        const { router, pendingModule } = renderLayout();
+
+        await act(async () => {
+            void router.navigate('/destination');
+        });
+        expect(screen.getByRole('status')).toBeInTheDocument();
+
+        await act(async () => pendingModule.reject(new Error('Route failed')));
+
+        const error = await screen.findByText('Unable to load page');
+        expect(error).toBeVisible();
+        expect(error.closest('[inert]')).toBeNull();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('keeps loading for a newer navigation when an abandoned module resolves', async () => {
+        const newerModule = Promise.withResolvers<void>();
+        const { router, pendingModule } = renderLayout({
+            additionalRoutes: [
+                {
+                    path: '/newer',
+                    lazy: async () => {
+                        await newerModule.promise;
+                        return { Component: () => <Text>Newer page</Text> };
+                    },
+                },
+            ],
+        });
+
+        await act(async () => {
+            void router.navigate('/destination');
+        });
+        await act(async () => {
+            void router.navigate('/newer');
+        });
+        await act(async () => pendingModule.resolve());
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+        expect(screen.queryByText('Destination page')).not.toBeInTheDocument();
+
+        await act(async () => newerModule.resolve());
+
+        expect(await screen.findByText('Newer page')).toBeVisible();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(router.state.location.pathname).toBe('/newer');
+    });
+
+    it('shows loading only after the unsaved-changes blocker allows navigation', async () => {
+        const user = userEvent.setup();
+        const BlockedEditor = () => {
+            const blocker = useBlocker(true);
+            return (
+                <>
+                    <TextInput
+                        aria-label="Draft"
+                        defaultValue="Unsaved draft"
+                    />
+                    {blocker.state === 'blocked' && (
+                        <>
+                            <Button onClick={() => blocker.reset()}>
+                                Keep editing
+                            </Button>
+                            <Button onClick={() => blocker.proceed()}>
+                                Leave page
+                            </Button>
+                        </>
+                    )}
+                </>
+            );
+        };
+        const { router, loadDestination, pendingModule } = renderLayout({
+            home: <BlockedEditor />,
+        });
+
+        await act(async () => {
+            await router.navigate('/destination');
+        });
+
+        expect(
+            screen.getByRole('button', { name: 'Keep editing' }),
+        ).toBeVisible();
+        expect(screen.getByRole('textbox', { name: 'Draft' })).toHaveValue(
+            'Unsaved draft',
+        );
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(loadDestination).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', { name: 'Keep editing' }));
+        expect(router.state.location.pathname).toBe('/home');
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+
+        await act(async () => {
+            await router.navigate('/destination');
+        });
+        await user.click(screen.getByRole('button', { name: 'Leave page' }));
+
+        expect(screen.getByRole('status')).toBeInTheDocument();
+
+        await act(async () => pendingModule.resolve());
+
+        expect(await screen.findByText('Destination page')).toBeVisible();
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('does not cover the page for a pending query-string update', async () => {
+        const pendingLoader = Promise.withResolvers<null>();
+        const { router } = renderLayout({
+            loader: ({ request }) =>
+                new URL(request.url).search ? pendingLoader.promise : null,
+        });
+        const draft = await screen.findByRole('textbox', { name: 'Draft' });
+
+        await act(async () => {
+            void router.navigate('/home?filter=updated');
+        });
+
+        expect(router.state.navigation.state).toBe('loading');
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        expect(draft.closest('[inert]')).toBeNull();
+
+        await act(async () => pendingLoader.resolve(null));
+
+        expect(router.state.location.search).toBe('?filter=updated');
+    });
+});

--- a/packages/frontend/src/components/common/ProjectLayout/index.tsx
+++ b/packages/frontend/src/components/common/ProjectLayout/index.tsx
@@ -1,9 +1,12 @@
+import { Box, VisuallyHidden } from '@mantine/core';
 import * as Sentry from '@sentry/react';
 import { type FC } from 'react';
-import { Outlet, useMatches } from 'react-router';
+import { Outlet, useLocation, useMatches, useNavigation } from 'react-router';
 import ScopeTourHost from '../../../features/scopeTours/ScopeTourHost';
 import SourceCodeDrawer from '../../../features/sourceCodeEditor/components/SourceCodeDrawer';
 import NavBar from '../../NavBar';
+import PageSpinner from '../../PageSpinner';
+import classes from './ProjectLayout.module.css';
 
 /**
  * Layout component for all /projects/:projectUuid/* routes.
@@ -20,6 +23,11 @@ import NavBar from '../../NavBar';
  */
 const ProjectLayout: FC = () => {
     const matches = useMatches();
+    const location = useLocation();
+    const navigation = useNavigation();
+    const isNavigating =
+        navigation.state === 'loading' &&
+        navigation.location.pathname !== location.pathname;
     // Search all matches for navBarFixed (handle may be on parent route)
     const isNavBarFixed = !matches.some((match) => {
         const handle = match.handle as { navBarFixed?: boolean } | undefined;
@@ -28,14 +36,23 @@ const ProjectLayout: FC = () => {
 
     return (
         <>
-            <NavBar isFixed={isNavBarFixed} />
+            <NavBar isFixed={isNavBarFixed || isNavigating} />
             <Sentry.ErrorBoundary fallback={<></>}>
                 <SourceCodeDrawer />
             </Sentry.ErrorBoundary>
             <Sentry.ErrorBoundary fallback={<></>}>
                 <ScopeTourHost />
             </Sentry.ErrorBoundary>
-            <Outlet />
+            {/* Keep the current page mounted so cancelled navigation preserves edits. */}
+            <Box display="contents" inert={isNavigating}>
+                <Outlet />
+            </Box>
+            {isNavigating && (
+                <Box className={classes.loading} role="status">
+                    <VisuallyHidden>Loading page</VisuallyHidden>
+                    <PageSpinner />
+                </Box>
+            )}
         </>
     );
 };


### PR DESCRIPTION
### Description:

Cold dashboard/chart clicks can leave the current page unchanged for several seconds because React Router waits for the lazy route module before mounting the destination's loader. Show the existing page spinner from the shared project layout as soon as a different-path navigation starts.

```diff
 Click a dashboard, chart, or another project page
- Current page stays unchanged until the route module finishes downloading
+ Loading feedback appears while the route module downloads
```

- Keep the current page mounted and inert during the wait, preserving edits if navigation is cancelled. Keep the navbar usable, including banner and fullscreen layouts.
- Respect unsaved-change blockers and leave same-path search/hash updates alone. Clear feedback on arrival, cancellation, superseding navigation, or route failure.
- This fixes the silent wait; reducing route bundle size is separate work.

Validation:

- **24 tests passed across 7 files**, including six new behavior tests for deferred loading, cancellation/edit preservation, failures, competing navigation, blockers, and query-string updates. Rerun after rebasing onto current `main`.
- Frontend typecheck, focused Oxlint/Oxfmt, commit hooks (including unused exports), and `git diff --check` passed. Production build and compiled-frontend smoke tests passed before rebase; the rebase introduced no project-layout changes.
- Chrome at `localhost:3000`: held dashboard/chart module requests showed feedback in approximately **73/87 ms**, then loaded successfully on release. Checked navbar cancellation, superseding navigation, Back/Forward, failed-module recovery, warm navigation, source drawer, light/dark themes, and unsaved changes (Stay/Leave). The chart edit was discarded and the original saved value confirmed.
- Compiled-frontend smoke coverage included the preview banner and fullscreen layout. Preview status was mocked only in the browser; fullscreen layout used a browser-only `requestFullscreen` stub because native permission was unavailable. Safari and native fullscreen entry remain untested.

<details>
<summary>Automated validation commands</summary>

```sh
pnpm -F frontend test \
  src/components/common/ProjectLayout/index.test.tsx \
  src/features/chunkErrorHandler/loadLazyRouteDefault.test.ts \
  src/features/errorBoundary/ChunkErrorRouteBoundary.test.tsx \
  src/components/NavBar/BrowseMenu.test.tsx \
  src/components/NavBar/MetricsLink.test.tsx \
  src/components/ProjectRoute.test.tsx \
  src/MobileRoutes.test.tsx
pnpm -F frontend typecheck
pnpm -F frontend exec oxlint -c .oxlintrc.json \
  src/components/common/ProjectLayout/index.tsx \
  src/components/common/ProjectLayout/index.test.tsx
pnpm -F frontend exec oxfmt --check \
  src/components/common/ProjectLayout/index.tsx \
  src/components/common/ProjectLayout/ProjectLayout.module.css \
  src/components/common/ProjectLayout/index.test.tsx
env -u SENTRY_AUTH_TOKEN NODE_ENV=production NODE_OPTIONS=--max-old-space-size=8192 \
  pnpm -F frontend build --outDir /tmp/lightdash-nav-build.Q2xjQs --manifest
git diff --check origin/main...HEAD
```

</details>

### Risk assessment:

- [ ] This is a high-risk change

Low risk: a reversible frontend loading-state change with no API, permission, or persistence changes. The shared layout affects project navigation broadly; cancellation, unsaved edits, error recovery, and navbar access were specifically exercised above. Remote CI is pending.
