### PR TITLE
refactor(frontend): drive auto-refresh and time-ago with the Mantine interval hook

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.test.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.test.tsx
@@ -1,0 +1,148 @@
+import { act, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { DashboardRefreshButton } from './DashboardRefreshButton';
+
+const invalidateDashboardRelatedQueries = vi.fn(() => Promise.resolve());
+const invalidateDashboardResultsQueries = vi.fn(() => Promise.resolve());
+const removeDashboardResultsQueries = vi.fn();
+const clearCacheAndFetch = vi.fn();
+const setIsAutoRefresh = vi.fn();
+
+vi.mock('../../../hooks/dashboard/useDashboardRefresh', () => ({
+    useDashboardRefresh: () => ({
+        isFetching: 0,
+        invalidateDashboardRelatedQueries,
+        invalidateDashboardResultsQueries,
+        removeDashboardResultsQueries,
+    }),
+}));
+
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastSuccess: vi.fn() }),
+}));
+
+vi.mock('../../../providers/Dashboard/useDashboardTileStatusContext', () => ({
+    default: (
+        selector: (context: {
+            clearCacheAndFetch: () => void;
+            setIsAutoRefresh: (value: boolean) => void;
+        }) => unknown,
+    ) => selector({ clearCacheAndFetch, setIsAutoRefresh }),
+}));
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+// The timer is armed a frame after the click, so give ticks a little slack.
+const SLACK = 100;
+
+const renderButton = () => {
+    const onIntervalChange = vi.fn();
+    const view = renderWithProviders(
+        <DashboardRefreshButton onIntervalChange={onIntervalChange} />,
+    );
+    return { ...view, onIntervalChange };
+};
+
+const chooseInterval = async (
+    user: ReturnType<typeof userEvent.setup>,
+    label: string,
+) => {
+    const [, menuTrigger] = within(screen.getByRole('group')).getAllByRole(
+        'button',
+    );
+    await user.click(menuTrigger);
+    await user.click(screen.getByRole('menuitem', { name: label }));
+};
+
+const advance = (ms: number) => {
+    act(() => {
+        vi.advanceTimersByTime(ms);
+    });
+};
+
+describe('DashboardRefreshButton auto-refresh', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.clearAllMocks();
+    });
+
+    test('refreshes once per chosen interval, not continuously', async () => {
+        const user = userEvent.setup({
+            advanceTimers: vi.advanceTimersByTime,
+            delay: null,
+        });
+        renderButton();
+
+        await chooseInterval(user, '5m');
+
+        advance(FIVE_MINUTES - SLACK);
+        expect(clearCacheAndFetch).not.toHaveBeenCalled();
+
+        advance(2 * SLACK);
+        expect(clearCacheAndFetch).toHaveBeenCalledTimes(1);
+
+        advance(FIVE_MINUTES);
+        expect(clearCacheAndFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('re-rendering while waiting does not reset the schedule', async () => {
+        const user = userEvent.setup({
+            advanceTimers: vi.advanceTimersByTime,
+            delay: null,
+        });
+        const { rerender } = renderButton();
+
+        await chooseInterval(user, '5m');
+
+        for (let elapsed = 0; elapsed < FIVE_MINUTES; elapsed += 60_000) {
+            advance(60_000);
+            rerender(<DashboardRefreshButton onIntervalChange={vi.fn()} />);
+        }
+        advance(SLACK);
+        expect(clearCacheAndFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('switching interval and turning off both take effect', async () => {
+        const user = userEvent.setup({
+            advanceTimers: vi.advanceTimersByTime,
+            delay: null,
+        });
+        renderButton();
+
+        await chooseInterval(user, '5m');
+        await chooseInterval(user, '15m');
+
+        advance(FIVE_MINUTES);
+        expect(clearCacheAndFetch).not.toHaveBeenCalled();
+        advance(2 * FIVE_MINUTES);
+        expect(clearCacheAndFetch).toHaveBeenCalledTimes(1);
+
+        await chooseInterval(user, 'Off');
+        expect(setIsAutoRefresh).toHaveBeenLastCalledWith(false);
+
+        advance(6 * FIVE_MINUTES);
+        expect(clearCacheAndFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('unmounting stops the timer', async () => {
+        const user = userEvent.setup({
+            advanceTimers: vi.advanceTimersByTime,
+            delay: null,
+        });
+        const { unmount, onIntervalChange } = renderButton();
+
+        await chooseInterval(user, '5m');
+        expect(onIntervalChange).toHaveBeenCalledWith(5);
+
+        unmount();
+        expect(onIntervalChange).toHaveBeenLastCalledWith(undefined);
+
+        advance(3 * FIVE_MINUTES);
+        expect(clearCacheAndFetch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, Menu, Text, Tooltip } from '@mantine/core';
+import { useInterval } from '@mantine/hooks';
 import { IconCheck, IconChevronDown, IconRefresh } from '@tabler/icons-react';
 import {
     memo,
@@ -8,9 +9,9 @@ import {
     useState,
     type FC,
 } from 'react';
-import { useInterval } from 'react-use';
 import { useDashboardRefresh } from '../../../hooks/dashboard/useDashboardRefresh';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { useStableCallback } from '../../../hooks/useStableCallback';
 import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import MantineIcon from '../MantineIcon';
 
@@ -90,13 +91,20 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
             invalidateDashboardResultsQueries,
         ]);
 
-        // Keyed on the interval only; a paused (null) delay stops the timer.
-        useInterval(
-            () => {
-                void invalidateAndSetRefreshTime();
-            },
-            refreshInterval === undefined ? null : refreshInterval * 60 * 1000,
-        );
+        // The interval restarts whenever its callback identity changes, so
+        // the tick must stay stable across re-renders.
+        const tick = useStableCallback(() => {
+            void invalidateAndSetRefreshTime();
+        });
+        const autoRefresh = useInterval(tick, (refreshInterval ?? 0) * 60_000);
+
+        useEffect(() => {
+            if (refreshInterval === undefined) return;
+            autoRefresh.start();
+            return autoRefresh.stop;
+            // start/stop are stable; only the chosen interval matters
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [refreshInterval]);
 
         useEffect(() => {
             return () => {
@@ -163,6 +171,9 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
                         <Menu.Item
                             fz="xs"
                             onClick={() => {
+                                // A running interval restarts when its delay
+                                // changes, so stop before the delay drops to 0.
+                                autoRefresh.stop();
                                 setRefreshInterval(undefined);
                                 setIsAutoRefresh(false);
                             }}

--- a/packages/frontend/src/hooks/mantineHooksCompatibility.test.tsx
+++ b/packages/frontend/src/hooks/mantineHooksCompatibility.test.tsx
@@ -2,6 +2,7 @@ import { useElementSize, useInterval, useTimeout } from '@mantine/hooks';
 import { act, render, renderHook, screen } from '@testing-library/react';
 import { useEffect, useState } from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { useStableCallback } from './useStableCallback';
 
 const useControlledInterval = (enabled: boolean) => {
     const [ticks, setTicks] = useState(0);
@@ -18,6 +19,22 @@ const useControlledInterval = (enabled: boolean) => {
         // Matches the controlled interval pattern used by JobDetailsDrawer.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [enabled]);
+
+    return ticks;
+};
+
+// Mirrors DashboardRefreshButton: the delay comes from state and the callback
+// identity never changes between renders.
+const useAdjustableInterval = (delay: number) => {
+    const [ticks, setTicks] = useState(0);
+    const tick = useStableCallback(() => setTicks((value) => value + 1));
+    const interval = useInterval(tick, delay);
+
+    useEffect(() => {
+        interval.start();
+        return interval.stop;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return ticks;
 };
@@ -72,6 +89,41 @@ describe('Mantine hooks compatibility', () => {
             vi.advanceTimersByTime(2_000);
         });
         expect(result.current).toBe(2);
+    });
+
+    test('a running interval adopts a delay chosen after it started', () => {
+        vi.useFakeTimers();
+        const { result, rerender } = renderHook(
+            ({ delay }) => useAdjustableInterval(delay),
+            { initialProps: { delay: 1_000 } },
+        );
+
+        rerender({ delay: 5_000 });
+        act(() => {
+            vi.advanceTimersByTime(4_999);
+        });
+        expect(result.current).toBe(0);
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+        expect(result.current).toBe(1);
+    });
+
+    test('re-renders between ticks do not reset the schedule', () => {
+        vi.useFakeTimers();
+        const { result, rerender } = renderHook(
+            ({ delay }) => useAdjustableInterval(delay),
+            { initialProps: { delay: 1_000 } },
+        );
+
+        for (let elapsed = 0; elapsed < 1_000; elapsed += 200) {
+            act(() => {
+                vi.advanceTimersByTime(200);
+            });
+            rerender({ delay: 1_000 });
+        }
+        expect(result.current).toBe(1);
     });
 
     test('delayed state appears after its timeout and stays hidden when cancelled', () => {

--- a/packages/frontend/src/hooks/useStableCallback.ts
+++ b/packages/frontend/src/hooks/useStableCallback.ts
@@ -1,0 +1,17 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+/**
+ * Returns a function whose identity never changes and always invokes the
+ * latest `callback`, for consumers that restart when a callback changes.
+ */
+export const useStableCallback = <Args extends unknown[], Result>(
+    callback: (...args: Args) => Result,
+) => {
+    const latest = useRef(callback);
+
+    useLayoutEffect(() => {
+        latest.current = callback;
+    });
+
+    return useCallback((...args: Args) => latest.current(...args), []);
+};

--- a/packages/frontend/src/hooks/useTimeAgo.ts
+++ b/packages/frontend/src/hooks/useTimeAgo.ts
@@ -1,6 +1,7 @@
+import { useInterval } from '@mantine/hooks';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useInterval } from 'react-use';
+import { useStableCallback } from './useStableCallback';
 
 export const useTimeAgo = (
     dateOrString: Date | string,
@@ -31,9 +32,10 @@ export const useTimeAgo = (
         setTimeAgo(nextTimeAgo);
     }, [getTimeAgo]);
 
-    useInterval(() => {
-        updateTimeAgo();
-    }, interval);
+    // Callers often pass a fresh Date each render; the interval restarts on
+    // every callback change, so the tick must stay identity-stable.
+    const tick = useStableCallback(updateTimeAgo);
+    useInterval(tick, interval, { autoInvoke: true });
 
     useEffect(() => {
         updateTimeAgo();


### PR DESCRIPTION
Dashboard auto-refresh was moved to react-use's \`useInterval\` as a workaround for the \`@mantine/hooks\` 8.3.18 hook that captured its interval on first render and flooded the API. Mantine 9.6.0 reads the current interval, so the refresh button and the time-ago hook go back to the shared hook and the app stops carrying two interval implementations. Until 9.6.1 lands, the Mantine hook still restarts when its callback identity or its delay changes, so both callers hand it an identity-stable callback and the refresh button stops the timer before turning off. The refresh button gains tests for the schedule that broke in production.

Verified locally on a dashboard: choosing 5m produced one refresh at the 5-minute mark and no requests in between.

Stacked on #28996.

Relates: ZAP-1023