### PR TITLE
fix(tables): refuse to run a totals query that has nothing to select

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.test.ts
@@ -395,6 +395,129 @@ describe('TotalQueryBuilder: grandTotal', () => {
     });
 });
 
+describe('TotalQueryBuilder: nothing to total', () => {
+    const popOnlyMetricQuery: MetricQuery = {
+        ...baseMetricQuery,
+        metrics: ['orders_total_revenue_pop_12m'],
+        additionalMetrics: [
+            {
+                name: 'total_revenue_pop_12m',
+                table: 'orders',
+                sql: '${TABLE}.revenue',
+                type: 'sum' as never,
+                generationType: 'periodOverPeriod',
+                baseMetricId: 'orders_total_revenue',
+                timeDimensionId: 'orders_created_at',
+                granularity: 'MONTH' as never,
+                periodOffset: 12,
+            } as never,
+        ],
+    };
+
+    it('refuses a grand total for a dimension-only query', () => {
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery: { ...baseMetricQuery, metrics: [] },
+                pivotConfiguration: null,
+                kind: 'grandTotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+    });
+
+    it('refuses a grand total when the only metrics are period-over-period', () => {
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery: popOnlyMetricQuery,
+                pivotConfiguration: null,
+                kind: 'grandTotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+    });
+
+    it('refuses a grand total when the only table calc is not totalable', () => {
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery: {
+                    ...baseMetricQuery,
+                    metrics: [],
+                    tableCalculations: [
+                        {
+                            name: 'status_length',
+                            displayName: 'Status length',
+                            sql: 'LENGTH(${orders.status})',
+                        } as never,
+                    ],
+                },
+                pivotConfiguration: null,
+                kind: 'grandTotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+    });
+
+    it('allows a query whose only value column is a sum-of-rows table calc', () => {
+        const result = new TotalQueryBuilder({
+            metricQuery: {
+                ...baseMetricQuery,
+                metrics: [],
+                tableCalculations: [
+                    {
+                        name: 'row_value',
+                        displayName: 'Row value',
+                        sql: '${orders.amount} * 2',
+                        totalMode: TableCalculationTotalMode.SUM_OF_ROWS,
+                    } as never,
+                ],
+            },
+            pivotConfiguration: null,
+            kind: 'grandTotal',
+        }).compileQuery();
+
+        expect(result.metricQuery.metrics).toEqual([]);
+        expect(result.sourceQuery).toBeDefined();
+    });
+
+    it('refuses pivoted column and row totals for a dimension-only query', () => {
+        const metricQuery = { ...baseMetricQuery, metrics: [] };
+        const emptyValuesPivot: PivotConfiguration = {
+            ...pivotConfiguration,
+            valuesColumns: [],
+        };
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery,
+                pivotConfiguration: emptyValuesPivot,
+                kind: 'columnTotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery,
+                pivotConfiguration: emptyValuesPivot,
+                kind: 'rowTotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+    });
+
+    it('refuses column and row subtotals when the only metrics are period-over-period', () => {
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery: popOnlyMetricQuery,
+                pivotConfiguration: null,
+                subtotalDimensions: ['orders_status'],
+                kind: 'columnSubtotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+        expect(() =>
+            new TotalQueryBuilder({
+                metricQuery: popOnlyMetricQuery,
+                pivotConfiguration,
+                subtotalDimensions: ['orders_created_at'],
+                kind: 'rowSubtotal',
+            }).compileQuery(),
+        ).toThrow(NotSupportedError);
+    });
+});
+
 describe('TotalQueryBuilder: columnTotal', () => {
     describe('pivoted source', () => {
         it('keeps only groupBy dimensions and drops the index column', () => {

--- a/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/TotalQueryBuilder.ts
@@ -193,6 +193,12 @@ export class TotalQueryBuilder {
     constructor(private readonly args: TotalQueryBuilderArgs) {}
 
     public compileQuery(): TotalQueryResult {
+        const result = this.buildQuery();
+        this.assertHasValueColumns(result.metricQuery);
+        return result;
+    }
+
+    private buildQuery(): TotalQueryResult {
         const { kind } = this.args;
         const sourceQuery = this.buildSourceQuery();
         switch (kind) {
@@ -215,6 +221,21 @@ export class TotalQueryBuilder {
                     kind,
                     `Total query kind "${kind}" is not supported`,
                 );
+        }
+    }
+
+    // Once dimensions, PoP metrics and non-totalable calcs are stripped, a
+    // query can be left with nothing to select. Refuse it here rather than
+    // sending `SELECT FROM ...` to the warehouse.
+    private assertHasValueColumns(totalsMetricQuery: MetricQuery): void {
+        const hasValueColumns =
+            totalsMetricQuery.metrics.length > 0 ||
+            totalsMetricQuery.tableCalculations.length > 0 ||
+            getSumOfRowsTableCalculations(this.args.metricQuery).length > 0;
+        if (!hasValueColumns) {
+            throw new NotSupportedError(
+                'Nothing to total: the query has no metrics or totalable table calculations',
+            );
         }
     }
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -25,6 +25,7 @@ import isEqual from 'lodash/isEqual';
 import uniq from 'lodash/uniq';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMergeSafe } from '../../features/mergeQuery/context/useMerge';
+import { canHaveWarehouseTotal } from '../../utils/canHaveWarehouseTotal';
 import {
     useAsyncCalculateGrandTotal,
     useAsyncCalculateRowSubtotals,
@@ -267,9 +268,19 @@ const useTableConfig = (
     // exist for a query that errored, and totals against that are meaningless.
     const isInitialQueryReady =
         resultsData?.queryStatus === QueryHistoryStatus.READY;
+    // A dimension-only table has nothing the warehouse can total; skip the
+    // request instead of letting the backend refuse it.
+    const hasTotalableColumns = useMemo(
+        () =>
+            columnOrder.some((fieldId) =>
+                canHaveWarehouseTotal(itemsMap?.[fieldId]),
+            ),
+        [columnOrder, itemsMap],
+    );
     const canFetchAsyncTotals =
         isInitialQueryReady &&
         !!resultsData?.queryUuid &&
+        hasTotalableColumns &&
         !!tableChartConfig?.showColumnCalculation;
     const {
         data: asyncTotals,
@@ -296,6 +307,7 @@ const useTableConfig = (
     const canFetchAsyncRowTotals =
         isInitialQueryReady &&
         !!resultsData?.queryUuid &&
+        hasTotalableColumns &&
         !!tableChartConfig?.showRowCalculation &&
         !!resultsData?.pivotDetails;
     const {
@@ -313,6 +325,7 @@ const useTableConfig = (
     const canFetchAsyncGrandTotals =
         isInitialQueryReady &&
         !!resultsData?.queryUuid &&
+        hasTotalableColumns &&
         !!resultsData?.pivotDetails &&
         !!tableChartConfig?.showColumnCalculation &&
         !!tableChartConfig?.showRowCalculation;
@@ -337,7 +350,11 @@ const useTableConfig = (
         dimensions: resultsData?.metricQuery?.dimensions,
         columnOrder,
         pivotDimensions,
-        enabled: isInitialQueryReady && showSubtotals && canUseSubtotals,
+        enabled:
+            isInitialQueryReady &&
+            hasTotalableColumns &&
+            showSubtotals &&
+            canUseSubtotals,
         invalidateCache,
     });
     const {
@@ -352,6 +369,7 @@ const useTableConfig = (
         pivotDimensions,
         enabled:
             isInitialQueryReady &&
+            hasTotalableColumns &&
             showSubtotals &&
             canUseSubtotals &&
             !!tableChartConfig?.showRowCalculation &&

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.test.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isTotalsNotSupportedError } from './useAsyncCalculateTotal';
+
+describe('isTotalsNotSupportedError', () => {
+    it('is true for a NotSupportedError api response', () => {
+        expect(
+            isTotalsNotSupportedError({
+                status: 'error',
+                error: {
+                    name: 'NotSupportedError',
+                    statusCode: 400,
+                    message: 'Nothing to total',
+                    data: {},
+                },
+            }),
+        ).toBe(true);
+    });
+
+    it('is false for other api errors and plain errors', () => {
+        expect(
+            isTotalsNotSupportedError({
+                status: 'error',
+                error: {
+                    name: 'ForbiddenError',
+                    statusCode: 403,
+                    message: 'Forbidden',
+                    data: {},
+                },
+            }),
+        ).toBe(false);
+        expect(isTotalsNotSupportedError(new Error('boom'))).toBe(false);
+        expect(isTotalsNotSupportedError(undefined)).toBe(false);
+    });
+});

--- a/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
+++ b/packages/frontend/src/hooks/useAsyncCalculateTotal.ts
@@ -2,6 +2,7 @@ import {
     buildWarehouseColumnTotals,
     buildWarehouseRowTotals,
     getSubtotalKey,
+    isApiError,
     QueryHistoryStatus,
     type ApiError,
     type ApiExecuteAsyncMetricQueryResults,
@@ -63,26 +64,38 @@ const getMockTotalError = (kind: CalculateTotalKind) => {
         : undefined;
 };
 
-const startCalculateTotalQuery = ({
+// The backend refuses to build a totals query with nothing to select (for
+// example a dimension-only table, or one whose only metrics are
+// period-over-period). That is "no totals", not a failure to surface.
+export const isTotalsNotSupportedError = (error: unknown): boolean =>
+    isApiError(error) && error.error.name === 'NotSupportedError';
+
+// Resolves to null when the backend reports there is nothing to total.
+const startCalculateTotalQuery = async ({
     projectUuid,
     sourceQueryUuid,
     kind,
     subtotalDimensions,
     invalidateCache,
-}: StartCalculateTotalArgs) => {
+}: StartCalculateTotalArgs): Promise<ApiExecuteAsyncMetricQueryResults | null> => {
     const mockError = getMockTotalError(kind);
     if (mockError) return Promise.reject(mockError);
 
-    return lightdashApi<ApiExecuteAsyncMetricQueryResults>({
-        url: `/projects/${projectUuid}/query/${sourceQueryUuid}/calculate-total`,
-        version: 'v2',
-        method: 'POST',
-        body: JSON.stringify({
-            kind,
-            subtotalDimensions,
-            invalidateCache,
-        }),
-    });
+    try {
+        return await lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+            url: `/projects/${projectUuid}/query/${sourceQueryUuid}/calculate-total`,
+            version: 'v2',
+            method: 'POST',
+            body: JSON.stringify({
+                kind,
+                subtotalDimensions,
+                invalidateCache,
+            }),
+        });
+    } catch (error) {
+        if (isTotalsNotSupportedError(error)) return null;
+        throw error;
+    }
 };
 
 // Single wide row of totals. Keys are pivoted SQL column names for pivoted
@@ -94,11 +107,12 @@ const fetchTotals = async (
         kind: Extract<CalculateTotalKind, 'columnTotal' | 'grandTotal'>;
     },
 ): Promise<AsyncTotalsMap> => {
-    const { queryUuid } = await startCalculateTotalQuery(args);
+    const started = await startCalculateTotalQuery(args);
+    if (!started) return {};
 
     // Polling endpoint defaults to page=1, so the READY response already
     // contains the single totals row — no separate stream fetch needed.
-    const query = await pollForResults(args.projectUuid, queryUuid);
+    const query = await pollForResults(args.projectUuid, started.queryUuid);
 
     if (
         query.status === QueryHistoryStatus.ERROR ||
@@ -194,12 +208,14 @@ const fetchRowTotals = async (
 ): Promise<PivotRowTotalsByIndex> => {
     const { projectUuid, sourceQueryUuid, indexFieldIds, invalidateCache } =
         args;
-    const { queryUuid } = await startCalculateTotalQuery({
+    const started = await startCalculateTotalQuery({
         projectUuid,
         sourceQueryUuid,
         kind: 'rowTotal',
         invalidateCache,
     });
+    if (!started) return {};
+    const { queryUuid } = started;
 
     const query = await pollForResults(projectUuid, queryUuid);
 
@@ -303,13 +319,15 @@ const fetchRowSubtotals = async (args: {
             async (
                 group,
             ): Promise<[dimensions: string[], rows: ResultRow[]]> => {
-                const { queryUuid } = await startCalculateTotalQuery({
+                const started = await startCalculateTotalQuery({
                     projectUuid: args.projectUuid,
                     sourceQueryUuid: args.sourceQueryUuid,
                     kind: 'rowSubtotal',
                     subtotalDimensions: group,
                     invalidateCache: args.invalidateCache,
                 });
+                if (!started) return [group, []];
+                const { queryUuid } = started;
 
                 const query = await pollForResults(args.projectUuid, queryUuid);
                 if (
@@ -416,13 +434,15 @@ const fetchSubtotals = async (args: {
     const entries = await Promise.all(
         dimensionGroups.map(
             async (group): Promise<[string, RawResultRow[]]> => {
-                const { queryUuid } = await startCalculateTotalQuery({
+                const started = await startCalculateTotalQuery({
                     projectUuid,
                     sourceQueryUuid,
                     kind: 'columnSubtotal',
                     subtotalDimensions: group,
                     invalidateCache: args.invalidateCache,
                 });
+                if (!started) return [getSubtotalKey(group), []];
+                const { queryUuid } = started;
 
                 const query = await pollForResults(projectUuid, queryUuid);
                 if (


### PR DESCRIPTION
### Description

Stacked on #28987.

The totals builder strips dimensions, period-over-period metrics, and table calcs it cannot total (dimension references, window functions, total mode set to none). When nothing survives, the totals query compiles to an empty SELECT list. BigQuery rejects it with `SELECT list must not be empty`, Postgres accepts it and returns a row with no columns, and either way the request was sent on every dashboard view and every scheduled delivery. That is the empty-SELECT failure in #28874.

Tables that hit this today:

- dimension-only tables
- tables whose only metrics are period-over-period metrics
- tables whose only value columns are non-totalable table calcs

**Backend.** `TotalQueryBuilder.compileQuery` now checks the collapsed query and throws `NotSupportedError` when it has no metrics, no totalable table calcs, and no sum-of-rows calcs. The check applies to every kind: grand total, column and row totals, column and row subtotals. The totals SQL is compiled synchronously inside the POST before the query-history row is written, and the outer catch rethrows, so the caller gets an immediate 400. Nothing reaches the warehouse and nothing is logged as a failed query. The legacy `calculateMetricQueryTotal` path already catches `NotSupportedError` and returns empty totals, so it benefits without changes.

**Frontend.** The calculate-total starter treats a `NotSupportedError` response as "no totals" and every fetcher resolves to an empty result for it, so the Total row and subtotal rows render blank instead of red. The chart table also skips the request up front when no visible column passes `canHaveWarehouseTotal` from #28987. That is an optimisation only. The frontend cannot cheaply replicate the PoP and table-calc rules, so the backend check remains the source of truth. The explorer results table already had a metrics guard.

### Regression analysis

The old client-side hook only requested totals when at least one selected field was a metric. That guard was lost when warehouse-computed totals replaced it in #23590, and the builder never had its own check, so the empty query has been sent since then on any warehouse. It only became visible on BigQuery because Postgres tolerates an empty select list, and it only became user-visible once #26126 rendered totals errors in cells.

Behaviour that stays the same:

- Any table with a metric or totalable table calc requests and renders totals exactly as before.
- Sum-of-rows table calcs are still totaled through the embedded source query, even with no metrics selected.
- Other totals failures (warehouse errors, permission errors) still surface as before.

### Testing

- Six new builder tests: dimension-only, PoP-only, non-totalable-calc-only refused for grand totals; pivoted column and row totals refused; column and row subtotals refused; sum-of-rows-only allowed.
- Predicate test for the frontend `NotSupportedError` detection.
- Backend and frontend typecheck, lint, and format clean after rebuilding common and warehouses.

Closes: #28874

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RSNnPPK369vYN8E5guiWH
