### PR TITLE
feat(pivot-table): URL actions and a value menu on pivoted dimension cells

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/UrlMenuItems.tsx
@@ -18,15 +18,20 @@ import { useMemo, type FC } from 'react';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import MantineIcon from '../../common/MantineIcon';
+import {
+    type GetTemplatedUrlItem,
+    type TemplatedUrlRow,
+    type TemplatedUrlRowContext,
+} from './templatedUrlRowContext';
 
 const UrlMenuItem: FC<{
     urlConfig: FieldUrl;
-    itemsMap?: Record<string, Field | TableCalculation>;
+    getItem?: GetTemplatedUrlItem;
     itemIdsInRow: string[];
     value: ResultValue;
-    row: Record<string, Record<string, ResultValue>>;
+    row: TemplatedUrlRow;
     showError?: boolean;
-}> = ({ urlConfig, itemsMap, itemIdsInRow, value, row, showError = true }) => {
+}> = ({ urlConfig, getItem, itemIdsInRow, value, row, showError = true }) => {
     const tracking = useTracking({ failSilently: true });
     const [url, renderError] = useMemo(() => {
         let parsedUrl: string | undefined = undefined;
@@ -55,10 +60,10 @@ const UrlMenuItem: FC<{
                 (rowDependency) => !itemIdsInRow.includes(rowDependency),
             );
             if (missingDependencies.length > 0) {
-                if (itemsMap) {
+                if (getItem) {
                     errorMessage = `To use this action add ${missingDependencies
                         .map((rowReference) => {
-                            const item = itemsMap[rowReference];
+                            const item = getItem(rowReference);
                             const label = item
                                 ? getItemLabel(item)
                                 : friendlyName(rowReference);
@@ -73,7 +78,7 @@ const UrlMenuItem: FC<{
             errorMessage = e instanceof Error ? e.message : `${e}`;
         }
         return errorMessage;
-    }, [itemIdsInRow, itemsMap, urlConfig]);
+    }, [itemIdsInRow, getItem, urlConfig]);
     const error: string | undefined = validationError || renderError;
     if (!showError && error) {
         return null;
@@ -105,6 +110,33 @@ const UrlMenuItem: FC<{
     );
 };
 
+/**
+ * Renders one menu item per templated URL from an already-resolved row
+ * context. Tables that don't use TanStack rows (e.g. the pivot table) build
+ * the context themselves with `buildTemplatedUrlRowContext`.
+ */
+export const TemplatedUrlMenuItems: FC<{
+    urls: FieldUrl[] | undefined;
+    value: ResultValue;
+    rowContext: TemplatedUrlRowContext;
+    getItem?: GetTemplatedUrlItem;
+    showErrors?: boolean;
+}> = ({ urls, value, rowContext, getItem, showErrors }) => (
+    <>
+        {(urls || []).map((urlConfig) => (
+            <UrlMenuItem
+                key={urlConfig.label}
+                urlConfig={urlConfig}
+                getItem={getItem}
+                itemIdsInRow={rowContext.itemIdsInRow}
+                row={rowContext.row}
+                value={value}
+                showError={showErrors}
+            />
+        ))}
+    </>
+);
+
 const UrlMenuItems: FC<{
     urls: FieldUrl[] | undefined;
     cell: Cell<ResultRow, ResultRow[0]>;
@@ -112,42 +144,36 @@ const UrlMenuItems: FC<{
     showErrors?: boolean;
 }> = ({ urls, cell, itemsMap, showErrors }) => {
     const value: ResultValue = cell.getValue()?.value || {};
-    const [itemIdsInRow, rowData] = useMemo(() => {
-        const itemIds: string[] = [];
+    const rowContext = useMemo<TemplatedUrlRowContext>(() => {
+        const itemIdsInRow: string[] = [];
         const row = cell.row
             .getAllCells()
-            .reduce<Record<string, Record<string, ResultValue>>>(
-                (acc, rowCell) => {
-                    const item = rowCell.column.columnDef.meta?.item;
-                    const rowCellValue = (rowCell.getValue() as ResultRow[0])
-                        ?.value;
-                    if (item && isField(item) && rowCellValue) {
-                        itemIds.push(getItemId(item));
-                        acc[item.table] = acc[item.table] || {};
-                        acc[item.table][item.name] = rowCellValue;
-                        return acc;
-                    }
-                    return acc;
-                },
-                {},
-            );
-        return [itemIds, row];
+            .reduce<TemplatedUrlRow>((acc, rowCell) => {
+                const item = rowCell.column.columnDef.meta?.item;
+                const rowCellValue = (rowCell.getValue() as ResultRow[0])
+                    ?.value;
+                if (item && isField(item) && rowCellValue) {
+                    itemIdsInRow.push(getItemId(item));
+                    acc[item.table] = acc[item.table] || {};
+                    acc[item.table][item.name] = rowCellValue;
+                }
+                return acc;
+            }, {});
+        return { itemIdsInRow, row };
     }, [cell]);
+    const getItem = useMemo(
+        () => (itemsMap ? (fieldId: string) => itemsMap[fieldId] : undefined),
+        [itemsMap],
+    );
 
     return (
-        <>
-            {(urls || []).map((urlConfig) => (
-                <UrlMenuItem
-                    key={urlConfig.label}
-                    urlConfig={urlConfig}
-                    itemsMap={itemsMap}
-                    itemIdsInRow={itemIdsInRow}
-                    row={rowData}
-                    value={value}
-                    showError={showErrors}
-                />
-            ))}
-        </>
+        <TemplatedUrlMenuItems
+            urls={urls}
+            value={value}
+            rowContext={rowContext}
+            getItem={getItem}
+            showErrors={showErrors}
+        />
     );
 };
 

--- a/packages/frontend/src/components/Explorer/ResultsCard/templatedUrlRowContext.test.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/templatedUrlRowContext.test.ts
@@ -1,0 +1,97 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CustomDimension,
+    type Dimension,
+    type ItemsMap,
+    type Metric,
+    type TableCalculation,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { buildTemplatedUrlRowContext } from './templatedUrlRowContext';
+
+const dimension = (table: string, name: string): Dimension => ({
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `\${TABLE}.${name}`,
+    hidden: false,
+});
+
+const metric = (table: string, name: string): Metric => ({
+    fieldType: FieldType.METRIC,
+    type: MetricType.SUM,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `\${TABLE}.${name}`,
+    hidden: false,
+});
+
+const items: ItemsMap = {
+    customers_first_name: dimension('customers', 'first_name'),
+    customers_customer_id: dimension('customers', 'customer_id'),
+    orders_total_order_amount: metric('orders', 'total_order_amount'),
+    calc_1: {
+        name: 'calc_1',
+        displayName: 'calc 1',
+        sql: '1',
+    } as TableCalculation,
+    custom_1: { id: 'custom_1', name: 'custom 1' } as CustomDimension,
+};
+const getItem = (fieldId: string) => items[fieldId];
+
+describe('buildTemplatedUrlRowContext', () => {
+    it('nests values under row.<table>.<field> and lists the item ids present', () => {
+        const context = buildTemplatedUrlRowContext(
+            {
+                customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+                customers_customer_id: { raw: 7, formatted: '7' },
+                orders_total_order_amount: { raw: 32, formatted: '$32.00' },
+            },
+            getItem,
+        );
+
+        expect(context).toEqual({
+            itemIdsInRow: [
+                'customers_first_name',
+                'customers_customer_id',
+                'orders_total_order_amount',
+            ],
+            row: {
+                customers: {
+                    first_name: { raw: 'Ada', formatted: 'Ada' },
+                    customer_id: { raw: 7, formatted: '7' },
+                },
+                orders: {
+                    total_order_amount: { raw: 32, formatted: '$32.00' },
+                },
+            },
+        });
+    });
+
+    it('skips unknown ids, non-field items and missing values', () => {
+        const context = buildTemplatedUrlRowContext(
+            {
+                customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+                calc_1: { raw: 1, formatted: '1' },
+                custom_1: { raw: 'x', formatted: 'x' },
+                not_a_field: { raw: 'x', formatted: 'x' },
+                customers_customer_id: undefined,
+            },
+            getItem,
+        );
+
+        expect(context).toEqual({
+            itemIdsInRow: ['customers_first_name'],
+            row: {
+                customers: { first_name: { raw: 'Ada', formatted: 'Ada' } },
+            },
+        });
+    });
+});

--- a/packages/frontend/src/components/Explorer/ResultsCard/templatedUrlRowContext.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/templatedUrlRowContext.ts
@@ -1,0 +1,39 @@
+import {
+    getItemId,
+    isField,
+    type ItemsMap,
+    type ResultValue,
+} from '@lightdash/common';
+
+/** `row.<table>.<field>` values a templated URL can reference. */
+export type TemplatedUrlRow = Record<string, Record<string, ResultValue>>;
+
+export type TemplatedUrlRowContext = {
+    /** Item ids present in the row, used to validate `row.*` references. */
+    itemIdsInRow: string[];
+    row: TemplatedUrlRow;
+};
+
+export type GetTemplatedUrlItem = (
+    fieldId: string,
+) => ItemsMap[string] | undefined;
+
+/**
+ * Builds the row context for a set of `fieldId -> value` pairs so it can be
+ * shared by any table that already knows which fields sit on a "row".
+ */
+export const buildTemplatedUrlRowContext = (
+    fieldValues: Record<string, ResultValue | undefined>,
+    getItem: GetTemplatedUrlItem,
+): TemplatedUrlRowContext => {
+    const itemIdsInRow: string[] = [];
+    const row: TemplatedUrlRow = {};
+    Object.entries(fieldValues).forEach(([fieldId, value]) => {
+        const item = getItem(fieldId);
+        if (!item || !isField(item) || !value) return;
+        itemIdsInRow.push(getItemId(item));
+        row[item.table] = row[item.table] || {};
+        row[item.table][item.name] = value;
+    });
+    return { itemIdsInRow, row };
+};

--- a/packages/frontend/src/components/common/LightTable/index.tsx
+++ b/packages/frontend/src/components/common/LightTable/index.tsx
@@ -76,6 +76,8 @@ type TableCellProps = PolymorphicComponentProps<'th' | 'td', BoxProps> & {
               renderFn: () => ReactNode,
           ) => ReactNode);
     withValue?: string;
+    /** Hints that the cell menu offers link actions, like the results table's dotted underline. */
+    withUrls?: boolean;
 };
 
 interface TableCompoundComponents {
@@ -387,6 +389,7 @@ const BaseCell = (
                 withTextStyle = false,
                 withMenu = false,
                 withValue = undefined,
+                withUrls = false,
                 ...rest
             },
             ref,
@@ -487,6 +490,7 @@ const BaseCell = (
                             [classes.cfUnderline]:
                                 !!withTextStyle && !!withTextStyle.underline,
                             [classes.withInteractions]: withInteractions,
+                            [classes.withUrls]: withUrls,
                             [classes.withBackground]: !!withBackground,
                             [classes.withCopying]: clipboard.copied,
                         })}
@@ -530,6 +534,7 @@ const BaseCell = (
                     withColor,
                     withTextStyle,
                     withInteractions,
+                    withUrls,
                     withBackground,
                     clipboard.copied,
                     children,

--- a/packages/frontend/src/components/common/LightTable/styles.module.css
+++ b/packages/frontend/src/components/common/LightTable/styles.module.css
@@ -232,6 +232,11 @@
     font-style: italic;
 }
 
+/* Before .cfUnderline so a conditional-formatting underline wins, as in Table.module.css. */
+.withUrls {
+    text-decoration: underline dotted;
+}
+
 .cfUnderline {
     text-decoration: underline;
 }

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -4,12 +4,13 @@ import {
     isDimensionValueInvalidDate,
     isField,
     isMetric,
+    type Field,
     type ItemsMap,
     type ResultValue,
 } from '@lightdash/common';
 import { Menu, type MenuProps, Text } from '@mantine/core';
 import { IconArrowBarToDown, IconCopy } from '@tabler/icons-react';
-import { memo, type FC } from 'react';
+import { memo, useState, type FC } from 'react';
 import { useLocation } from 'react-router';
 import { FilterDashboardTo } from '../../../features/dashboardFilters/FilterDashboardTo';
 import { useContextMenuPermissions } from '../../../hooks/useContextMenuPermissions';
@@ -19,8 +20,24 @@ import { useAccount } from '../../../hooks/user/useAccount';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { UnderlyingDataMenuItem } from '../../DashboardTiles/UnderlyingDataMenuItem';
+import {
+    type GetTemplatedUrlItem,
+    type TemplatedUrlRowContext,
+} from '../../Explorer/ResultsCard/templatedUrlRowContext';
+import { TemplatedUrlMenuItems } from '../../Explorer/ResultsCard/UrlMenuItems';
 import { useMetricQueryDataContext } from '../../MetricQueryData/useMetricQueryDataContext';
 import MantineIcon from '../MantineIcon';
+
+/**
+ * Templated URL actions for a cell. `field` is the field whose `urls` apply,
+ * which is not always the cell's display `item` (metricsAsRows swaps the
+ * dimension for the row metric). `getRowContext` runs when the menu opens.
+ */
+export type ValueCellUrlActions = {
+    field: Field | undefined;
+    getRowContext: () => TemplatedUrlRowContext;
+    getItem: GetTemplatedUrlItem;
+};
 
 type ValueCellMenuProps = {
     value?: ResultValue | null;
@@ -29,12 +46,49 @@ type ValueCellMenuProps = {
     rowIndex?: number;
     colIndex?: number;
     item?: ItemsMap[string] | undefined;
+    urlActions?: ValueCellUrlActions;
     getUnderlyingFieldValues?: (
         colIndex: number,
         rowIndex: number,
     ) => Record<string, ResultValue>;
     isMinimal?: boolean;
 } & Pick<MenuProps, 'opened' | 'onOpen' | 'onClose'>;
+
+const CopyValueMenuItem: FC<{ onCopy: () => void }> = ({ onCopy }) => (
+    <Menu.Item
+        leftSection={<MantineIcon icon={IconCopy} size="md" fillOpacity={0} />}
+        onClick={onCopy}
+    >
+        Copy value
+    </Menu.Item>
+);
+
+const UrlMenuSection: FC<{
+    value: ResultValue;
+    urlActions: ValueCellUrlActions;
+    isMinimal: boolean;
+}> = ({ value, urlActions, isMinimal }) => {
+    // Resolved once per open: the dropdown content mounts when the menu opens.
+    const [rowContext] = useState(urlActions.getRowContext);
+
+    const urls = urlActions.field?.urls;
+    if (!urls?.length || value.raw === undefined || value.raw === null) {
+        return null;
+    }
+
+    return (
+        <>
+            <TemplatedUrlMenuItems
+                urls={urls}
+                value={value}
+                rowContext={rowContext}
+                getItem={urlActions.getItem}
+                showErrors={!isMinimal}
+            />
+            <Menu.Divider />
+        </>
+    );
+};
 
 /**
  * Inner dropdown content that is only mounted when the menu is opened.
@@ -44,6 +98,7 @@ type ValueCellMenuProps = {
 const ValueCellMenuDropdownContent: FC<{
     value: ResultValue;
     item?: ItemsMap[string] | undefined;
+    urlActions: ValueCellUrlActions | undefined;
     rowIndex?: number;
     colIndex?: number;
     getUnderlyingFieldValues?: (
@@ -55,6 +110,7 @@ const ValueCellMenuDropdownContent: FC<{
 }> = ({
     value,
     item,
+    urlActions,
     rowIndex,
     colIndex,
     getUnderlyingFieldValues,
@@ -72,21 +128,19 @@ const ValueCellMenuDropdownContent: FC<{
         minimal: isMinimal,
     });
 
+    const urlSection = urlActions && (
+        <UrlMenuSection
+            value={value}
+            urlActions={urlActions}
+            isMinimal={isMinimal}
+        />
+    );
+
     if (!tracking || !metricQueryData) {
         return (
             <Menu.Dropdown>
-                <Menu.Item
-                    leftSection={
-                        <MantineIcon
-                            icon={IconCopy}
-                            size="md"
-                            fillOpacity={0}
-                        />
-                    }
-                    onClick={onCopy}
-                >
-                    Copy value
-                </Menu.Item>
+                {urlSection}
+                <CopyValueMenuItem onCopy={onCopy} />
             </Menu.Dropdown>
         );
     }
@@ -171,14 +225,8 @@ const ValueCellMenuDropdownContent: FC<{
 
     return (
         <Menu.Dropdown>
-            <Menu.Item
-                leftSection={
-                    <MantineIcon icon={IconCopy} size="md" fillOpacity={0} />
-                }
-                onClick={onCopy}
-            >
-                Copy value
-            </Menu.Item>
+            {urlSection}
+            <CopyValueMenuItem onCopy={onCopy} />
 
             {hasUnderlyingData &&
                 !isDimension(item) &&
@@ -223,6 +271,7 @@ const ValueCellMenu: FC<React.PropsWithChildren<ValueCellMenuProps>> = memo(
         colIndex,
         getUnderlyingFieldValues,
         item,
+        urlActions,
         value,
         opened,
         onOpen,
@@ -254,6 +303,7 @@ const ValueCellMenu: FC<React.PropsWithChildren<ValueCellMenuProps>> = memo(
                     <ValueCellMenuDropdownContent
                         value={value}
                         item={item}
+                        urlActions={urlActions}
                         rowIndex={rowIndex}
                         colIndex={colIndex}
                         getUnderlyingFieldValues={getUnderlyingFieldValues}

--- a/packages/frontend/src/components/common/PivotTable/getTemplatedUrlRowValues.test.ts
+++ b/packages/frontend/src/components/common/PivotTable/getTemplatedUrlRowValues.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+import {
+    collectPivotBodyRowValues,
+    collectPivotHeaderRowValues,
+    type PivotRowContextCell,
+} from './getTemplatedUrlRowValues';
+
+const indexCell = (
+    itemId: string,
+    raw: unknown,
+    formatted: string,
+): PivotRowContextCell => ({
+    type: 'indexValue',
+    itemId,
+    value: { value: { raw, formatted } },
+    headerInfo: undefined,
+});
+
+const dataCell = (
+    itemId: string,
+    raw: unknown,
+    formatted: string,
+    headerInfo: PivotRowContextCell['headerInfo'],
+): PivotRowContextCell => ({
+    type: undefined,
+    itemId,
+    value: { value: { raw, formatted } },
+    headerInfo,
+});
+
+const express = {
+    orders_shipping_method: { raw: 'express', formatted: 'Express' },
+};
+const standard = {
+    orders_shipping_method: { raw: 'standard', formatted: 'Standard' },
+};
+
+describe('collectPivotBodyRowValues', () => {
+    const cells: PivotRowContextCell[] = [
+        indexCell('customers_first_name', 'Ada', 'Ada'),
+        indexCell('customers_customer_id', 7, '7'),
+        dataCell('orders_total_order_amount', 32, '$32.00', express),
+        dataCell('orders_order_count', 3, '3', express),
+        dataCell('orders_total_order_amount', 10, '$10.00', standard),
+        {
+            type: 'rowTotal',
+            itemId: 'orders_total_order_amount',
+            value: { value: { raw: 42, formatted: '$42.00' } },
+            headerInfo: undefined,
+        },
+    ];
+
+    it('gives an index dim cell every index dim of its row and nothing pivoted', () => {
+        const result = collectPivotBodyRowValues({
+            cells,
+            clickedColIndex: 0,
+            labelFieldId: undefined,
+            hiddenIndexCells: [],
+            metricsAsRows: false,
+        });
+
+        expect(result).toEqual({
+            customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+            customers_customer_id: { raw: 7, formatted: '7' },
+        });
+    });
+
+    it('gives a data cell its pivot dims and sibling metrics under the same header only', () => {
+        const result = collectPivotBodyRowValues({
+            cells,
+            clickedColIndex: 2,
+            labelFieldId: undefined,
+            hiddenIndexCells: [],
+            metricsAsRows: false,
+        });
+
+        expect(result).toEqual({
+            customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+            customers_customer_id: { raw: 7, formatted: '7' },
+            orders_shipping_method: { raw: 'express', formatted: 'Express' },
+            orders_total_order_amount: { raw: 32, formatted: '$32.00' },
+            orders_order_count: { raw: 3, formatted: '3' },
+        });
+    });
+
+    it('includes hidden passthrough dims like rendered index dims', () => {
+        const result = collectPivotBodyRowValues({
+            cells: [
+                ...cells.slice(0, 1),
+                {
+                    type: 'passthrough',
+                    itemId: 'customers_customer_id',
+                    value: { value: { raw: 7, formatted: '7' } },
+                    headerInfo: undefined,
+                },
+            ],
+            clickedColIndex: 0,
+            labelFieldId: undefined,
+            hiddenIndexCells: [],
+            metricsAsRows: false,
+        });
+
+        expect(result).toEqual({
+            customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+            customers_customer_id: { raw: 7, formatted: '7' },
+        });
+    });
+
+    it('merges hidden row-index dims', () => {
+        const result = collectPivotBodyRowValues({
+            cells: cells.slice(0, 1),
+            clickedColIndex: 0,
+            labelFieldId: undefined,
+            hiddenIndexCells: [
+                {
+                    type: 'value',
+                    fieldId: 'customers_customer_id',
+                    value: { raw: 7, formatted: '7' },
+                    colSpan: 1,
+                },
+            ],
+            metricsAsRows: false,
+        });
+
+        expect(result.customers_customer_id).toEqual({
+            raw: 7,
+            formatted: '7',
+        });
+    });
+
+    describe('metricsAsRows', () => {
+        const metricsAsRowsCells: PivotRowContextCell[] = [
+            indexCell('customers_first_name', 'Ada', 'Ada'),
+            {
+                type: 'label',
+                itemId: undefined,
+                value: undefined,
+                headerInfo: undefined,
+            },
+            // data columns carry the last pivot dim as their item in this mode
+            dataCell('orders_shipping_method', 32, '$32.00', express),
+            dataCell('orders_shipping_method', 10, '$10.00', standard),
+        ];
+
+        it('maps a data cell to the row metric label and skips sibling columns', () => {
+            const result = collectPivotBodyRowValues({
+                cells: metricsAsRowsCells,
+                clickedColIndex: 2,
+                labelFieldId: 'orders_total_order_amount',
+                hiddenIndexCells: [],
+                metricsAsRows: true,
+            });
+
+            expect(result).toEqual({
+                customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+                orders_shipping_method: {
+                    raw: 'express',
+                    formatted: 'Express',
+                },
+                orders_total_order_amount: { raw: 32, formatted: '$32.00' },
+            });
+        });
+
+        it('does not assign an index dim value to the metric label', () => {
+            const result = collectPivotBodyRowValues({
+                cells: metricsAsRowsCells,
+                clickedColIndex: 0,
+                labelFieldId: 'orders_total_order_amount',
+                hiddenIndexCells: [],
+                metricsAsRows: true,
+            });
+
+            expect(result).toEqual({
+                customers_first_name: { raw: 'Ada', formatted: 'Ada' },
+            });
+        });
+    });
+});
+
+describe('collectPivotHeaderRowValues', () => {
+    const headerValues = [
+        [
+            {
+                type: 'value' as const,
+                fieldId: 'orders_status',
+                value: { raw: 'shipped', formatted: 'Shipped' },
+                colSpan: 2,
+            },
+            {
+                type: 'value' as const,
+                fieldId: 'orders_status',
+                value: { raw: 'shipped', formatted: 'Shipped' },
+                colSpan: 0,
+            },
+        ],
+        [
+            {
+                type: 'value' as const,
+                fieldId: 'customers_first_name',
+                value: { raw: 'Ada', formatted: 'Ada' },
+                colSpan: 1,
+            },
+            {
+                type: 'value' as const,
+                fieldId: 'customers_first_name',
+                value: { raw: 'Bob', formatted: 'Bob' },
+                colSpan: 1,
+            },
+        ],
+        [
+            { type: 'label' as const, fieldId: 'orders_total_order_amount' },
+            { type: 'label' as const, fieldId: 'orders_total_order_amount' },
+        ],
+    ];
+
+    it('includes the cell and its ancestors in the same column, even through merged spans', () => {
+        expect(collectPivotHeaderRowValues(headerValues, 1, 1)).toEqual({
+            orders_status: { raw: 'shipped', formatted: 'Shipped' },
+            customers_first_name: { raw: 'Bob', formatted: 'Bob' },
+        });
+    });
+
+    it('excludes descendant levels for a top-level header', () => {
+        expect(collectPivotHeaderRowValues(headerValues, 0, 0)).toEqual({
+            orders_status: { raw: 'shipped', formatted: 'Shipped' },
+        });
+    });
+});

--- a/packages/frontend/src/components/common/PivotTable/getTemplatedUrlRowValues.ts
+++ b/packages/frontend/src/components/common/PivotTable/getTemplatedUrlRowValues.ts
@@ -1,0 +1,118 @@
+import {
+    type PivotData,
+    type ResultRow,
+    type ResultValue,
+} from '@lightdash/common';
+import isEqual from 'lodash/isEqual';
+
+/**
+ * Normalised view of a TanStack pivot body cell, mirroring
+ * `PivotUnderlyingCell` but keyed by the column's field item id instead of the
+ * synthetic column id.
+ */
+export type PivotRowContextCell = {
+    /** `meta.type` — 'indexValue' | 'passthrough' | 'label' | 'rowTotal' | a data column type */
+    type: string | undefined;
+    /** Item id of `meta.item` when the column renders a field */
+    itemId: string | undefined;
+    /** The cell's full value (`{ value: ResultValue }`), if any */
+    value: ResultRow[string] | undefined;
+    /** Pivot-dimension context on data columns (`meta.headerInfo`) */
+    headerInfo: Record<string, ResultValue> | undefined;
+};
+
+/** Row-level dims: rendered index columns and hidden passthrough columns. */
+const isRowDimCell = (cell: PivotRowContextCell) =>
+    cell.type === 'indexValue' || cell.type === 'passthrough';
+
+const isDataCell = (cell: PivotRowContextCell | undefined) =>
+    cell !== undefined &&
+    !isRowDimCell(cell) &&
+    cell.type !== 'label' &&
+    cell.type !== 'rowTotal';
+
+/**
+ * Collects the `fieldId -> value` pairs a templated URL on a pivot body cell
+ * can reference. A pivot cell's "row" is the set of row-level dims (rendered,
+ * hidden and passthrough), the pivoted dims of the clicked column, the clicked
+ * value and, when metrics are columns, the sibling metrics under the same
+ * pivot header.
+ */
+export const collectPivotBodyRowValues = ({
+    cells,
+    clickedColIndex,
+    labelFieldId,
+    hiddenIndexCells,
+    metricsAsRows,
+}: {
+    cells: PivotRowContextCell[];
+    clickedColIndex: number;
+    /** metricsAsRows: the row's metric label field id */
+    labelFieldId: string | undefined;
+    hiddenIndexCells: PivotData['indexValues'][number];
+    metricsAsRows: boolean;
+}): Record<string, ResultValue> => {
+    const clickedCell = cells[clickedColIndex];
+    const clickedHeaderInfo = clickedCell?.headerInfo;
+    const clickedValue = clickedCell?.value?.value;
+    const values: Record<string, ResultValue> = {};
+
+    cells.forEach((cell) => {
+        if (isRowDimCell(cell)) {
+            if (cell.itemId && cell.value?.value) {
+                values[cell.itemId] = cell.value.value;
+            }
+        } else if (
+            !metricsAsRows &&
+            isDataCell(cell) &&
+            cell.itemId &&
+            cell.value?.value &&
+            clickedHeaderInfo &&
+            isEqual(cell.headerInfo, clickedHeaderInfo)
+        ) {
+            values[cell.itemId] = cell.value.value;
+        }
+    });
+
+    hiddenIndexCells.forEach((cell) => {
+        if (cell.type === 'value') {
+            values[cell.fieldId] = cell.value;
+        }
+    });
+
+    if (isDataCell(clickedCell) && clickedHeaderInfo) {
+        Object.assign(values, clickedHeaderInfo);
+    }
+
+    // metricsAsRows: a data cell's field is the row's metric label, not the
+    // pivot dim its column is keyed by.
+    const clickedFieldId =
+        metricsAsRows && isDataCell(clickedCell)
+            ? labelFieldId
+            : clickedCell?.itemId;
+    if (clickedFieldId && clickedValue) {
+        values[clickedFieldId] = clickedValue;
+    }
+
+    return values;
+};
+
+/**
+ * Collects the values a templated URL on a pivot header cell can reference:
+ * the cell's own value plus its ancestor header values in the same column.
+ * Descendant levels fan out to many values, so they are deliberately absent.
+ */
+export const collectPivotHeaderRowValues = (
+    headerValues: PivotData['headerValues'],
+    headerRowIndex: number,
+    headerColIndex: number,
+): Record<string, ResultValue> =>
+    headerValues
+        .slice(0, headerRowIndex + 1)
+        .reduce<Record<string, ResultValue>>((acc, headerRow) => {
+            const cell = headerRow[headerColIndex];
+            if (cell?.type === 'value') {
+                acc[cell.fieldId] = cell.value;
+            }
+            return acc;
+        }, {});

--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -79,6 +79,7 @@ import {
     getPivotColumnIdentities,
 } from '../../../utils/pivotColumnIdentity';
 import { getSortIcon } from '../../../utils/sortUtils';
+import { buildTemplatedUrlRowContext } from '../../Explorer/ResultsCard/templatedUrlRowContext';
 import { getConditionalRuleLabelFromItem } from '../Filters/FilterInputs/utils';
 import Table from '../LightTable';
 import { CELL_HEIGHT } from '../LightTable/constants';
@@ -99,6 +100,10 @@ import {
 } from './getMetricsAsRowsSubtotalRenderRows';
 import { getPivotCellInteractionProps } from './getPivotCellInteractionProps';
 import { getGroupedDimColumnIds, getRowSpanMerges } from './getRowSpanMerges';
+import {
+    collectPivotBodyRowValues,
+    collectPivotHeaderRowValues,
+} from './getTemplatedUrlRowValues';
 import { collectPivotUnderlyingValues } from './getUnderlyingFieldValues';
 import pivotStyles from './PivotTable.module.css';
 import TotalCellMenu from './TotalCellMenu';
@@ -896,6 +901,64 @@ const PivotTable: FC<PivotTableProps> = ({
         [data.indexValues, data.hiddenIndexValues],
     );
 
+    const getBodyCellTemplatedUrlRowContext = useCallback(
+        (
+            row: Row<ResultRow>,
+            dataRowIndex: number | null,
+            colIndex: number,
+        ) => {
+            // All cells, not just visible ones: hidden passthrough columns
+            // carry dims that templates may reference, as richText does.
+            const cells = row.getAllCells();
+            const clickedColumnId = row.getVisibleCells()[colIndex]?.column.id;
+            const values = collectPivotBodyRowValues({
+                cells: cells.map((cell) => {
+                    const cellItem = cell.column.columnDef.meta?.item;
+                    return {
+                        type: cell.column.columnDef.meta?.type,
+                        itemId: cellItem ? getItemId(cellItem) : undefined,
+                        value: cell.getValue() as ResultRow[string] | undefined,
+                        headerInfo: cell.column.columnDef.meta?.headerInfo,
+                    };
+                }),
+                clickedColIndex: cells.findIndex(
+                    (cell) => cell.column.id === clickedColumnId,
+                ),
+                labelFieldId:
+                    dataRowIndex === null
+                        ? undefined
+                        : data.indexValues[dataRowIndex]?.find(
+                              (indexValue) => indexValue.type === 'label',
+                          )?.fieldId,
+                hiddenIndexCells:
+                    dataRowIndex === null
+                        ? []
+                        : (data.hiddenIndexValues?.[dataRowIndex] ?? []),
+                metricsAsRows: data.pivotConfig.metricsAsRows,
+            });
+            return buildTemplatedUrlRowContext(values, getField);
+        },
+        [
+            data.indexValues,
+            data.hiddenIndexValues,
+            data.pivotConfig.metricsAsRows,
+            getField,
+        ],
+    );
+
+    const getHeaderCellTemplatedUrlRowContext = useCallback(
+        (headerRowIndex: number, headerColIndex: number) =>
+            buildTemplatedUrlRowContext(
+                collectPivotHeaderRowValues(
+                    data.headerValues,
+                    headerRowIndex,
+                    headerColIndex,
+                ),
+                getField,
+            ),
+        [data.headerValues, getField],
+    );
+
     // Find the data column index from headerInfo by matching against headerValues
     // Used for metricsAsRows mode to look up values from dataValues
     const findDataColumnIndex = useCallback(
@@ -1570,6 +1633,48 @@ const PivotTable: FC<PivotTableProps> = ({
                                       }
                                     : null;
 
+                            // Pivoted dimension values get the same value menu
+                            // as body cells; their row context is the column's
+                            // ancestor header values.
+                            const headerValueMenuProps =
+                                headerValue.type === 'value'
+                                    ? getPivotCellInteractionProps({
+                                          enabled: enableContextMenu,
+                                          withInteractions:
+                                              !!headerValue.value.formatted,
+                                          withMenu: (
+                                              {
+                                                  isOpen,
+                                                  onClose,
+                                                  onCopy,
+                                              }: MenuCallbackProps,
+                                              render: RenderCallback,
+                                          ) => (
+                                              <ValueCellMenu
+                                                  opened={isOpen}
+                                                  item={field}
+                                                  value={headerValue.value}
+                                                  urlActions={{
+                                                      field: isField(field)
+                                                          ? field
+                                                          : undefined,
+                                                      getItem: getField,
+                                                      getRowContext: () =>
+                                                          getHeaderCellTemplatedUrlRowContext(
+                                                              headerRowIndex,
+                                                              headerColIndex,
+                                                          ),
+                                                  }}
+                                                  onClose={onClose}
+                                                  onCopy={onCopy}
+                                                  isMinimal={isMinimal}
+                                              >
+                                                  {render()}
+                                              </ValueCellMenu>
+                                          ),
+                                      })
+                                    : {};
+
                             return isLabel || headerValue.colSpan > 0 ? (
                                 <Table.CellHead
                                     key={`header-${headerRowIndex}-${headerColIndex}`}
@@ -1578,6 +1683,18 @@ const PivotTable: FC<PivotTableProps> = ({
                                     isMinimal={isMinimal}
                                     withBoldFont={isLabel}
                                     withTooltip={description}
+                                    withValue={
+                                        headerValue.type === 'value'
+                                            ? headerValue.value.formatted
+                                            : undefined
+                                    }
+                                    withUrls={
+                                        enableContextMenu &&
+                                        headerValue.type === 'value' &&
+                                        isField(field) &&
+                                        !!field.urls?.length
+                                    }
+                                    {...headerValueMenuProps}
                                     colSpan={
                                         isLabel
                                             ? undefined
@@ -2076,6 +2193,31 @@ const PivotTable: FC<PivotTableProps> = ({
                                         : undefined;
                                 })();
 
+                                // The field whose `urls` apply: index cells keep
+                                // their dimension even when `item` is swapped for
+                                // the row metric in metricsAsRows mode.
+                                const urlField =
+                                    meta?.type === 'indexValue'
+                                        ? meta.item
+                                        : item;
+                                const urlActions =
+                                    isRowTotal || meta?.type === 'label'
+                                        ? undefined
+                                        : {
+                                              field: isField(urlField)
+                                                  ? urlField
+                                                  : undefined,
+                                              getItem: getField,
+                                              getRowContext: () =>
+                                                  getBodyCellTemplatedUrlRowContext(
+                                                      row,
+                                                      dataRowIndex,
+                                                      colIndex,
+                                                  ),
+                                          };
+                                const hasUrlActions =
+                                    !!urlActions?.field?.urls?.length;
+
                                 const suppressContextMenu =
                                     isMetricSubtotal ||
                                     ((value === undefined ||
@@ -2136,6 +2278,11 @@ const PivotTable: FC<PivotTableProps> = ({
                                             conditionalFormatting?.tooltipContent
                                         }
                                         withValue={value?.formatted}
+                                        withUrls={
+                                            enableContextMenu &&
+                                            !!allowInteractions &&
+                                            hasUrlActions
+                                        }
                                         {...getPivotCellInteractionProps({
                                             enabled: enableContextMenu,
                                             withInteractions: allowInteractions,
@@ -2155,6 +2302,7 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     }
                                                     colIndex={colIndex}
                                                     item={item}
+                                                    urlActions={urlActions}
                                                     value={value}
                                                     getUnderlyingFieldValues={
                                                         isRowTotal ||


### PR DESCRIPTION
## What

Dimension cells in pivot tables get the templated `urls` actions that the results table and the flat table viz already offer, and the pivoted dimension values along the column header get a value menu for the first time (Copy value, URL actions, and on dashboards the "Show only / Exclude" filters). Cells whose field declares `urls` show the same dotted underline hint as the flat table.

Evidence page with before/after menus, screenshots and recordings for twelve permutations (row cells, header cells, two pivot levels, metrics as rows, totals, dashboard, minimal view, dark mode): https://claude.ai/code/artifact/36cc73e6-a257-4829-add9-2a6312746540

## Why

The pivot table renders its own cell menu (`ValueCellMenu`) and never received the URL items the flat tables share through `UrlMenuItems`. Header value cells had no menu at all.

## How

- `UrlMenuItems` is split into a presentational `TemplatedUrlMenuItems` that takes a resolved row context; the TanStack-cell wrapper is kept for the three existing callers. Missing-dependency labels resolve through a `getItem` function instead of a map. The row-context type and builder live in a new non-component module (`templatedUrlRowContext.ts`).
- New pure helpers in `PivotTable/getTemplatedUrlRowValues.ts` work out what a pivot cell can reference:
  - body cell: row-level dims (rendered index columns, hidden index dims, hidden `passthrough` columns), the pivoted dims of the clicked column, the clicked value and, when metrics are columns, sibling metrics under the same header;
  - header cell: the cell and its ancestor header values in the same column (descendant levels fan out, so they are deliberately absent and the template is disabled with the usual "add X to your query" hint).
- `ValueCellMenu` takes one optional `urlActions: { field, getRowContext, getItem }`; the row context is resolved once when the dropdown mounts, so per-cell render cost is unchanged.
- `PivotTable` wires body cells (using the real dimension field even in `metricsAsRows` mode, where `item` is swapped for the row metric) and gives header value cells the same `withMenu`/`withValue` wiring the footer totals use.
- `LightTable` gains a `withUrls` cell prop (dotted underline), ordered before `.cfUnderline` so a conditional-formatting underline wins, matching `Table.module.css`.

## Regression analysis

- Flat tables: the three `UrlMenuItems` callers keep the same row-building loop and validation; `itemsMap` is adapted to `getItem`.
- Metric cells, row/column totals and the metric-label sort header are unchanged (verified before/after in the evidence page).
- Header cells now have `withInteractions` (pointer, hover, select, cmd+C) and a menu, only for `type === 'value'` cells. The resize handle stops propagation, so dragging it does not open the menu. `pivotTables.cy.ts` never clicks a header value cell.
- Hint and menu are gated on `enableContextMenu`, so AI chat visualisations with analytical interaction disabled, and any embed that disables menus, stay clean. Minimal (scheduled delivery) views hide broken templates instead of showing a disabled item, matching `MinimalCellContextMenu`. Scheduled-delivery images will show the dotted underline on pivot cells, as they already do for flat tables.
- `ExplorerResults` also renders `PivotTable` (results card pivot view) and gets the same behaviour.
- Pre-existing, not changed here: with metrics as rows, a row-dimension cell also offers "View underlying data / Drill into" for the row metric because `PivotTable` swaps that cell's item. This PR reads the dimension separately for URLs rather than touching that behaviour.

## Tests

- New: `getTemplatedUrlRowValues.test.ts` (8 cases: both modes, hidden and passthrough dims, sibling scoping, merged header spans) and `templatedUrlRowContext.test.ts` (2).
- Existing `SimpleTable`, `PivotTable`, `LightTable` suites pass (79 tests).
- Live: every permutation in the evidence page was driven headlessly against a worktree build, and the same script run against `main` produced the "before" column.

Closes: #7024

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmiQ4oYNPXVeqEghwdmvRg
