### PR TITLE
chore(frontend): prepare for Mantine 9

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFilterItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFilterItem.tsx
@@ -53,7 +53,7 @@ const FilterSummaryLabel: FC<
     }
     return (
         <Text fw={400} span>
-            <Text span color="ldGray.7">
+            <Text span c="ldGray.7">
                 {filterSummary?.operator}{' '}
             </Text>
             <Text fw={600} span>
@@ -165,7 +165,7 @@ export const SchedulerFilterItem = <R extends SchedulerOverridableRule>({
                         />
                     )}
                     {isMissingRequiredValue && !isEditing && (
-                        <Text fz="sm" color="red">
+                        <Text fz="sm" c="red">
                             *
                         </Text>
                     )}

--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormFiltersTab.tsx
@@ -328,7 +328,7 @@ export const SchedulerFormFiltersTab: FC<SchedulerFiltersProps> = ({
                 </Stack>
             ) : (
                 <Center component={Stack} h={100}>
-                    <Text color="dimmed">
+                    <Text c="dimmed">
                         No filters defined for this dashboard.
                     </Text>
                 </Center>

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -143,7 +143,7 @@ const Register: FC = () => {
                     my="md"
                     labelPosition="center"
                     label={
-                        <Text color="ldGray.5" size="sm" fw={500}>
+                        <Text c="ldGray.5" size="sm" fw={500}>
                             {isNewLayout ? 'or' : 'OR'}
                         </Text>
                     }

--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
@@ -130,7 +130,7 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                         {screenshotError ? (
                             <>
                                 <MantineIcon icon={IconIdOff} color="ldGray" />
-                                <Text color="dimmed" ta="center">
+                                <Text c="dimmed" ta="center">
                                     Screenshot could not be captured. You can
                                     still submit your report with the details
                                     below
@@ -157,12 +157,12 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                 onChange={(event) => setAllowAccess(event.target.checked)}
                 mt="xs"
             />
-            <Text size="xs" color="dimmed">
+            <Text size="xs" c="dimmed">
                 By ticking this box, you agree to give Lightdash Support access
                 to your organization for 12 hours to investigate this issue.
             </Text>
 
-            <Text size="xs" color="dimmed">
+            <Text size="xs" c="dimmed">
                 We will also share your Lightdash logs and your recent network
                 requests to help us investigate this issue.
             </Text>

--- a/packages/frontend/src/stories/mantineBaseline/Controls.stories.tsx
+++ b/packages/frontend/src/stories/mantineBaseline/Controls.stories.tsx
@@ -1,0 +1,308 @@
+import {
+    ActionIcon,
+    Anchor,
+    Avatar,
+    Badge,
+    Breadcrumbs,
+    Button,
+    CloseButton,
+    Group,
+    Kbd,
+    Loader,
+    Pagination,
+    Pill,
+    SegmentedControl,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+    IconPlus,
+    IconSettings,
+    IconTrash,
+    type Icon,
+} from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+
+/**
+ * Static render of every control the theme restyles through the Styles API
+ * (theme/components/*.module.css). Each block covers the variants, sizes and
+ * data-attribute states those CSS modules key on, so a screenshot before and
+ * after a Mantine bump shows any drift in the overrides.
+ */
+const meta: Meta = {
+    title: 'Mantine baseline/Controls',
+    parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+const BUTTON_VARIANTS = [
+    'filled',
+    'default',
+    'light',
+    'subtle',
+    'outline',
+    'white',
+] as const;
+
+const Section: FC<{ title: string; children: ReactNode }> = ({
+    title,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Title order={5}>{title}</Title>
+        {children}
+    </Stack>
+);
+
+const Row: FC<{ label: string; children: ReactNode }> = ({
+    label,
+    children,
+}) => (
+    <Group gap="sm" wrap="nowrap" align="center">
+        <Text w={90} size="xs" c="dimmed">
+            {label}
+        </Text>
+        <Group gap="sm">{children}</Group>
+    </Group>
+);
+
+const PlusIcon: FC<{ icon?: Icon }> = ({ icon = IconPlus }) => (
+    <MantineIcon icon={icon} />
+);
+
+export const Buttons: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="Variants (primary colour)">
+                {BUTTON_VARIANTS.map((variant) => (
+                    <Row key={variant} label={variant}>
+                        <Button variant={variant}>Label</Button>
+                        <Button variant={variant} leftSection={<PlusIcon />}>
+                            Left section
+                        </Button>
+                        <Button
+                            variant={variant}
+                            rightSection={<PlusIcon icon={IconSettings} />}
+                        >
+                            Right section
+                        </Button>
+                        <Button variant={variant} disabled>
+                            Disabled
+                        </Button>
+                        <Button variant={variant} loading>
+                            Loading
+                        </Button>
+                    </Row>
+                ))}
+            </Section>
+            <Section title="Variants (color=gray keeps Mantine's muted tone)">
+                {(['light', 'subtle'] as const).map((variant) => (
+                    <Row key={variant} label={variant}>
+                        <Button variant={variant} color="gray">
+                            Gray
+                        </Button>
+                        <Button variant={variant} color="red">
+                            Red
+                        </Button>
+                    </Row>
+                ))}
+            </Section>
+            <Section title="Sizes (font stays at body size until lg)">
+                {(['filled', 'default'] as const).map((variant) => (
+                    <Row key={variant} label={variant}>
+                        {SIZES.map((size) => (
+                            <Button key={size} variant={variant} size={size}>
+                                {size}
+                            </Button>
+                        ))}
+                    </Row>
+                ))}
+            </Section>
+        </Stack>
+    ),
+};
+
+export const ActionIcons: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="Variants">
+                {(
+                    [
+                        'subtle',
+                        'transparent',
+                        'default',
+                        'filled',
+                        'light',
+                    ] as const
+                ).map((variant) => (
+                    <Row key={variant} label={variant}>
+                        <ActionIcon variant={variant}>
+                            <PlusIcon icon={IconSettings} />
+                        </ActionIcon>
+                        <ActionIcon variant={variant} color="gray">
+                            <PlusIcon icon={IconSettings} />
+                        </ActionIcon>
+                        <ActionIcon variant={variant} color="red">
+                            <PlusIcon icon={IconTrash} />
+                        </ActionIcon>
+                        <ActionIcon variant={variant} disabled>
+                            <PlusIcon icon={IconSettings} />
+                        </ActionIcon>
+                    </Row>
+                ))}
+            </Section>
+            <Section title="Sizes and CloseButton">
+                <Row label="default">
+                    {SIZES.map((size) => (
+                        <ActionIcon key={size} variant="default" size={size}>
+                            <PlusIcon icon={IconSettings} />
+                        </ActionIcon>
+                    ))}
+                </Row>
+                <Row label="close">
+                    {SIZES.map((size) => (
+                        <CloseButton key={size} size={size} />
+                    ))}
+                    <CloseButton disabled />
+                </Row>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const BadgesAndPills: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="Badge (theme default: light gray, radius sm)">
+                <Row label="default">
+                    <Badge>Neutral</Badge>
+                    <Badge color="blue">Blue</Badge>
+                    <Badge color="red">Red</Badge>
+                    <Badge variant="default">variant=default</Badge>
+                    <Badge variant="filled">Filled</Badge>
+                    <Badge variant="outline">Outline</Badge>
+                    <Badge variant="dot">Dot</Badge>
+                </Row>
+                <Row label="sizes">
+                    {SIZES.map((size) => (
+                        <Badge key={size} size={size}>
+                            {size}
+                        </Badge>
+                    ))}
+                </Row>
+                <Row label="sections">
+                    <Badge leftSection={<PlusIcon />}>Left</Badge>
+                    <Badge rightSection={<PlusIcon />}>Right</Badge>
+                </Row>
+            </Section>
+            <Section title="Pill">
+                <Row label="default">
+                    <Pill>Pill</Pill>
+                    <Pill withRemoveButton>Removable</Pill>
+                    <Pill disabled>Disabled</Pill>
+                </Row>
+                <Row label="outline">
+                    <Pill variant="outline">Pill</Pill>
+                    <Pill variant="outline" withRemoveButton>
+                        Removable
+                    </Pill>
+                </Row>
+                <Row label="sizes">
+                    {SIZES.map((size) => (
+                        <Pill key={size} size={size} withRemoveButton>
+                            {size}
+                        </Pill>
+                    ))}
+                </Row>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const SegmentedControls: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="SegmentedControl">
+                {SIZES.map((size) => (
+                    <Row key={size} label={size}>
+                        <SegmentedControl
+                            size={size}
+                            defaultValue="table"
+                            data={[
+                                { label: 'Chart', value: 'chart' },
+                                { label: 'Table', value: 'table' },
+                                { label: 'SQL', value: 'sql' },
+                            ]}
+                        />
+                    </Row>
+                ))}
+                <Row label="disabled">
+                    <SegmentedControl
+                        disabled
+                        defaultValue="a"
+                        data={['a', 'b', 'c']}
+                    />
+                </Row>
+            </Section>
+            <Section title="Pagination">
+                <Row label="default">
+                    <Pagination total={10} value={3} />
+                </Row>
+                <Row label="input-sm">
+                    <Pagination total={10} value={3} size="input-sm" />
+                </Row>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const Miscellaneous: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="Kbd">
+                <Row label="kbd">
+                    <Kbd>⌘</Kbd>
+                    <Kbd>Enter</Kbd>
+                    <Kbd>Shift</Kbd> + <Kbd>K</Kbd>
+                </Row>
+            </Section>
+            <Section title="Avatar placeholder">
+                <Row label="sizes">
+                    {SIZES.map((size) => (
+                        <Avatar
+                            key={size}
+                            size={size}
+                            color="initials"
+                            name="Tati Inama"
+                        />
+                    ))}
+                    <Avatar radius="xl" />
+                </Row>
+            </Section>
+            <Section title="Breadcrumbs">
+                <Breadcrumbs>
+                    <Anchor href="#">Spaces</Anchor>
+                    <Anchor href="#">Finance</Anchor>
+                    <Text>Revenue by month</Text>
+                </Breadcrumbs>
+            </Section>
+            <Section title="Loader (theme registers the dots loader)">
+                <Row label="types">
+                    <Loader type="dots" />
+                    <Loader type="oval" />
+                    <Loader type="bars" />
+                </Row>
+                <Row label="sizes">
+                    {SIZES.map((size) => (
+                        <Loader key={size} type="dots" size={size} />
+                    ))}
+                </Row>
+            </Section>
+        </Stack>
+    ),
+};

--- a/packages/frontend/src/stories/mantineBaseline/FeatureSelectors.stories.tsx
+++ b/packages/frontend/src/stories/mantineBaseline/FeatureSelectors.stories.tsx
@@ -1,0 +1,233 @@
+import {
+    Accordion,
+    Badge,
+    Checkbox,
+    Group,
+    Paper,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { FC, ReactNode } from 'react';
+import CodeBlock from '../../components/common/CodeBlock/CodeBlock';
+import contentTableClasses from '../../components/common/ContentTable/ContentTable.module.css';
+import PromptComposer from '../../components/common/PromptComposer/PromptComposer';
+import sortButtonClasses from '../../components/SortButton/SortButton.module.css';
+import accordionClasses from '../../components/VisualizationConfigs/common/Accordion.module.css';
+import { AccordionControl } from '../../components/VisualizationConfigs/common/AccordionControl';
+import { AiAgentIcon } from '../../ee/features/aiCopilot/components/AiAgentIcon/AiAgentIcon';
+import { FormulaReferencePanel } from '../../features/tableCalculation/components/FormulaForm/FormulaReference';
+
+/**
+ * Feature components whose CSS modules reach into Mantine's generated class
+ * names through :global(.mantine-*). Those selectors are not covered by the
+ * Styles API contract, so they are the first thing to break when Mantine
+ * renames an internal part. Each story renders the owning component with the
+ * selector-dependent state visible.
+ */
+const meta: Meta = {
+    title: 'Mantine baseline/Feature selectors',
+    parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+const Section: FC<{ title: string; hint: string; children: ReactNode }> = ({
+    title,
+    hint,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Title order={5}>{title}</Title>
+        <Text size="xs" c="dimmed">
+            {hint}
+        </Text>
+        {children}
+    </Stack>
+);
+
+const SQL = `SELECT
+    order_date,
+    customer_id,
+    SUM(order_total) AS total
+FROM analytics.orders
+WHERE order_date >= '2026-01-01'
+GROUP BY 1, 2
+ORDER BY total DESC
+LIMIT 500`;
+
+export const CodeHighlight: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section
+                title="CodeBlock with line numbers"
+                hint="CodeBlock.module.css: .wrapper[data-with-line-numbers] :global(.mantine-CodeHighlight-code)"
+            >
+                <CodeBlock code={SQL} language="sql" withLineNumbers />
+            </Section>
+            <Section
+                title="CodeBlock without line numbers"
+                hint="Same component, copy control from @mantine/code-highlight"
+            >
+                <CodeBlock code={SQL} language="sql" />
+            </Section>
+        </Stack>
+    ),
+};
+
+export const RichTextEditor: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section
+                title="PromptComposer card, sizes lg / md / sm"
+                hint="PromptComposer.module.css: :global(.mantine-RichTextEditor-content)"
+            >
+                <PromptComposer
+                    size="lg"
+                    placeholder="Ask anything about your data"
+                    defaultValue="Large composer with a default value"
+                />
+                <PromptComposer size="md" placeholder="Medium composer" />
+                <PromptComposer size="sm" placeholder="Small composer" />
+            </Section>
+            <Section
+                title="PromptComposer inline and accent"
+                hint="Inline variant is used inside cards; indigo accent marks deep research"
+            >
+                <Paper p="sm">
+                    <PromptComposer variant="inline" placeholder="Inline" />
+                </Paper>
+                <PromptComposer
+                    accent="indigo"
+                    size="md"
+                    placeholder="Indigo accent"
+                />
+                <PromptComposer size="md" disabled defaultValue="Disabled" />
+            </Section>
+        </Stack>
+    ),
+};
+
+export const VisualizationConfigAccordion: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={420}>
+            <Section
+                title="Conditional formatting list"
+                hint="VisualizationConfigs/common/Accordion.module.css: :global(.mantine-Accordion-control | -label | -panel)"
+            >
+                <Accordion
+                    multiple
+                    variant="contained"
+                    defaultValue={['rule-1']}
+                    className={accordionClasses.containedList}
+                    transparentActiveItem
+                >
+                    <Accordion.Item value="rule-1">
+                        <AccordionControl
+                            label="Rule 1"
+                            description="Revenue greater than 1,000"
+                            onRemove={() => {}}
+                        />
+                        <Accordion.Panel>
+                            <Text size="xs" p="sm">
+                                Open panel content
+                            </Text>
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                    <Accordion.Item value="rule-2">
+                        <AccordionControl
+                            label="Rule 2"
+                            description="Status is cancelled"
+                            onRemove={() => {}}
+                        />
+                        <Accordion.Panel>
+                            <Text size="xs" p="sm">
+                                Hidden
+                            </Text>
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Accordion>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const BadgesAndCheckboxes: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={520}>
+            <Section
+                title="SortButton badge truncation"
+                hint="SortButton.module.css: .badge :global(.mantine-Badge-label) gets ellipsis"
+            >
+                <Group maw={180}>
+                    <Badge color="blue" className={sortButtonClasses.badge}>
+                        <Group
+                            className={sortButtonClasses.content}
+                            gap={2}
+                            wrap="nowrap"
+                        >
+                            <Text span fw={400} fz="xs">
+                                Sorted by
+                            </Text>
+                            <Text
+                                className={sortButtonClasses.field}
+                                fw={600}
+                                fz="xs"
+                            >
+                                A very long field label that must truncate
+                            </Text>
+                        </Group>
+                    </Badge>
+                </Group>
+            </Section>
+            <Section
+                title="ContentTable row-select cell"
+                hint="ContentTable.module.css: .rowSelectCell :global(.mantine-Checkbox-root | -body | -inner) centred"
+            >
+                <Paper p={0} maw={120}>
+                    <div className={contentTableClasses.rowSelectCell}>
+                        <Checkbox size="xs" defaultChecked />
+                    </div>
+                    <div className={contentTableClasses.rowSelectCell}>
+                        <Checkbox size="xs" indeterminate />
+                    </div>
+                </Paper>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const AgentIconHover: StoryObj = {
+    render: () => (
+        <Section
+            title="AiAgentIcon inside a Group"
+            hint="AiAgentIcon.module.css: :global(.mantine-Group-root:hover) .root animates. Hover the row."
+        >
+            <Group gap="md" p="sm" style={{ width: 'fit-content' }}>
+                <AiAgentIcon size={20} />
+                <AiAgentIcon size={20} muted />
+                <AiAgentIcon size={20} animated />
+                <AiAgentIcon size={20} calm />
+                <Text size="sm">Hover this group</Text>
+            </Group>
+        </Section>
+    ),
+};
+
+export const FormulaReference: StoryObj = {
+    render: () => (
+        <Section
+            title="Formula reference panel"
+            hint="FormulaReference.module.css: .helperButton :global(.mantine-Button-section)"
+        >
+            <Paper maw={360} h={480} style={{ overflow: 'hidden' }}>
+                <FormulaReferencePanel
+                    opened
+                    onToggle={() => {}}
+                    onInsert={() => {}}
+                />
+            </Paper>
+        </Section>
+    ),
+};

--- a/packages/frontend/src/stories/mantineBaseline/Inputs.stories.tsx
+++ b/packages/frontend/src/stories/mantineBaseline/Inputs.stories.tsx
@@ -1,0 +1,309 @@
+import {
+    Checkbox,
+    Fieldset,
+    Group,
+    MultiSelect,
+    NativeSelect,
+    NumberInput,
+    PasswordInput,
+    Radio,
+    Select,
+    SimpleGrid,
+    Stack,
+    Switch,
+    TagsInput,
+    Text,
+    Textarea,
+    TextInput,
+    Title,
+} from '@mantine/core';
+import { DateInput, DatePicker, TimeInput } from '@mantine/dates';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { IconSearch } from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+
+/**
+ * Static render of every input-based component. Input.module.css applies to
+ * all of them through the shared Input primitive and keys on
+ * data-variant / data-error / data-disabled; Checkbox, Radio and Switch key
+ * on data-size.
+ */
+const meta: Meta = {
+    title: 'Mantine baseline/Inputs',
+    parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+const Section: FC<{ title: string; children: ReactNode }> = ({
+    title,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Title order={5}>{title}</Title>
+        {children}
+    </Stack>
+);
+
+const SELECT_DATA = [
+    { group: 'Dimensions', items: ['Order date', 'Customer name', 'Status'] },
+    {
+        group: 'Metrics',
+        items: [
+            'Total revenue',
+            { value: 'disabled', label: 'Disabled option', disabled: true },
+        ],
+    },
+];
+
+export const TextInputs: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="States (variant=default)">
+                <SimpleGrid cols={2}>
+                    <TextInput
+                        label="Label"
+                        description="Description text"
+                        placeholder="Placeholder"
+                    />
+                    <TextInput
+                        label="Required"
+                        required
+                        withAsterisk
+                        defaultValue="Value"
+                    />
+                    <TextInput
+                        label="Error"
+                        error="Something is wrong"
+                        defaultValue="Value"
+                    />
+                    <TextInput label="Disabled" disabled defaultValue="Value" />
+                    <TextInput
+                        label="With sections"
+                        leftSection={<MantineIcon icon={IconSearch} />}
+                        rightSection={<Text size="xs">⌘K</Text>}
+                        placeholder="Search"
+                    />
+                    <TextInput
+                        label="Autofocus (focus ring)"
+                        placeholder="Focused"
+                        autoFocus
+                    />
+                </SimpleGrid>
+            </Section>
+            <Section title="variant=subtle (transparent until hover/focus)">
+                <SimpleGrid cols={2}>
+                    <TextInput variant="subtle" placeholder="Subtle" />
+                    <TextInput
+                        variant="subtle"
+                        error
+                        defaultValue="Subtle with error"
+                    />
+                    <TextInput
+                        variant="subtle"
+                        disabled
+                        defaultValue="Subtle disabled"
+                    />
+                    <TextInput variant="filled" placeholder="variant=filled" />
+                </SimpleGrid>
+            </Section>
+            <Section title="Sizes (28 / 32 / 36 / 40 / 44px, font stays sm until lg)">
+                <Stack gap="xs">
+                    {SIZES.map((size) => (
+                        <TextInput
+                            key={size}
+                            size={size}
+                            placeholder={`size=${size}`}
+                            leftSection={<MantineIcon icon={IconSearch} />}
+                        />
+                    ))}
+                </Stack>
+            </Section>
+            <Section title="Other Input-based components">
+                <SimpleGrid cols={2}>
+                    <PasswordInput
+                        label="PasswordInput (theme forces size=sm)"
+                        defaultValue="hunter2"
+                    />
+                    <NumberInput label="NumberInput" defaultValue={42} />
+                    <Textarea
+                        label="Textarea"
+                        placeholder="Multi-line"
+                        autosize
+                        minRows={2}
+                    />
+                    <NativeSelect
+                        label="NativeSelect"
+                        data={['One', 'Two', 'Three']}
+                    />
+                </SimpleGrid>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const Selects: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="Select with the dropdown held open (Combobox.module.css)">
+                <Group align="flex-start" grow>
+                    <Select
+                        label="Select"
+                        data={SELECT_DATA}
+                        defaultValue="Order date"
+                        dropdownOpened
+                        comboboxProps={{ withinPortal: false }}
+                        searchable
+                        nothingFoundMessage="Nothing found"
+                    />
+                    <Select
+                        label="Empty state"
+                        data={[]}
+                        dropdownOpened
+                        comboboxProps={{ withinPortal: false }}
+                        nothingFoundMessage="No fields match"
+                        placeholder="Type to search"
+                    />
+                </Group>
+            </Section>
+            <Section title="MultiSelect and TagsInput (Pill inside Input)">
+                <SimpleGrid cols={2} pt={260}>
+                    <MultiSelect
+                        label="MultiSelect"
+                        data={SELECT_DATA}
+                        defaultValue={['Order date', 'Total revenue']}
+                    />
+                    <TagsInput
+                        label="TagsInput"
+                        defaultValue={['finance', 'weekly']}
+                    />
+                    <MultiSelect
+                        label="Disabled"
+                        data={SELECT_DATA}
+                        defaultValue={['Order date']}
+                        disabled
+                    />
+                    <MultiSelect
+                        label="Error"
+                        data={SELECT_DATA}
+                        defaultValue={['Order date']}
+                        error="Pick at least two"
+                    />
+                </SimpleGrid>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const ChecksAndSwitches: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="Checkbox (data-size=xs gets the secondary label)">
+                {SIZES.map((size) => (
+                    <Group key={size} gap="xl">
+                        <Checkbox size={size} label={`size=${size}`} />
+                        <Checkbox size={size} label="Checked" defaultChecked />
+                        <Checkbox
+                            size={size}
+                            label="Indeterminate"
+                            indeterminate
+                        />
+                        <Checkbox size={size} label="Disabled" disabled />
+                        <Checkbox
+                            size={size}
+                            label="Description"
+                            description="Helper text"
+                        />
+                    </Group>
+                ))}
+            </Section>
+            <Section title="Radio (shares Checkbox.module.css)">
+                <Radio.Group defaultValue="b" label="Radio group">
+                    <Group gap="xl" mt="xs">
+                        <Radio value="a" label="Option A" />
+                        <Radio value="b" label="Option B" />
+                        <Radio value="c" label="Disabled" disabled />
+                        <Radio
+                            value="d"
+                            label="Description"
+                            description="Helper text"
+                        />
+                    </Group>
+                </Radio.Group>
+                <Group gap="xl">
+                    <Radio size="xs" label="size=xs" defaultChecked />
+                    <Radio size="xs" label="size=xs" />
+                </Group>
+            </Section>
+            <Section title="Switch">
+                {SIZES.map((size) => (
+                    <Group key={size} gap="xl">
+                        <Switch size={size} label={`size=${size}`} />
+                        <Switch size={size} label="On" defaultChecked />
+                        <Switch size={size} label="Disabled" disabled />
+                        <Switch
+                            size={size}
+                            label="Description"
+                            description="Helper text"
+                        />
+                    </Group>
+                ))}
+            </Section>
+            <Section title="Fieldset (radius lg)">
+                <Fieldset legend="Connection">
+                    <TextInput label="Host" placeholder="localhost" />
+                    <TextInput label="Port" placeholder="5432" mt="sm" />
+                </Fieldset>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const Dates: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="DatePicker range (data-selected / data-in-range)">
+                <Group align="flex-start">
+                    <DatePicker
+                        type="range"
+                        value={[new Date(2026, 8, 3), new Date(2026, 8, 18)]}
+                        defaultDate={new Date(2026, 8, 1)}
+                    />
+                    <DatePicker
+                        type="range"
+                        numberOfColumns={2}
+                        value={[new Date(2026, 7, 20), new Date(2026, 8, 5)]}
+                        defaultDate={new Date(2026, 7, 1)}
+                    />
+                </Group>
+            </Section>
+            <Section title="Year and decade levels">
+                <Group align="flex-start">
+                    <DatePicker
+                        defaultLevel="year"
+                        defaultDate={new Date(2026, 8, 1)}
+                        value={new Date(2026, 8, 3)}
+                    />
+                    <DatePicker
+                        defaultLevel="decade"
+                        defaultDate={new Date(2026, 8, 1)}
+                        value={new Date(2026, 8, 3)}
+                    />
+                </Group>
+            </Section>
+            <Section title="Inputs">
+                <SimpleGrid cols={2}>
+                    <DateInput
+                        label="DateInput"
+                        value={new Date(2026, 8, 3)}
+                        valueFormat="YYYY-MM-DD"
+                    />
+                    <TimeInput label="TimeInput" defaultValue="09:30" />
+                </SimpleGrid>
+            </Section>
+        </Stack>
+    ),
+};

--- a/packages/frontend/src/stories/mantineBaseline/Overlays.stories.tsx
+++ b/packages/frontend/src/stories/mantineBaseline/Overlays.stories.tsx
@@ -1,0 +1,269 @@
+import {
+    Alert,
+    Box,
+    Button,
+    Center,
+    Drawer,
+    Group,
+    HoverCard,
+    Menu,
+    Modal,
+    Notification,
+    Popover,
+    SimpleGrid,
+    Stack,
+    Text,
+    Title,
+    Tooltip,
+    type PopoverProps,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+    IconAlertCircle,
+    IconCheck,
+    IconCopy,
+    IconSettings,
+    IconTrash,
+} from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+
+/**
+ * Overlays held open so they can be screenshotted. Dropdown.module.css keys
+ * on data-position to set the transform origin; Menu, Popover, Tooltip and
+ * HoverCard all inherit it. Portals are disabled so the dropdowns stay inside
+ * the story frame.
+ */
+const meta: Meta = {
+    title: 'Mantine baseline/Overlays',
+    parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+const Section: FC<{ title: string; children: ReactNode }> = ({
+    title,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Title order={5}>{title}</Title>
+        {children}
+    </Stack>
+);
+
+const POSITIONS: NonNullable<PopoverProps['position']>[] = [
+    'top-start',
+    'top',
+    'top-end',
+    'left',
+    'right',
+    'bottom-start',
+    'bottom',
+    'bottom-end',
+];
+
+export const Popovers: StoryObj = {
+    render: () => (
+        <Section title="Popover opened in every position (data-position)">
+            <SimpleGrid cols={3} spacing={120} verticalSpacing={120} p={100}>
+                {POSITIONS.map((position) => (
+                    <Center key={position}>
+                        <Popover
+                            opened
+                            position={position}
+                            withinPortal={false}
+                            withArrow
+                        >
+                            <Popover.Target>
+                                <Button variant="default">{position}</Button>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                                <Text size="sm">Dropdown content</Text>
+                            </Popover.Dropdown>
+                        </Popover>
+                    </Center>
+                ))}
+            </SimpleGrid>
+        </Section>
+    ),
+};
+
+export const Menus: StoryObj = {
+    render: () => (
+        <Section title="Menu opened (label, sections, divider, colours)">
+            <Group align="flex-start" gap={260} pb={300}>
+                <Menu opened withinPortal={false} position="bottom-start">
+                    <Menu.Target>
+                        <Button variant="default">Actions</Button>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Label>Chart</Menu.Label>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconCopy} />}
+                        >
+                            Duplicate
+                        </Menu.Item>
+                        <Menu.Item
+                            leftSection={<MantineIcon icon={IconSettings} />}
+                            rightSection={
+                                <Text size="xs" c="dimmed">
+                                    ⌘,
+                                </Text>
+                            }
+                        >
+                            Settings
+                        </Menu.Item>
+                        <Menu.Item disabled>Disabled item</Menu.Item>
+                        <Menu.Divider />
+                        <Menu.Label>Danger zone</Menu.Label>
+                        <Menu.Item
+                            color="red"
+                            leftSection={<MantineIcon icon={IconTrash} />}
+                        >
+                            Delete
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+                <Menu opened withinPortal={false} position="bottom-end">
+                    <Menu.Target>
+                        <Button variant="default">Plain items</Button>
+                    </Menu.Target>
+                    <Menu.Dropdown>
+                        <Menu.Item>First</Menu.Item>
+                        <Menu.Item>Second</Menu.Item>
+                        <Menu.Item>Third</Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
+            </Group>
+        </Section>
+    ),
+};
+
+export const TooltipsAndHoverCards: StoryObj = {
+    render: () => (
+        <Stack gap="xl">
+            <Section title="Tooltip opened (theme: arrow, multiline, maw 280, radius sm)">
+                <Group gap={120} p={60}>
+                    <Tooltip opened withinPortal={false} label="Short label">
+                        <Button variant="default">Top</Button>
+                    </Tooltip>
+                    <Tooltip
+                        opened
+                        withinPortal={false}
+                        position="bottom"
+                        label="A longer multiline tooltip that wraps at the theme's max width of 280 pixels."
+                    >
+                        <Button variant="default">Bottom, multiline</Button>
+                    </Tooltip>
+                    <Tooltip
+                        opened
+                        withinPortal={false}
+                        position="right"
+                        label="Right"
+                    >
+                        <Button variant="default">Right</Button>
+                    </Tooltip>
+                </Group>
+            </Section>
+            <Section title="HoverCard opened (shares Popover.module.css)">
+                <Box p={60} pb={160}>
+                    <HoverCard
+                        initiallyOpened
+                        withinPortal={false}
+                        width={280}
+                        position="bottom-start"
+                    >
+                        <HoverCard.Target>
+                            <Button variant="default">Hover me</Button>
+                        </HoverCard.Target>
+                        <HoverCard.Dropdown>
+                            <Text size="sm" fw={500}>
+                                Total revenue
+                            </Text>
+                            <Text size="xs" c="dimmed">
+                                Sum of order_total across all completed orders.
+                            </Text>
+                        </HoverCard.Dropdown>
+                    </HoverCard>
+                </Box>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const NotificationsAndAlerts: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={520}>
+            <Section title="Notification (static component)">
+                <Notification
+                    title="Saved"
+                    icon={<MantineIcon icon={IconCheck} />}
+                >
+                    Chart saved to Finance space.
+                </Notification>
+                <Notification
+                    color="red"
+                    title="Query failed"
+                    icon={<MantineIcon icon={IconAlertCircle} />}
+                >
+                    Column order_total does not exist.
+                </Notification>
+                <Notification
+                    loading
+                    title="Refreshing"
+                    withCloseButton={false}
+                >
+                    Compiling dbt models…
+                </Notification>
+            </Section>
+            <Section title="Alert (theme default variant=light)">
+                <Alert
+                    title="Heads up"
+                    icon={<MantineIcon icon={IconAlertCircle} />}
+                >
+                    Alert message body at font-size sm with the tighter line
+                    height set by the theme.
+                </Alert>
+                <Alert
+                    color="red"
+                    title="Error"
+                    icon={<MantineIcon icon={IconAlertCircle} />}
+                    withCloseButton
+                >
+                    Something went wrong.
+                </Alert>
+                <Alert variant="outline" title="Outline variant">
+                    Not the default, but used in places.
+                </Alert>
+                <Alert>Alert without a title.</Alert>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const ModalOpened: StoryObj = {
+    render: () => (
+        <Modal opened onClose={() => {}} title="Modal title">
+            <Stack gap="sm">
+                <Text size="sm">
+                    Theme defaults: radius lg, centered. Modal.module.css styles
+                    content, header, title and body.
+                </Text>
+                <Group justify="flex-end">
+                    <Button variant="default">Cancel</Button>
+                    <Button>Confirm</Button>
+                </Group>
+            </Stack>
+        </Modal>
+    ),
+};
+
+export const DrawerOpened: StoryObj = {
+    render: () => (
+        <Drawer opened onClose={() => {}} title="Drawer title" position="right">
+            <Text size="sm">
+                Drawer reuses the Modal content, header, title and body classes.
+            </Text>
+        </Drawer>
+    ),
+};

--- a/packages/frontend/src/stories/mantineBaseline/Surfaces.stories.tsx
+++ b/packages/frontend/src/stories/mantineBaseline/Surfaces.stories.tsx
@@ -1,0 +1,269 @@
+import {
+    Accordion,
+    Anchor,
+    Card,
+    Code,
+    Divider,
+    Group,
+    NavLink,
+    Paper,
+    ScrollArea,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Table,
+    Tabs,
+    Text,
+    Title,
+} from '@mantine/core';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+    IconChartBar,
+    IconHome,
+    IconLayoutDashboard,
+    IconSettings,
+} from '@tabler/icons-react';
+import type { FC, ReactNode } from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+
+/**
+ * Static render of the surface and navigation components the theme restyles:
+ * Paper/Card, Table, Tabs, NavLink, Accordion, Title, Code, Divider,
+ * ScrollArea, Skeleton, plus the global Text/Anchor rule in global.css.
+ */
+const meta: Meta = {
+    title: 'Mantine baseline/Surfaces',
+    parameters: { layout: 'padded' },
+};
+
+export default meta;
+
+const Section: FC<{ title: string; children: ReactNode }> = ({
+    title,
+    children,
+}) => (
+    <Stack gap="xs">
+        <Title order={5}>{title}</Title>
+        {children}
+    </Stack>
+);
+
+const ROWS = [
+    ['Revenue by month', 'Finance', 'Tati', '2 days ago'],
+    ['Orders funnel', 'Growth', 'Josh', '5 days ago'],
+    ['Churn cohort', 'Product', 'Yegor', '3 weeks ago'],
+];
+
+export const PapersAndCards: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="Paper (theme default: radius lg, border, no shadow)">
+                <SimpleGrid cols={3}>
+                    <Paper p="md">
+                        <Text size="sm">Default</Text>
+                    </Paper>
+                    <Paper p="md" variant="dotted">
+                        <Text size="sm" c="dimmed">
+                            variant=dotted (empty state)
+                        </Text>
+                    </Paper>
+                    <Paper p="md" shadow="md" withBorder={false}>
+                        <Text size="sm">shadow=md, no border</Text>
+                    </Paper>
+                </SimpleGrid>
+            </Section>
+            <Section title="Card with sections (data-with-border)">
+                <Card maw={320}>
+                    <Card.Section withBorder inheritPadding py="xs">
+                        <Text fw={500} size="sm">
+                            Section with border
+                        </Text>
+                    </Card.Section>
+                    <Text size="sm" mt="sm">
+                        Card body inherits the Paper root class.
+                    </Text>
+                    <Card.Section withBorder inheritPadding py="xs" mt="sm">
+                        <Text size="xs" c="dimmed">
+                            Footer section
+                        </Text>
+                    </Card.Section>
+                </Card>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const Tables: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            <Section title="Table (theme: sm spacing, dimmed header, hover and striped colours)">
+                <Table
+                    highlightOnHover
+                    striped
+                    withTableBorder
+                    withColumnBorders
+                >
+                    <Table.Caption>Table caption</Table.Caption>
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th>Name</Table.Th>
+                            <Table.Th>Space</Table.Th>
+                            <Table.Th>Owner</Table.Th>
+                            <Table.Th>Updated</Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                        {ROWS.map((row) => (
+                            <Table.Tr key={row[0]}>
+                                {row.map((cell) => (
+                                    <Table.Td key={cell}>{cell}</Table.Td>
+                                ))}
+                            </Table.Tr>
+                        ))}
+                    </Table.Tbody>
+                </Table>
+            </Section>
+            <Section title="Plain table">
+                <Table>
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th>Name</Table.Th>
+                            <Table.Th>Space</Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                        {ROWS.map((row) => (
+                            <Table.Tr key={row[0]}>
+                                <Table.Td>{row[0]}</Table.Td>
+                                <Table.Td>{row[1]}</Table.Td>
+                            </Table.Tr>
+                        ))}
+                    </Table.Tbody>
+                </Table>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const TabsAndNavigation: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            {(['default', 'outline', 'pills'] as const).map((variant) => (
+                <Section key={variant} title={`Tabs variant=${variant}`}>
+                    <Tabs defaultValue="charts" variant={variant}>
+                        <Tabs.List>
+                            <Tabs.Tab
+                                value="charts"
+                                leftSection={
+                                    <MantineIcon icon={IconChartBar} />
+                                }
+                            >
+                                Charts
+                            </Tabs.Tab>
+                            <Tabs.Tab
+                                value="dashboards"
+                                leftSection={
+                                    <MantineIcon icon={IconLayoutDashboard} />
+                                }
+                            >
+                                Dashboards
+                            </Tabs.Tab>
+                            <Tabs.Tab value="settings" disabled>
+                                Disabled
+                            </Tabs.Tab>
+                        </Tabs.List>
+                        <Tabs.Panel value="charts" pt="sm">
+                            <Text size="sm">Charts panel</Text>
+                        </Tabs.Panel>
+                    </Tabs>
+                </Section>
+            ))}
+            <Section title="NavLink (theme default variant=subtle)">
+                <Paper p="xs" maw={260}>
+                    <NavLink
+                        label="Home"
+                        leftSection={<MantineIcon icon={IconHome} />}
+                    />
+                    <NavLink
+                        label="Dashboards"
+                        active
+                        leftSection={<MantineIcon icon={IconLayoutDashboard} />}
+                        description="Active with description"
+                    />
+                    <NavLink
+                        label="Settings"
+                        leftSection={<MantineIcon icon={IconSettings} />}
+                        defaultOpened
+                    >
+                        <NavLink label="Nested child" />
+                        <NavLink label="Nested active" active />
+                    </NavLink>
+                    <NavLink label="Disabled" disabled />
+                    <NavLink label="color=blue" active color="blue" />
+                </Paper>
+            </Section>
+        </Stack>
+    ),
+};
+
+export const AccordionsAndText: StoryObj = {
+    render: () => (
+        <Stack gap="xl" maw={720}>
+            {(['default', 'contained', 'separated'] as const).map((variant) => (
+                <Section key={variant} title={`Accordion variant=${variant}`}>
+                    <Accordion variant={variant} defaultValue="first">
+                        <Accordion.Item value="first">
+                            <Accordion.Control>Open item</Accordion.Control>
+                            <Accordion.Panel>
+                                <Text size="sm">Panel content</Text>
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                        <Accordion.Item value="second">
+                            <Accordion.Control>Closed item</Accordion.Control>
+                            <Accordion.Panel>
+                                <Text size="sm">Hidden</Text>
+                            </Accordion.Panel>
+                        </Accordion.Item>
+                    </Accordion>
+                </Section>
+            ))}
+            <Section title="Title tracking (data-order 1 to 4)">
+                <Title order={1}>Heading one</Title>
+                <Title order={2}>Heading two</Title>
+                <Title order={3}>Heading three</Title>
+                <Title order={4}>Heading four</Title>
+                <Title order={5}>Heading five</Title>
+            </Section>
+            <Section title="Text and Anchor (global.css rule) and Code">
+                <Text>
+                    Body text with an <Anchor href="#">anchor</Anchor>, inline{' '}
+                    <Code>code</Code> and{' '}
+                    <Text span c="dimmed">
+                        dimmed span
+                    </Text>
+                    .
+                </Text>
+                <Code
+                    block
+                >{`SELECT order_date, SUM(order_total)\nFROM analytics.orders\nGROUP BY 1`}</Code>
+            </Section>
+            <Section title="Divider, Skeleton, ScrollArea">
+                <Divider label="With label" labelPosition="center" />
+                <Divider />
+                <Group grow>
+                    <Skeleton height={12} />
+                    <Skeleton height={12} width="60%" />
+                </Group>
+                <ScrollArea h={80} type="always">
+                    <Stack gap={4}>
+                        {Array.from({ length: 12 }, (_, i) => (
+                            <Text key={i} size="sm">
+                                Scrollable row {i + 1}
+                            </Text>
+                        ))}
+                    </Stack>
+                </ScrollArea>
+            </Section>
+        </Stack>
+    ),
+};


### PR DESCRIPTION
Mantine 9 drops the \`color\` prop on \`Text\` and \`Anchor\`, and the upgrade changes internal markup that our theme overrides and a handful of CSS modules key on through data attributes and \`.mantine-*\` class names. Landing the prop rename and a static Storybook suite of every one of those overrides first lets the 8.3.18 screenshots be taken from main and compared against the upgrade branch.

Relates: ZAP-1023