### PR TITLE
fix(chart-types): dismiss the topmost gallery modal first

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeDetailModal.tsx
@@ -29,6 +29,7 @@ import OfficialChartTypeBadge from './OfficialChartTypeBadge';
 type Props = {
     projectUuid: string;
     dataAppViz: DataAppViz;
+    isActive: boolean;
     /** This chart type's registry entry, when it is a registry install */
     registryEntry: RegistryChartTypeListItem | null;
     onClose: () => void;
@@ -39,6 +40,7 @@ type Props = {
 const ChartTypeDetailModal: FC<Props> = ({
     projectUuid,
     dataAppViz,
+    isActive,
     registryEntry,
     onClose,
     onPreview,
@@ -48,6 +50,7 @@ const ChartTypeDetailModal: FC<Props> = ({
     const canFork = useCanCreateDataApp(projectUuid);
     const isOfficial = isOfficialChartType(dataAppViz);
     const [isForkOpen, setIsForkOpen] = useState(false);
+    const isDetailActive = isActive && !isForkOpen;
     const upgradeMutation = useInstallRegistryChartType();
     const { track } = useTracking();
     const registryUpdate =
@@ -88,6 +91,11 @@ const ChartTypeDetailModal: FC<Props> = ({
             <MantineModal
                 opened
                 onClose={onClose}
+                modalRootProps={{
+                    closeOnEscape: isDetailActive,
+                    closeOnClickOutside: isDetailActive,
+                    trapFocus: isDetailActive,
+                }}
                 title={
                     <Group gap="xs" wrap="nowrap">
                         <MantineIcon icon={getChartTypeIcon(dataAppViz.icon)} />

--- a/packages/frontend/src/pages/ChartTypeGallery.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.test.tsx
@@ -1,5 +1,6 @@
 import { FeatureFlags, type DataAppViz } from '@lightdash/common';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppVersionHistory } from '../features/apps/hooks/useAppVersionHistory';
@@ -399,6 +400,13 @@ describe('ChartTypeGallery', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
         expect(screen.getByText('Delete chart type')).toBeInTheDocument();
+        fireEvent.keyDown(screen.getByText('Delete chart type'), {
+            key: 'Escape',
+        });
+        expect(screen.getByText('Delete chart type')).toBeInTheDocument();
+        expect(
+            screen.getByRole('dialog', { name: 'Radial gauge' }),
+        ).toBeInTheDocument();
     });
 
     it('labels the action Uninstall for official chart types', async () => {
@@ -503,6 +511,43 @@ describe('ChartTypeGallery', () => {
         expect(
             screen.queryByRole('button', { name: /Upgrade to v/ }),
         ).not.toBeInTheDocument();
+    });
+
+    it('dismisses the preview before the chart details with Escape', async () => {
+        const user = userEvent.setup();
+        setData([makeDataAppViz({})]);
+        renderPage();
+
+        await user.click(screen.getByText('Radial gauge'));
+        await user.click(
+            screen.getByRole('button', { name: 'Preview in explorer' }),
+        );
+
+        await waitFor(() =>
+            expect(screen.getByPlaceholderText('Select a table')).toHaveFocus(),
+        );
+        await user.click(screen.getByPlaceholderText('Select a table'));
+        expect(screen.getByRole('listbox')).toBeVisible();
+        await user.keyboard('{Escape}');
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+        expect(screen.getAllByRole('dialog')).toHaveLength(2);
+
+        await user.tab();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+        await user.keyboard('{Escape}');
+
+        expect(
+            screen.queryByRole('dialog', { name: 'Preview in explorer' }),
+        ).not.toBeInTheDocument();
+        const details = screen.getByRole('dialog', { name: 'Radial gauge' });
+        await waitFor(() =>
+            expect(
+                within(details).getByRole('button', { name: 'Close' }),
+            ).toHaveFocus(),
+        );
+        await user.keyboard('{Escape}');
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('previews in the explorer with the chosen table and config open', () => {
@@ -652,7 +697,8 @@ describe('ChartTypeGallery', () => {
             );
         });
 
-        it('shows the badge and a fork action in the detail modal', () => {
+        it('keeps the detail modal open when dismissing the fork dialog', async () => {
+            const user = userEvent.setup();
             setData([makeDataAppViz({ registrySlug: 'radial-gauge' })]);
             renderPage();
 
@@ -662,6 +708,18 @@ describe('ChartTypeGallery', () => {
                 screen.getByRole('button', { name: /Fork to customize/ }),
             ).toBeInTheDocument();
             expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+
+            await user.click(
+                screen.getByRole('button', { name: 'Fork to customize' }),
+            );
+            await user.keyboard('{Escape}');
+
+            expect(
+                screen.queryByRole('dialog', { name: 'Fork to customize' }),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.getByRole('dialog', { name: /Radial gauge/ }),
+            ).toBeInTheDocument();
         });
 
         it.each(['card', 'detail modal'])(

--- a/packages/frontend/src/pages/ChartTypeGallery.tsx
+++ b/packages/frontend/src/pages/ChartTypeGallery.tsx
@@ -299,6 +299,7 @@ const ChartTypeGallery = () => {
                 <ChartTypeDetailModal
                     projectUuid={projectUuid}
                     dataAppViz={selected}
+                    isActive={previewUuid === null && deleteUuid === null}
                     registryEntry={registryEntryFor(selected)}
                     onClose={() => setSelectedUuid(null)}
                     onPreview={() => setPreviewUuid(selected.dataAppVizUuid)}


### PR DESCRIPTION
Closes: N/A (dogfooding report; no linked ticket)

### Description:

```diff
 Installed charts → chart details → Preview in explorer → Escape
- closes the chart details behind the preview
+ closes the preview and keeps the chart details open
```

- Suspend the details dialog's dismissal handlers and focus trap while Preview, Fork, or Delete is above it; restore them when the child dialog closes.
- Keep keyboard focus in the active dialog. Escape closes an open table dropdown first, then the preview, then chart details. Clicking outside the preview closes only the preview.
- Preserve the explicit Delete confirmation; dismissing dialogs does not change chart data.

### Validation:

- `pnpm -F frontend test src/pages/ChartTypeGallery.test.tsx` — 24 passed, including preview dismissal/focus, fork dismissal, and Delete confirmation protection.
- `pnpm -F frontend typecheck` — passed.
- Targeted Oxlint and Oxfmt checks on all three changed files; `git diff --check` — passed.
- Reproduced the original bug in localhost, then verified Escape order, outside-click dismissal, table-dropdown Escape handling, Tab containment, and restored detail focus. No chart data was persisted.
- Fork/Delete dismissal was covered by component tests, not live browser checks.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: reversible frontend change scoped to the chart gallery dialogs, with no API, permission, or persistence changes.
