### PR TITLE
feat: add roadmap project follow requests

### DIFF
--- a/packages/backend/src/ee/controllers/OrgRoadmapController.ts
+++ b/packages/backend/src/ee/controllers/OrgRoadmapController.ts
@@ -1,14 +1,20 @@
 import {
     assertRegisteredAccount,
     type ApiErrorPayload,
+    type ApiRoadmapFollowProjectResponse,
     type ApiRoadmapProjectResponse,
     type ApiRoadmapResponse,
+    type RoadmapFollowProjectRequest,
+    type UUID,
 } from '@lightdash/common';
 import {
+    Body,
     Get,
     Hidden,
     Middlewares,
     OperationId,
+    Path,
+    Post,
     Query,
     Request,
     Response,
@@ -29,6 +35,25 @@ import type { RoadmapService } from '../services/RoadmapService/RoadmapService';
 @Hidden()
 @Response<ApiErrorPayload>('default', 'Error')
 export class OrgRoadmapController extends BaseController {
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/projects/{projectId}/follow')
+    @OperationId('followOrgRoadmapProject')
+    async followProject(
+        @Request() req: express.Request,
+        @Path() projectId: UUID,
+        @Body() body: RoadmapFollowProjectRequest,
+    ): Promise<ApiRoadmapFollowProjectResponse> {
+        assertRegisteredAccount(req.account);
+        this.setHeader('Cache-Control', 'no-store');
+        return {
+            status: 'ok',
+            results: await this.services
+                .getRoadmapService<RoadmapService>()
+                .followProject(req.account, projectId, body),
+        };
+    }
+
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('/')

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -697,16 +697,48 @@ describe('RoadmapService', () => {
             ).rejects.toThrow(UnexpectedServerError);
         });
 
-        it('handles timeouts without retrying a potentially delivered request', async () => {
-            fetchMock.mockRejectedValueOnce(
-                new DOMException('timeout', 'TimeoutError'),
-            );
-            await expect(
-                buildService().followProject(account(), projectId, {
-                    note: 'Use case',
+        it.each([
+            {
+                error: new DOMException(
+                    'private timeout details',
+                    'TimeoutError',
+                ),
+                errorName: 'TimeoutError',
+                errorCode: undefined,
+            },
+            ...['ECONNREFUSED', 'ENOTFOUND', 'ECONNRESET'].map((code) => ({
+                error: new TypeError('private request details', {
+                    cause: { code, message: 'private provider details' },
                 }),
-            ).rejects.toThrow(UnexpectedServerError);
-            expect(fetchMock).toHaveBeenCalledOnce();
-        });
+                errorName: 'TypeError',
+                errorCode: code,
+            })),
+            {
+                error: 'private thrown value',
+                errorName: 'UnknownError',
+                errorCode: undefined,
+            },
+        ])(
+            'logs safe network diagnostics without retrying: $errorName $errorCode',
+            async ({ error, errorName, errorCode }) => {
+                const service = buildService();
+                const warn = vi.spyOn(service['logger'], 'warn');
+                fetchMock.mockRejectedValueOnce(error);
+                await expect(
+                    service.followProject(account(), projectId, {
+                        note: 'Use case',
+                    }),
+                ).rejects.toThrow(UnexpectedServerError);
+                expect(warn).toHaveBeenCalledExactlyOnceWith(
+                    'Could not reach the roadmap service',
+                    { errorName, errorCode },
+                );
+                expect(JSON.stringify(warn.mock.calls)).not.toContain(
+                    'private',
+                );
+                expect(fetchMock).toHaveBeenCalledOnce();
+                warn.mockRestore();
+            },
+        );
     });
 });

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -1,5 +1,6 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
+    buildAbilityFromScopes,
     ForbiddenError,
     NotFoundError,
     OrganizationMemberRole,
@@ -489,7 +490,17 @@ describe('RoadmapService', () => {
             },
         };
         const account = () => {
-            const value = buildAccount(viewRoadmapAbility(sessionOrgUuid));
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            buildAbilityFromScopes(
+                {
+                    organizationUuid: sessionOrgUuid,
+                    userUuid,
+                    isEnterprise: true,
+                    scopes: ['view:Roadmap', 'manage:Roadmap'],
+                },
+                builder,
+            );
+            const value = buildAccount(builder.build());
             return { ...value, user: { ...value.user, userUuid } } as Account;
         };
 
@@ -551,22 +562,61 @@ describe('RoadmapService', () => {
             expect(fetchMock).not.toHaveBeenCalled();
         });
 
-        it('requires an admin even with roadmap view access and rejects service accounts', async () => {
-            const nonAdmin = account();
-            nonAdmin.user = {
-                ...nonAdmin.user,
-                role: OrganizationMemberRole.DEVELOPER,
-            } as typeof nonAdmin.user;
+        it('allows a non-admin with the organization scope', async () => {
+            const customRoleAccount = account();
+            customRoleAccount.user = {
+                ...customRoleAccount.user,
+                role: OrganizationMemberRole.MEMBER,
+            } as typeof customRoleAccount.user;
+            fetchMock.mockResolvedValueOnce(
+                new Response(JSON.stringify(confirmation)),
+            );
             await expect(
-                buildService().followProject(nonAdmin, projectId, {
+                buildService().followProject(customRoleAccount, projectId, {
                     note: 'Use case',
                 }),
-            ).rejects.toThrow(ForbiddenError);
+            ).resolves.toEqual(confirmation.results);
+        });
+
+        it('allows service accounts with the scope and required identity', async () => {
             const serviceAccount = account();
             serviceAccount.isServiceAccount = (() =>
                 true) as typeof serviceAccount.isServiceAccount;
+            fetchMock.mockResolvedValueOnce(
+                new Response(JSON.stringify(confirmation)),
+            );
             await expect(
                 buildService().followProject(serviceAccount, projectId, {
+                    note: 'Use case',
+                }),
+            ).resolves.toEqual(confirmation.results);
+        });
+
+        it('denies view-only accounts even when their stored role is admin', async () => {
+            const viewer = account();
+            viewer.user.ability = viewRoadmapAbility(sessionOrgUuid);
+            viewer.user.abilityRules = viewer.user.ability.rules;
+            await expect(
+                buildService().followProject(viewer, projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('denies management grants belonging to another organization', async () => {
+            const wrongOrg = account();
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            builder.can('view', 'Roadmap', {
+                organizationUuid: sessionOrgUuid,
+            });
+            builder.can('manage', 'Roadmap', {
+                organizationUuid: otherOrgUuid,
+            });
+            wrongOrg.user.ability = builder.build();
+            wrongOrg.user.abilityRules = wrongOrg.user.ability.rules;
+            await expect(
+                buildService().followProject(wrongOrg, projectId, {
                     note: 'Use case',
                 }),
             ).rejects.toThrow(ForbiddenError);

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -1,6 +1,8 @@
 import { Ability, AbilityBuilder } from '@casl/ability';
 import {
     ForbiddenError,
+    NotFoundError,
+    OrganizationMemberRole,
     ParameterError,
     RoadmapItemPriority,
     RoadmapItemStatus,
@@ -476,4 +478,185 @@ describe('RoadmapService', () => {
             expect(fetchMock).not.toHaveBeenCalled();
         },
     );
+    describe('followProject', () => {
+        const projectId = '9333377a-b301-4e30-a244-5ad5ea3cdc6e';
+        const userUuid = 'ae3aef51-a909-4d3d-a80f-bc5b68918b5f';
+        const confirmation = {
+            status: 'ok',
+            results: {
+                message:
+                    'The request has been sent to the Lightdash team and will soon be reviewed',
+            },
+        };
+        const account = () => {
+            const value = buildAccount(viewRoadmapAbility(sessionOrgUuid));
+            return { ...value, user: { ...value.user, userUuid } } as Account;
+        };
+
+        it('sends trusted identity and a trimmed note to the configured follow endpoint', async () => {
+            fetchMock.mockResolvedValueOnce(
+                new Response(JSON.stringify(confirmation)),
+            );
+            const result = await buildService({
+                baseUrl: 'http://localhost:8082',
+            }).followProject(account(), projectId, {
+                note: '  Our use case  ',
+            });
+            expect(result).toEqual(confirmation.results);
+            const [url, options] = fetchMock.mock.calls[0];
+            expect(url).toBe(
+                `http://localhost:8082/api/v1/roadmap/organizations/${sessionOrgUuid}/projects/${projectId}/follow`,
+            );
+            expect(options.method).toBe('POST');
+            expect(options.headers).toEqual({
+                'lightdash-license-key': 'test-license-key',
+                'Content-Type': 'application/json',
+            });
+            expect(JSON.parse(options.body)).toEqual({
+                organizationName: 'Org',
+                user: {
+                    userUuid,
+                    name: 'Test User',
+                    email: 'user@example.com',
+                },
+                note: 'Our use case',
+            });
+            expect(options.signal).toBeInstanceOf(AbortSignal);
+            expect(fetchMock).toHaveBeenCalledOnce();
+        });
+
+        it.each([
+            { note: '' },
+            { note: '   ' },
+            { note: 'a'.repeat(2001) },
+            { note: 'Use case', organizationUuid: otherOrgUuid },
+            { note: 'Use case', organizationName: 'Spoofed org' },
+            { note: 'Use case', user: { email: 'attacker@example.com' } },
+        ])(
+            'rejects invalid notes and caller-supplied identity: %j',
+            async (body) => {
+                await expect(
+                    buildService().followProject(account(), projectId, body),
+                ).rejects.toThrow(ParameterError);
+                expect(fetchMock).not.toHaveBeenCalled();
+            },
+        );
+
+        it('rejects non-UUID project IDs before fetching', async () => {
+            await expect(
+                buildService().followProject(account(), '../projects', {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('requires an admin even with roadmap view access and rejects service accounts', async () => {
+            const nonAdmin = account();
+            nonAdmin.user = {
+                ...nonAdmin.user,
+                role: OrganizationMemberRole.DEVELOPER,
+            } as typeof nonAdmin.user;
+            await expect(
+                buildService().followProject(nonAdmin, projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            const serviceAccount = account();
+            serviceAccount.isServiceAccount = (() =>
+                true) as typeof serviceAccount.isServiceAccount;
+            await expect(
+                buildService().followProject(serviceAccount, projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('requires roadmap access, its feature flag and a configured license', async () => {
+            const wrongOrg = account();
+            wrongOrg.user.ability = viewRoadmapAbility(otherOrgUuid);
+            wrongOrg.user.abilityRules = wrongOrg.user.ability.rules;
+            await expect(
+                buildService().followProject(wrongOrg, projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                buildService({ flagEnabled: false }).followProject(
+                    account(),
+                    projectId,
+                    { note: 'Use case' },
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            await expect(
+                buildService({ licenseKey: '' }).followProject(
+                    account(),
+                    projectId,
+                    { note: 'Use case' },
+                ),
+            ).rejects.toThrow(UnexpectedServerError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it('requires complete trusted identity before forwarding', async () => {
+            const missingEmail = account();
+            missingEmail.user.email = undefined;
+            await expect(
+                buildService().followProject(missingEmail, projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it.each([201, 202, 401, 403, 404, 429, 500, 502, 503])(
+            'handles upstream %s without retrying or exposing its body',
+            async (status) => {
+                fetchMock.mockResolvedValueOnce(
+                    new Response('private note and provider details', {
+                        status,
+                    }),
+                );
+                const result = buildService().followProject(
+                    account(),
+                    projectId,
+                    { note: 'Use case' },
+                );
+                const errorType =
+                    new Map([
+                        [401, ForbiddenError],
+                        [403, ForbiddenError],
+                        [404, NotFoundError],
+                    ]).get(status) ?? UnexpectedServerError;
+                await expect(result).rejects.toThrow(errorType);
+                await expect(result).rejects.not.toThrow('private note');
+                expect(fetchMock).toHaveBeenCalledOnce();
+            },
+        );
+
+        it.each([
+            'not JSON',
+            JSON.stringify({ status: 'ok', results: { hasDirectNeed: true } }),
+        ])('rejects malformed confirmation %s', async (body) => {
+            fetchMock.mockResolvedValueOnce(new Response(body));
+            await expect(
+                buildService().followProject(account(), projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(UnexpectedServerError);
+        });
+
+        it('handles timeouts without retrying a potentially delivered request', async () => {
+            fetchMock.mockRejectedValueOnce(
+                new DOMException('timeout', 'TimeoutError'),
+            );
+            await expect(
+                buildService().followProject(account(), projectId, {
+                    note: 'Use case',
+                }),
+            ).rejects.toThrow(UnexpectedServerError);
+            expect(fetchMock).toHaveBeenCalledOnce();
+        });
+    });
 });

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -139,7 +139,11 @@ export class RoadmapService extends BaseService {
             RoadmapFollowProjectResponseSchema,
             {
                 method: 'POST',
-                body: JSON.stringify({ ...identity.data, ...parsed.data }),
+                body: JSON.stringify({
+                    organizationName: identity.data.organizationName,
+                    user: identity.data.user,
+                    note: parsed.data.note,
+                }),
                 timeoutMs: 120_000,
                 errorMessage:
                     'Could not send the roadmap request. Please try again.',
@@ -249,8 +253,14 @@ export class RoadmapService extends BaseService {
                 },
                 signal: AbortSignal.timeout(options.timeoutMs),
             });
-        } catch {
-            this.logger.warn('Could not reach the roadmap service');
+        } catch (error) {
+            const cause = z
+                .object({ code: z.string() })
+                .safeParse(error instanceof Error ? error.cause : undefined);
+            this.logger.warn('Could not reach the roadmap service', {
+                errorName: error instanceof Error ? error.name : 'UnknownError',
+                errorCode: cause.success ? cause.data.code : undefined,
+            });
             throw new UnexpectedServerError(options.errorMessage);
         }
 
@@ -270,6 +280,7 @@ export class RoadmapService extends BaseService {
                 'This roadmap project is no longer available',
             );
         }
+        // Control Center confirms receipt only with HTTP 200 and a validated body.
         if (
             !response.ok ||
             (options.method === 'POST' && response.status !== 200)

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -4,8 +4,12 @@ import {
     assertRegisteredAccount,
     FeatureFlags,
     ForbiddenError,
+    NotFoundError,
+    OrganizationMemberRole,
     ParameterError,
     ROADMAP_DEFAULT_PAGE_SIZE,
+    RoadmapFollowProjectRequestSchema,
+    RoadmapFollowProjectResponseSchema,
     RoadmapProjectQuerySchema,
     RoadmapProjectRequestsResponseSchema,
     RoadmapProjectResponseSchema,
@@ -13,10 +17,13 @@ import {
     RoadmapResponseSchema,
     UnexpectedServerError,
     type Account,
+    type RoadmapFollowProjectRequest,
+    type RoadmapFollowProjectResults,
     type RoadmapProjectQuery,
     type RoadmapProjectResults,
     type RoadmapQuery,
     type RoadmapResults,
+    type UUID,
 } from '@lightdash/common';
 import { z } from 'zod';
 import type { LightdashConfig } from '../../../config/parseConfig';
@@ -76,6 +83,68 @@ export class RoadmapService extends BaseService {
         }
 
         return { organizationUuid, licenseKey };
+    }
+
+    async followProject(
+        account: Account,
+        projectId: UUID,
+        body: RoadmapFollowProjectRequest,
+    ): Promise<RoadmapFollowProjectResults> {
+        const { organizationUuid, licenseKey } = await this.authorize(account);
+        assertRegisteredAccount(account);
+        assertIsAccountWithOrg(account);
+        if (
+            account.user.role !== OrganizationMemberRole.ADMIN ||
+            account.isServiceAccount()
+        ) {
+            throw new ForbiddenError(
+                'Only organization admins can request to follow roadmap projects',
+            );
+        }
+        const parsed = RoadmapFollowProjectRequestSchema.safeParse(body);
+        const parsedProjectId = z.uuid().safeParse(projectId);
+        if (!parsed.success || !parsedProjectId.success) {
+            throw new ParameterError(
+                'Provide a valid project and a note of 1–2000 characters',
+            );
+        }
+        const identity = z
+            .object({
+                organizationName: z.string().trim().min(1).max(255),
+                user: z.object({
+                    userUuid: z.uuid(),
+                    name: z.string().trim().min(1).max(255),
+                    email: z.string().trim().max(320).pipe(z.email()),
+                }),
+            })
+            .safeParse({
+                organizationName: account.organization.name,
+                user: {
+                    userUuid: account.user.userUuid,
+                    name: `${account.user.firstName} ${account.user.lastName}`.trim(),
+                    email: account.user.email,
+                },
+            });
+        if (!identity.success) {
+            throw new ParameterError(
+                'Your organization name, user name and email are required to send this request',
+            );
+        }
+        const response = await this.request(
+            organizationUuid,
+            licenseKey,
+            `/projects/${encodeURIComponent(parsedProjectId.data)}/follow`,
+            {},
+            RoadmapFollowProjectResponseSchema,
+            {
+                method: 'POST',
+                body: JSON.stringify({ ...identity.data, ...parsed.data }),
+                timeoutMs: 120_000,
+                errorMessage:
+                    'Could not send the roadmap request. Please try again.',
+            },
+        );
+        return response.results;
     }
 
     async getProjects(
@@ -147,6 +216,16 @@ export class RoadmapService extends BaseService {
         suffix: string,
         query: Record<string, string | number | boolean | undefined>,
         schema: z.ZodType<T>,
+        options: {
+            method: 'GET' | 'POST';
+            body?: string;
+            timeoutMs: number;
+            errorMessage: string;
+        } = {
+            method: 'GET',
+            timeoutMs: ROADMAP_REQUEST_TIMEOUT_MS,
+            errorMessage: 'Could not load the organization roadmap',
+        },
     ): Promise<T> {
         const url = new URL(
             '/api/v1/roadmap/organizations',
@@ -159,18 +238,19 @@ export class RoadmapService extends BaseService {
         let response: Response;
         try {
             response = await fetch(url.toString(), {
+                method: options.method,
+                body: options.body,
                 headers: {
                     'lightdash-license-key': licenseKey,
+                    ...(options.method === 'POST' && {
+                        'Content-Type': 'application/json',
+                    }),
                 },
-                signal: AbortSignal.timeout(ROADMAP_REQUEST_TIMEOUT_MS),
+                signal: AbortSignal.timeout(options.timeoutMs),
             });
-        } catch (error) {
-            this.logger.warn('Could not reach the roadmap service', {
-                error: error instanceof Error ? error.message : String(error),
-            });
-            throw new UnexpectedServerError(
-                'Could not load the organization roadmap',
-            );
+        } catch {
+            this.logger.warn('Could not reach the roadmap service');
+            throw new UnexpectedServerError(options.errorMessage);
         }
 
         // 401/403 means the instance license is not bound to this org in the
@@ -184,22 +264,26 @@ export class RoadmapService extends BaseService {
             );
         }
 
-        if (!response.ok) {
+        if (options.method === 'POST' && response.status === 404) {
+            throw new NotFoundError(
+                'This roadmap project is no longer available',
+            );
+        }
+        if (
+            !response.ok ||
+            (options.method === 'POST' && response.status !== 200)
+        ) {
             this.logger.warn('Roadmap service returned an error', {
                 statusCode: response.status,
             });
-            throw new UnexpectedServerError(
-                'Could not load the organization roadmap',
-            );
+            throw new UnexpectedServerError(options.errorMessage);
         }
 
         let payload: unknown;
         try {
             payload = await response.json();
         } catch {
-            throw new UnexpectedServerError(
-                'Could not load the organization roadmap',
-            );
+            throw new UnexpectedServerError(options.errorMessage);
         }
 
         const parsedResponse = schema.safeParse(payload);
@@ -207,9 +291,7 @@ export class RoadmapService extends BaseService {
             this.logger.warn('Roadmap service returned an invalid response', {
                 issueCount: parsedResponse.error.issues.length,
             });
-            throw new UnexpectedServerError(
-                'Could not load the organization roadmap',
-            );
+            throw new UnexpectedServerError(options.errorMessage);
         }
 
         return parsedResponse.data;

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -5,7 +5,6 @@ import {
     FeatureFlags,
     ForbiddenError,
     NotFoundError,
-    OrganizationMemberRole,
     ParameterError,
     ROADMAP_DEFAULT_PAGE_SIZE,
     RoadmapFollowProjectRequestSchema,
@@ -94,11 +93,13 @@ export class RoadmapService extends BaseService {
         assertRegisteredAccount(account);
         assertIsAccountWithOrg(account);
         if (
-            account.user.role !== OrganizationMemberRole.ADMIN ||
-            account.isServiceAccount()
+            this.createAuditedAbility(account).cannot(
+                'manage',
+                subject('Roadmap', { organizationUuid }),
+            )
         ) {
             throw new ForbiddenError(
-                'Only organization admins can request to follow roadmap projects',
+                'You do not have permission to request to follow roadmap projects',
             );
         }
         const parsed = RoadmapFollowProjectRequestSchema.safeParse(body);

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -93,37 +93,40 @@ describe('Organization member permissions', () => {
         );
     });
 
-    it('allows only admins to view their organization roadmap', () => {
-        const adminAbility =
-            defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
-        const memberAbility =
-            defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
+    it.each(['view', 'manage'] as const)(
+        'allows only admins to %s their organization roadmap',
+        (action) => {
+            const adminAbility =
+                defineAbilityForOrganizationMember(ORGANIZATION_ADMIN);
+            const memberAbility =
+                defineAbilityForOrganizationMember(ORGANIZATION_MEMBER);
 
-        expect(
-            adminAbility.can(
-                'view',
-                subject('Roadmap', {
-                    organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
-                }),
-            ),
-        ).toBe(true);
-        expect(
-            adminAbility.can(
-                'view',
-                subject('Roadmap', {
-                    organizationUuid: 'another-organization',
-                }),
-            ),
-        ).toBe(false);
-        expect(
-            memberAbility.can(
-                'view',
-                subject('Roadmap', {
-                    organizationUuid: ORGANIZATION_MEMBER.organizationUuid,
-                }),
-            ),
-        ).toBe(false);
-    });
+            expect(
+                adminAbility.can(
+                    action,
+                    subject('Roadmap', {
+                        organizationUuid: ORGANIZATION_ADMIN.organizationUuid,
+                    }),
+                ),
+            ).toBe(true);
+            expect(
+                adminAbility.can(
+                    action,
+                    subject('Roadmap', {
+                        organizationUuid: 'another-organization',
+                    }),
+                ),
+            ).toBe(false);
+            expect(
+                memberAbility.can(
+                    action,
+                    subject('Roadmap', {
+                        organizationUuid: ORGANIZATION_MEMBER.organizationUuid,
+                    }),
+                ),
+            ).toBe(false);
+        },
+    );
 
     describe('Member permissions', () => {
         let ability = defineAbilityForOrganizationMember(ORGANIZATION_VIEWER);

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -450,6 +450,9 @@ export const applyOrganizationMemberStaticAbilities: Record<
         can('view', 'Roadmap', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'Roadmap', {
+            organizationUuid: member.organizationUuid,
+        });
 
         can('manage', 'DataApp', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -212,6 +212,7 @@ const BASE_ROLE_SCOPES = {
         'manage:Organization',
         'manage:OrganizationColorPalette',
         'view:Roadmap',
+        'manage:Roadmap',
         'impersonate:User',
 
         // System roles take token access from the deployment config; listing
@@ -389,6 +390,7 @@ export const getNonEnterpriseScopesForRole = (
         'view:OrganizationDesign',
         'manage:OrganizationDesign',
         'view:Roadmap',
+        'manage:Roadmap',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',
     ]);

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -19,6 +19,57 @@ describe('scopeAbilityBuilder', () => {
         organizationUuid: 'org-123',
     };
 
+    it('grants organization roadmap management through a custom scope', () => {
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        buildAbilityFromScopes(
+            {
+                ...baseContextWithOrg,
+                isEnterprise: true,
+                scopes: ['manage:Roadmap'],
+            },
+            builder,
+        );
+        const ability = builder.build();
+        expect(
+            ability.can(
+                'manage',
+                subject('Roadmap', { organizationUuid: 'org-123' }),
+            ),
+        ).toBe(true);
+        expect(
+            ability.can(
+                'view',
+                subject('Roadmap', { organizationUuid: 'org-123' }),
+            ),
+        ).toBe(true);
+        expect(
+            ability.can(
+                'manage',
+                subject('Roadmap', { organizationUuid: 'different-org' }),
+            ),
+        ).toBe(false);
+    });
+
+    it('keeps roadmap view-only scopes read-only', () => {
+        const builder = new AbilityBuilder<MemberAbility>(Ability);
+        buildAbilityFromScopes(
+            {
+                ...baseContextWithOrg,
+                isEnterprise: true,
+                scopes: ['view:Roadmap'],
+            },
+            builder,
+        );
+        expect(
+            builder
+                .build()
+                .can(
+                    'manage',
+                    subject('Roadmap', { organizationUuid: 'org-123' }),
+                ),
+        ).toBe(false);
+    });
+
     it('should build ability with organization view permissions', () => {
         const builder = new AbilityBuilder<MemberAbility>(Ability);
         buildAbilityFromScopes(

--- a/packages/common/src/authorization/scopes.level.test.ts
+++ b/packages/common/src/authorization/scopes.level.test.ts
@@ -12,6 +12,7 @@ const ORG_ONLY_SCOPE_NAMES = [
     'view:Organization',
     'manage:Organization',
     'view:Roadmap',
+    'manage:Roadmap',
     'view:OrganizationMemberProfile',
     'manage:OrganizationMemberProfile',
     'manage:InviteLink',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -885,6 +885,15 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:Roadmap',
+        description: 'Request to follow organization roadmap projects',
+        isEnterprise: true,
+        group: ScopeGroup.ORGANIZATION_MANAGEMENT,
+        dependencies: [{ name: 'view:Roadmap' }],
+        level: 'organization',
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:OrganizationColorPalette',
         description:
             'Create, edit, delete, and activate organization color palettes',

--- a/packages/common/src/authorization/serviceAccountAbility.test.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.test.ts
@@ -25,6 +25,36 @@ const buildAbility = (scopes: ServiceAccountScope[]) => {
     return builder.build();
 };
 
+describe('roadmap management', () => {
+    it('grants legacy org admins management only within their organization', () => {
+        const ability = buildAbility([ServiceAccountScope.ORG_ADMIN]);
+        expect(
+            ability.can(
+                'manage',
+                subject('Roadmap', { organizationUuid: ORG }),
+            ),
+        ).toBe(true);
+        expect(
+            ability.can(
+                'manage',
+                subject('Roadmap', { organizationUuid: 'other-org' }),
+            ),
+        ).toBe(false);
+        expect(
+            buildAbility([ServiceAccountScope.ORG_READ]).can(
+                'manage',
+                subject('Roadmap', { organizationUuid: ORG }),
+            ),
+        ).toBe(false);
+        expect(
+            buildAbility([ServiceAccountScope.ORG_EDIT]).can(
+                'manage',
+                subject('Roadmap', { organizationUuid: ORG }),
+            ),
+        ).toBe(false);
+    });
+});
+
 describe('delegation permission footprints', () => {
     it.each(Object.values(ServiceAccountScope))(
         'derives %s from the permissions emitted by the ability builder',

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -253,6 +253,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('view', 'Roadmap', {
             organizationUuid,
         });
+        can('manage', 'Roadmap', {
+            organizationUuid,
+        });
         can('manage', 'PreAggregation', {
             organizationUuid,
         });

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -341,6 +341,7 @@ import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import { type ResultColumns, type ResultRow } from './results';
 import { type ApiResultsCacheProjectSettingsResponse } from './resultsCacheProjectSettings';
 import {
+    type ApiRoadmapFollowProjectResponse,
     type ApiRoadmapProjectResponse,
     type ApiRoadmapResponse,
 } from './roadmap';
@@ -1346,6 +1347,7 @@ type ApiResults =
     | ApiValidationSummaryResponse['results']
     | ApiRoadmapResponse['results']
     | ApiRoadmapProjectResponse['results']
+    | ApiRoadmapFollowProjectResponse['results']
     | ChartHistory
     | ChartVersion
     | DashboardHistory

--- a/packages/common/src/types/roadmap.ts
+++ b/packages/common/src/types/roadmap.ts
@@ -297,3 +297,31 @@ export type ApiRoadmapProjectResponse = {
     status: 'ok';
     results: RoadmapProjectResults;
 };
+
+export type RoadmapFollowProjectRequest = { note: string };
+export const RoadmapFollowProjectRequestSchema = z
+    .object({
+        note: z
+            .string()
+            .trim()
+            .min(1, 'Tell us why you are interested in this feature.')
+            .max(2000),
+    })
+    .strict();
+export type RoadmapFollowProjectResults = { message: string };
+export type ApiRoadmapFollowProjectResponse = {
+    status: 'ok';
+    results: RoadmapFollowProjectResults;
+};
+export const RoadmapFollowProjectResultsSchema: z.ZodType<RoadmapFollowProjectResults> =
+    z
+        .object({
+            message: z.string().min(1),
+        })
+        .strict();
+export const RoadmapFollowProjectResponseSchema = z
+    .object({
+        status: z.literal('ok'),
+        results: RoadmapFollowProjectResultsSchema,
+    })
+    .strict();

--- a/packages/frontend/src/ee/features/roadmap/FollowProjectButton.tsx
+++ b/packages/frontend/src/ee/features/roadmap/FollowProjectButton.tsx
@@ -1,0 +1,44 @@
+import { type RoadmapProjectGroup } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconStar } from '@tabler/icons-react';
+import MantineIcon from '../../../components/common/MantineIcon';
+
+export type FollowProjectAction = {
+    isLoading: boolean;
+    isSubmitted: boolean;
+    canFollow: boolean;
+    onFollow: () => void;
+};
+
+export function FollowProjectButton({
+    item,
+    isLoading,
+    isSubmitted,
+    canFollow,
+    onFollow,
+    className,
+    compact = false,
+}: FollowProjectAction & {
+    item: RoadmapProjectGroup;
+    className?: string;
+    compact?: boolean;
+}) {
+    if (!canFollow || item.hasDirectNeed || item.ownRequestCount > 0)
+        return null;
+
+    return (
+        <Button
+            color="indigo"
+            className={className}
+            size={compact ? 'compact-xs' : 'xs'}
+            leftSection={
+                <MantineIcon icon={IconStar} size={compact ? 12 : 16} />
+            }
+            loading={isLoading}
+            disabled={isSubmitted}
+            onClick={onFollow}
+        >
+            {isSubmitted ? 'Request sent' : 'Follow'}
+        </Button>
+    );
+}

--- a/packages/frontend/src/ee/features/roadmap/FollowProjectModal.tsx
+++ b/packages/frontend/src/ee/features/roadmap/FollowProjectModal.tsx
@@ -1,0 +1,75 @@
+import { RoadmapFollowProjectRequestSchema } from '@lightdash/common';
+import { Box, Button, Textarea } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { zod4Resolver as zodResolver } from 'mantine-form-zod-resolver';
+import Callout from '../../../components/common/Callout';
+import MantineModal from '../../../components/common/MantineModal';
+
+export function FollowProjectModal({
+    projectTitle,
+    isLoading,
+    onSubmit,
+    onClose,
+}: {
+    projectTitle: string;
+    isLoading: boolean;
+    onSubmit: (note: string) => Promise<boolean>;
+    onClose: () => void;
+}) {
+    const form = useForm({
+        initialValues: { note: '' },
+        validate: zodResolver(RoadmapFollowProjectRequestSchema),
+    });
+    const handleSubmit = form.onSubmit(async ({ note }) => {
+        if (isLoading) return;
+        if (await onSubmit(note.trim())) onClose();
+    });
+
+    return (
+        <MantineModal
+            opened
+            title={`Follow "${projectTitle}"`}
+            size="lg"
+            onClose={() => {
+                if (!isLoading) onClose();
+            }}
+            cancelDisabled={isLoading}
+            withCloseButton={!isLoading}
+            actions={
+                <Button
+                    color="indigo"
+                    type="submit"
+                    form="follow-roadmap-project-form"
+                    loading={isLoading}
+                    disabled={!form.isValid()}
+                >
+                    Send request
+                </Button>
+            }
+        >
+            <Box
+                component="form"
+                id="follow-roadmap-project-form"
+                onSubmit={handleSubmit}
+            >
+                <Callout variant="info" mb="md">
+                    Your organization and user details, including your name and
+                    email address, will be shared with the Lightdash team along
+                    with your note.
+                </Callout>
+                <Textarea
+                    label="Why are you interested in this feature?"
+                    placeholder="Tell us how your team would use it."
+                    required
+                    data-autofocus
+                    autosize
+                    minRows={4}
+                    maxRows={8}
+                    maxLength={2000}
+                    disabled={isLoading}
+                    {...form.getInputProps('note')}
+                />
+            </Box>
+        </MantineModal>
+    );
+}

--- a/packages/frontend/src/ee/features/roadmap/README.md
+++ b/packages/frontend/src/ee/features/roadmap/README.md
@@ -1,9 +1,7 @@
 # Lightdash roadmap
 
-The roadmap in Settings helps customers explore what Lightdash is building and track their organization’s feature requests. It brings projects and individual requests together in a board or table, with search and filters to find relevant work. Opening a project shows the requests their organization is following.
+The roadmap displays projects and organization-specific tickets in a board or table. The frontend reads this data through the Lightdash backend, which checks roadmap access and calls Lightdash Control Center using the instance license and the authenticated organization. Control Center provides the project catalog and organization-specific interest.
 
-Roadmap data comes from Linear through Lightdash Control Center. Control Center provides the shared project catalog and organization-specific requests; this feature presents them within Lightdash.
+When an organization admin requests to follow a project, the frontend sends their note to the backend. The backend adds the authenticated user and organization details before forwarding the request to Control Center. Control Center handles the interest request and notifies the Lightdash team; some requests require manual follow-up.
 
-Project-board header badges show the overall ticket total for each status. Columns show a stack above followed tickets for the remaining count: the overall status total minus the full followed-ticket count matching the column's filters, clamped to zero. Pagination does not change this count. Empty columns show ‘No items’ when the remaining count is zero. Overall totals include non-archived Product-team tickets and descendant-team tickets, independent of customer filters and the 30-day completed/canceled request window; canceled totals include duplicates. These counts do not grant access to additional ticket details. The project modal shows `lastIssueUpdatedAt` as “Last ticket update,” using an em dash when it is null.
-
-With a valid license but no Linear customer mapping (or a deleted customer), Control Center returns shared projects with empty organization relevance and requests. Lightdash defaults to All and opens project details without offering an empty project board. Private request access still requires the exact license-and-organization mapping; invalid licenses and existing Lightdash feature/permission checks remain enforced.
+After a successful submission, the frontend confirms receipt and refreshes the roadmap. Following state comes from server reads, and following a project does not grant access to additional tickets.

--- a/packages/frontend/src/ee/features/roadmap/README.md
+++ b/packages/frontend/src/ee/features/roadmap/README.md
@@ -2,6 +2,6 @@
 
 The roadmap displays projects and organization-specific tickets in a board or table. The frontend reads this data through the Lightdash backend, which checks roadmap access and calls Lightdash Control Center using the instance license and the authenticated organization. Control Center provides the project catalog and organization-specific interest.
 
-When an organization admin requests to follow a project, the frontend sends their note to the backend. The backend adds the authenticated user and organization details before forwarding the request to Control Center. Control Center handles the interest request and notifies the Lightdash team; some requests require manual follow-up.
+Users with the organization-level `manage:Roadmap` permission can request to follow projects; admins have this permission by default. When a user submits a request, the frontend sends their note to the backend. The backend adds the authenticated user and organization details before forwarding the request to Control Center. Control Center handles the interest request and notifies the Lightdash team; some requests require manual follow-up.
 
 After a successful submission, the frontend confirms receipt and refreshes the roadmap. Following state comes from server reads, and following a project does not grant access to additional tickets.

--- a/packages/frontend/src/ee/features/roadmap/RoadmapDetails.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapDetails.tsx
@@ -27,10 +27,12 @@ export function RoadmapDetails({
     propertiesLabel,
     children,
     actions,
+    headerActions,
     compact = false,
 }: {
     compact?: boolean;
     actions: ReactNode;
+    headerActions?: ReactNode;
     opened: boolean;
     onClose: () => void;
     title: string;
@@ -60,6 +62,7 @@ export function RoadmapDetails({
             }
             cancelLabel={false}
             actions={actions}
+            headerActions={headerActions}
             modalBodyProps={{ px: 0, py: 0 }}
             bodyScrollAreaMaxHeight="calc(85vh - 120px)"
         >

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjectDetails.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjectDetails.tsx
@@ -4,6 +4,10 @@ import {
     formatRoadmapDetailDate,
     getPriorityColor,
 } from '../../pages/roadmapUtils';
+import {
+    FollowProjectButton,
+    type FollowProjectAction,
+} from './FollowProjectButton';
 import { RoadmapDetails, RoadmapRailRow } from './RoadmapDetails';
 import styles from './RoadmapDetails.module.css';
 import { getProjectPresentation } from './roadmapPresentation';
@@ -13,11 +17,13 @@ export function RoadmapProjectDetails({
     status,
     onClose,
     onOpenBoard,
+    followAction,
 }: {
     item: RoadmapProjectGroup | null;
     status: { label: string; color: string };
     onClose: () => void;
     onOpenBoard: (() => void) | null;
+    followAction: FollowProjectAction;
 }) {
     const project = item ? getProjectPresentation(item.project) : null;
     return (
@@ -27,6 +33,11 @@ export function RoadmapProjectDetails({
             onClose={onClose}
             title={item?.project.title ?? 'Roadmap project'}
             propertiesLabel="Roadmap project properties"
+            headerActions={
+                item ? (
+                    <FollowProjectButton item={item} {...followAction} />
+                ) : null
+            }
             actions={
                 onOpenBoard ? (
                     <Button onClick={onOpenBoard} size="xs" variant="default">

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.module.css
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.module.css
@@ -182,9 +182,30 @@
 }
 
 .projectCard {
+    position: relative;
     padding: 0;
     gap: 0;
     overflow: hidden;
+}
+.projectFollowAction {
+    position: absolute;
+    top: var(--mantine-spacing-xs);
+    right: var(--mantine-spacing-xs);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease;
+}
+.projectCard:hover .projectFollowAction,
+.projectCard:focus-within .projectFollowAction,
+.projectFollowAction[data-loading] {
+    opacity: 1;
+    pointer-events: auto;
+}
+@media (hover: none) {
+    .projectFollowAction {
+        opacity: 1;
+        pointer-events: auto;
+    }
 }
 .projectCardBody {
     display: flex;

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
@@ -281,7 +281,7 @@ describe('following roadmap projects', () => {
         expect(screen.getByRole('button', { name: 'Follow' })).toBeEnabled();
     });
 
-    it('does not offer follow requests to non-admins', async () => {
+    it('does not offer follow requests without permission', async () => {
         renderRoadmap('org-1', false);
         await showAllProjects();
         expect(

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
@@ -1,0 +1,342 @@
+import {
+    act,
+    fireEvent,
+    screen,
+    waitFor,
+    within,
+} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { mockRoadmapProject, mockRoadmapResults } from './roadmap.mock';
+import { roadmapApi } from './roadmapApi';
+import { RoadmapProjects } from './RoadmapProjects';
+
+const { showToastError, showToastSuccess } = vi.hoisted(() => ({
+    showToastError: vi.fn(),
+    showToastSuccess: vi.fn(),
+}));
+const confirmation = {
+    message:
+        'The request has been sent to the Lightdash team and will soon be reviewed',
+};
+let hasDirectNeed = false;
+vi.mock('../../../hooks/toaster/useToaster', () => ({
+    default: () => ({ showToastError, showToastSuccess }),
+}));
+
+const renderRoadmap = (organizationUuid = 'org-1', canFollow = true) =>
+    renderWithProviders(
+        <MemoryRouter>
+            <RoadmapProjects
+                key={organizationUuid}
+                canFollow={canFollow}
+                cacheKey={`${organizationUuid}:user-1`}
+            />
+        </MemoryRouter>,
+    );
+
+describe('following roadmap projects', () => {
+    beforeEach(() => {
+        hasDirectNeed = false;
+        showToastSuccess.mockReset();
+        vi.spyOn(roadmapApi, 'followProject').mockImplementation(async () => {
+            hasDirectNeed = true;
+            return confirmation;
+        });
+        showToastError.mockReset();
+        vi.spyOn(roadmapApi, 'getProjects').mockImplementation(
+            async (query) => {
+                const projects = [
+                    { ...mockRoadmapProject('alpha'), hasDirectNeed },
+                    { ...mockRoadmapProject('direct'), hasDirectNeed: true },
+                    { ...mockRoadmapProject('tickets'), ownRequestCount: 2 },
+                ].filter(
+                    (group) =>
+                        (!query.onlyInterested ||
+                            group.hasDirectNeed ||
+                            group.ownRequestCount > 0) &&
+                        (!query.statuses ||
+                            query.statuses
+                                .split(',')
+                                .includes(group.project.stage)),
+                );
+                return mockRoadmapResults(projects);
+            },
+        );
+        vi.spyOn(roadmapApi, 'getRequests').mockResolvedValue({
+            data: [],
+            pagination: {
+                page: 1,
+                pageSize: 20,
+                totalIssues: 0,
+                totalPages: 0,
+            },
+            expiresAt: '2099-01-01T00:00:00Z',
+            facets: {
+                statusCounts: {
+                    Backlog: 0,
+                    Building: 0,
+                    Shipped: 0,
+                    Canceled: 0,
+                },
+                priorityCounts: {
+                    Urgent: 0,
+                    High: 0,
+                    Medium: 0,
+                    Low: 0,
+                    'No priority': 0,
+                },
+            },
+        });
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    const showAllProjects = async () => {
+        await screen.findByRole('button', { name: 'Open Project direct' });
+        await userEvent.click(screen.getByRole('radio', { name: 'All' }));
+        await screen.findByRole('button', { name: 'Open Project alpha' });
+    };
+
+    const note = 'Our team needs this feature.';
+    const submitNote = async () => {
+        const dialog = await screen.findByRole('dialog', {
+            name: 'Follow "Project alpha"',
+        });
+        await userEvent.type(within(dialog).getByRole('textbox'), note);
+        await userEvent.click(
+            within(dialog).getByRole('button', { name: 'Send request' }),
+        );
+        return dialog;
+    };
+
+    it('offers following only on unfollowed cards and keeps the card action independent', async () => {
+        const follow = vi.spyOn(roadmapApi, 'followProject');
+        renderRoadmap();
+        await showAllProjects();
+        expect(screen.getAllByRole('button', { name: 'Follow' })).toHaveLength(
+            1,
+        );
+        const button = screen.getByRole('button', { name: 'Follow' });
+        screen.getByRole('button', { name: 'Open Project alpha' }).focus();
+        await userEvent.keyboard('{Tab}');
+        expect(button).toHaveFocus();
+        await userEvent.keyboard('{Enter}');
+        expect(follow).not.toHaveBeenCalled();
+        await submitNote();
+        await waitFor(() =>
+            expect(
+                screen.queryByRole('button', { name: 'Follow' }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(follow).toHaveBeenCalledExactlyOnceWith({
+            projectId: 'alpha',
+            note,
+        });
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', {
+                name: 'Open project board for Project alpha',
+            }),
+        ).not.toBeInTheDocument();
+        await userEvent.click(screen.getByRole('radio', { name: 'Following' }));
+        expect(
+            await screen.findByRole('button', { name: 'Open Project alpha' }),
+        ).toBeInTheDocument();
+        await userEvent.click(screen.getByRole('radio', { name: 'Table' }));
+        expect(await screen.findByText('Project alpha')).toBeInTheDocument();
+        expect(screen.getByText('2 tickets')).toBeInTheDocument();
+    });
+
+    it('shares pending state and prevents duplicate submits across the card and modal', async () => {
+        const pending =
+            Promise.withResolvers<
+                Awaited<ReturnType<typeof roadmapApi.followProject>>
+            >();
+        const follow = vi
+            .spyOn(roadmapApi, 'followProject')
+            .mockReturnValueOnce(pending.promise);
+        renderRoadmap();
+        await showAllProjects();
+        const cardButton = screen.getByRole('button', {
+            name: 'Follow',
+        });
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Open Project alpha' }),
+        );
+        const dialog = await screen.findByRole('dialog');
+        const modalButton = within(dialog).getByRole('button', {
+            name: 'Follow',
+        });
+        await userEvent.click(modalButton);
+        const noteDialog = await screen.findByRole('dialog', {
+            name: 'Follow "Project alpha"',
+        });
+        await userEvent.type(within(noteDialog).getByRole('textbox'), note);
+        const submitButton = within(noteDialog).getByRole('button', {
+            name: 'Send request',
+        });
+        act(() => {
+            fireEvent.click(submitButton);
+            fireEvent.click(submitButton);
+        });
+        await waitFor(() => {
+            expect(modalButton).toBeDisabled();
+            expect(cardButton).toBeDisabled();
+            expect(submitButton).toBeDisabled();
+        });
+        expect(follow).toHaveBeenCalledOnce();
+        await act(async () => {
+            hasDirectNeed = true;
+            pending.resolve(confirmation);
+        });
+        await waitFor(() =>
+            expect(
+                within(dialog).queryByRole('button', {
+                    name: 'Follow',
+                }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(within(dialog).getByText('Following')).toBeInTheDocument();
+        expect(cardButton).not.toBeInTheDocument();
+        expect(
+            within(dialog).queryByRole('button', {
+                name: 'Open project board',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('shows an error without changing interest, then allows retry', async () => {
+        const follow = vi
+            .spyOn(roadmapApi, 'followProject')
+            .mockRejectedValueOnce(new Error('Service unavailable'));
+        renderRoadmap();
+        await showAllProjects();
+        await userEvent.click(screen.getByRole('button', { name: 'Follow' }));
+        const noteDialog = await submitNote();
+        await waitFor(() =>
+            expect(showToastError).toHaveBeenCalledWith(
+                expect.objectContaining({ title: 'Could not send request' }),
+            ),
+        );
+        expect(hasDirectNeed).toBe(false);
+        expect(within(noteDialog).getByRole('textbox')).toHaveValue(note);
+        const retry = within(noteDialog).getByRole('button', {
+            name: 'Send request',
+        });
+        expect(retry).toBeEnabled();
+        await userEvent.click(retry);
+        await waitFor(() =>
+            expect(
+                screen.queryByRole('button', { name: 'Follow' }),
+            ).not.toBeInTheDocument(),
+        );
+        expect(follow).toHaveBeenCalledTimes(2);
+    });
+
+    it('confirms receipt without inventing interest when manual follow-up is needed', async () => {
+        vi.mocked(roadmapApi.followProject).mockResolvedValue(confirmation);
+        renderRoadmap();
+        await showAllProjects();
+        await userEvent.click(screen.getByRole('button', { name: 'Follow' }));
+        await submitNote();
+        expect(
+            await screen.findByRole('button', { name: 'Request sent' }),
+        ).toBeDisabled();
+        expect(showToastSuccess).toHaveBeenCalledWith({
+            title: 'Request sent',
+            subtitle: confirmation.message,
+        });
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Open Project alpha' }),
+        );
+        const dialog = await screen.findByRole('dialog');
+        expect(
+            within(dialog).getByRole('button', { name: 'Request sent' }),
+        ).toBeDisabled();
+        expect(within(dialog).queryByText('Following')).not.toBeInTheDocument();
+        expect(hasDirectNeed).toBe(false);
+    });
+
+    it('loads interest from the server after remount and isolates organizations', async () => {
+        const first = renderRoadmap();
+        await showAllProjects();
+        await userEvent.click(screen.getByRole('button', { name: 'Follow' }));
+        await submitNote();
+        await waitFor(() => expect(hasDirectNeed).toBe(true));
+        first.unmount();
+        const second = renderRoadmap();
+        expect(
+            await screen.findByRole('button', { name: 'Open Project alpha' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: 'Follow' }),
+        ).not.toBeInTheDocument();
+        second.unmount();
+        hasDirectNeed = false;
+        renderRoadmap('org-2');
+        await showAllProjects();
+        expect(screen.getByRole('button', { name: 'Follow' })).toBeEnabled();
+    });
+
+    it('does not offer follow requests to non-admins', async () => {
+        renderRoadmap('org-1', false);
+        await showAllProjects();
+        expect(
+            screen.queryByRole('button', { name: 'Follow' }),
+        ).not.toBeInTheDocument();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'Open Project alpha' }),
+        );
+        expect(
+            within(await screen.findByRole('dialog')).queryByRole('button', {
+                name: 'Follow',
+            }),
+        ).not.toBeInTheDocument();
+    });
+
+    it('does not offer following inside an already followed project modal', async () => {
+        renderRoadmap();
+        await userEvent.click(
+            await screen.findByRole('button', { name: 'Open Project direct' }),
+        );
+        const dialog = await screen.findByRole('dialog');
+        expect(
+            within(dialog).queryByRole('button', { name: 'Follow' }),
+        ).not.toBeInTheDocument();
+        expect(within(dialog).getByText('Following')).toBeInTheDocument();
+    });
+
+    it('requires a nonblank note and cancels without following or keeping the draft', async () => {
+        const follow = vi.spyOn(roadmapApi, 'followProject');
+        renderRoadmap();
+        await showAllProjects();
+        await userEvent.click(screen.getByRole('button', { name: 'Follow' }));
+        const dialog = await screen.findByRole('dialog', {
+            name: 'Follow "Project alpha"',
+        });
+        const submit = within(dialog).getByRole('button', {
+            name: 'Send request',
+        });
+        expect(submit).toBeDisabled();
+        await userEvent.type(within(dialog).getByRole('textbox'), '   ');
+        expect(submit).toBeDisabled();
+        await userEvent.type(within(dialog).getByRole('textbox'), note);
+        expect(submit).toBeEnabled();
+        await userEvent.click(
+            within(dialog).getByRole('button', { name: 'Cancel' }),
+        );
+        await waitFor(() =>
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+        );
+        expect(follow).not.toHaveBeenCalled();
+        expect(hasDirectNeed).toBe(false);
+        await userEvent.click(screen.getByRole('button', { name: 'Follow' }));
+        const reopened = await screen.findByRole('dialog', {
+            name: 'Follow "Project alpha"',
+        });
+        expect(within(reopened).getByRole('textbox')).toHaveValue('');
+    });
+});

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.tsx
@@ -1,4 +1,5 @@
 import {
+    ROADMAP_DEFAULT_PAGE_SIZE,
     type RoadmapItem,
     type RoadmapProjectGroup,
     type RoadmapProject,
@@ -49,6 +50,11 @@ import { SettingsPage } from '../../../components/common/Settings/SettingsPage';
 import SuboptimalState from '../../../components/common/SuboptimalState/SuboptimalState';
 import { getPriorityColor } from '../../pages/roadmapUtils';
 import {
+    FollowProjectButton,
+    type FollowProjectAction,
+} from './FollowProjectButton';
+import { FollowProjectModal } from './FollowProjectModal';
+import {
     defaultProjectPresentation,
     getProjectPresentation,
     ticketStage,
@@ -58,6 +64,7 @@ import {
 import { RoadmapProjectDetails } from './RoadmapProjectDetails';
 import classes from './RoadmapProjects.module.css';
 import { RoadmapRequestDetails } from './RoadmapRequestDetails';
+import { useFollowRoadmapProject } from './useFollowRoadmapProject';
 import { useRoadmapBoard } from './useRoadmapBoard';
 import { useRoadmapProjects, useRoadmapRequests } from './useRoadmapProjects';
 
@@ -323,11 +330,13 @@ function ProjectCard({
     presentation,
     onClick,
     onOpenBoard,
+    followAction,
 }: {
     group: RoadmapProjectGroup;
     presentation: RoadmapProjectPresentation;
     onClick: () => void;
     onOpenBoard: (() => void) | null;
+    followAction: FollowProjectAction;
 }) {
     return (
         <Box className={classes.projectCard}>
@@ -374,6 +383,12 @@ function ProjectCard({
                 </Group>
                 <ProjectProgress value={presentation.progress} expanded />
             </UnstyledButton>
+            <FollowProjectButton
+                compact
+                className={classes.projectFollowAction}
+                item={group}
+                {...followAction}
+            />
             {onOpenBoard && (
                 <UnstyledButton
                     className={classes.projectCardFooter}
@@ -599,30 +614,41 @@ function RoadmapTable({ entries }: { entries: RoadmapEntry[] }) {
     );
 }
 
-function BoardError({
-    retry,
-    message = 'Could not load the roadmap',
-}: {
-    retry: () => void;
-    message?: string;
-}) {
+function BoardError() {
     return (
         <Box p="xl">
             <SuboptimalState
                 icon={IconAlertCircle}
-                title={message}
-                description="We couldn't refresh the board. Please try again."
-                action={
-                    <Button variant="default" onClick={retry}>
-                        Try again
-                    </Button>
-                }
+                title="Could not load the roadmap"
+                description="The roadmap is currently unavailable."
             />
         </Box>
     );
 }
 
-export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
+export function RoadmapProjects({
+    cacheKey,
+    canFollow,
+}: {
+    cacheKey: string;
+    canFollow: boolean;
+}) {
+    const { follow, submittedProjectIds, pendingProjectIds } =
+        useFollowRoadmapProject(cacheKey);
+    const [projectToFollow, setProjectToFollow] =
+        useState<RoadmapProjectGroup | null>(null);
+    const followAction = (
+        group: RoadmapProjectGroup | null,
+    ): FollowProjectAction => ({
+        canFollow,
+        isSubmitted:
+            group !== null &&
+            submittedProjectIds.includes(group.project.projectId),
+        isLoading:
+            group !== null &&
+            pendingProjectIds.includes(group.project.projectId),
+        onFollow: () => setProjectToFollow(group),
+    });
     const { pathname } = useLocation();
     const [view, setView] = useState('board');
     const [itemTypes, setItemTypes] = useState<string[]>([]);
@@ -642,7 +668,7 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
     );
     const [selectedProject, setSelectedProject] =
         useState<RoadmapProjectGroup | null>(null);
-    const [projectDetails, setProjectDetails] =
+    const [projectDetailsSelection, setProjectDetails] =
         useState<RoadmapProjectGroup | null>(null);
     const selectedProjectId = selectedProject?.project.projectId ?? null;
     const [selectedTicket, setSelectedTicket] = useState<RoadmapItem | null>(
@@ -652,7 +678,7 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
     const showProjects = !projectBoard && itemType !== 'tickets';
     const showTickets = projectBoard || itemType !== 'projects';
     const projectQuery: RoadmapProjectQuery = {
-        pageSize: COLUMN_PREVIEW_LIMIT,
+        pageSize: ROADMAP_DEFAULT_PAGE_SIZE,
         search: initializingInterest ? '' : debouncedMainSearch,
         onlyInterested: onlyInterested ?? true,
         statuses: initializingInterest ? '' : statusQuery(mainStatuses),
@@ -711,13 +737,17 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
               )
             : (projectsQuery.data?.pages ?? [])
     ).flatMap((page) => page.projects);
+    const projectDetails =
+        projects.find(
+            (group) =>
+                group.project.projectId ===
+                projectDetailsSelection?.project.projectId,
+        ) ?? projectDetailsSelection;
     const tickets = (
         view === 'board'
             ? boardQueries.flatMap((column) => column.tickets.data?.pages ?? [])
             : (ticketsQuery.data?.pages ?? [])
     ).flatMap((page) => page.data);
-    const { refetch: refetchProjects } = projectsQuery;
-    const { refetch: refetchTickets } = ticketsQuery;
     const presentation = getProjectPresentation(
         selectedProject?.project ?? defaultProjectPresentation,
     );
@@ -752,16 +782,6 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
         (error) => error?.error?.statusCode === 403,
     );
     const failed = errors.some(Boolean);
-    const retry = () => {
-        if (!initializingInterest && view === 'board') {
-            boardQueries.forEach((column) => {
-                void column.refetch();
-            });
-        } else {
-            void refetchProjects();
-            if (projectsQuery.isSuccess && showTickets) void refetchTickets();
-        }
-    };
     const back = () => {
         setSelectedProject(null);
         setProjectSearch('');
@@ -798,6 +818,7 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
                       card: (
                           <ProjectCard
                               group={group}
+                              followAction={followAction(group)}
                               presentation={metadata}
                               onClick={onOpen}
                               onOpenBoard={onOpenBoard}
@@ -1016,7 +1037,7 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
                     />
                 </Box>
             ) : failed ? (
-                <BoardError retry={retry} />
+                <BoardError />
             ) : loading ? (
                 <Box p="xl">
                     <EmptyStateLoader
@@ -1080,6 +1101,7 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
                 </>
             )}
             <RoadmapProjectDetails
+                followAction={followAction(projectDetails)}
                 item={failed ? null : projectDetails}
                 status={
                     columns.find(
@@ -1101,6 +1123,22 @@ export function RoadmapProjects({ cacheKey }: { cacheKey: string }) {
                 item={failed ? null : selectedTicket}
                 onClose={() => setSelectedTicket(null)}
             />
+            {!failed && projectToFollow && (
+                <FollowProjectModal
+                    key={projectToFollow.project.projectId}
+                    projectTitle={projectToFollow.project.title}
+                    isLoading={pendingProjectIds.includes(
+                        projectToFollow.project.projectId,
+                    )}
+                    onSubmit={(note) =>
+                        follow({
+                            projectId: projectToFollow.project.projectId,
+                            note,
+                        })
+                    }
+                    onClose={() => setProjectToFollow(null)}
+                />
+            )}
         </SettingsPage>
     );
 }

--- a/packages/frontend/src/ee/features/roadmap/roadmap.mock.ts
+++ b/packages/frontend/src/ee/features/roadmap/roadmap.mock.ts
@@ -1,0 +1,44 @@
+import {
+    RoadmapItemPriority,
+    RoadmapItemStatus,
+    type RoadmapProjectGroup,
+    type RoadmapProjectResults,
+} from '@lightdash/common';
+
+export function mockRoadmapProject(projectId: string): RoadmapProjectGroup {
+    return {
+        project: {
+            projectId,
+            title: `Project ${projectId}`,
+            description: 'A roadmap project',
+            stage: 'planned',
+            progress: 0,
+            priority: RoadmapItemPriority.MEDIUM,
+            issueStatusCounts: {
+                [RoadmapItemStatus.BACKLOG]: 5,
+                [RoadmapItemStatus.BUILDING]: 0,
+                [RoadmapItemStatus.SHIPPED]: 0,
+                [RoadmapItemStatus.CANCELED]: 0,
+            },
+            lastIssueUpdatedAt: null,
+        },
+        hasDirectNeed: false,
+        ownRequestCount: 0,
+    };
+}
+
+export function mockRoadmapResults(
+    projects: RoadmapProjectGroup[],
+): RoadmapProjectResults {
+    return {
+        projects,
+        otherRequestCount: 0,
+        expiresAt: '2099-01-01T00:00:00Z',
+        pagination: {
+            page: 1,
+            pageSize: 100,
+            totalResults: projects.length,
+            totalPages: projects.length ? 1 : 0,
+        },
+    };
+}

--- a/packages/frontend/src/ee/features/roadmap/roadmapApi.test.ts
+++ b/packages/frontend/src/ee/features/roadmap/roadmapApi.test.ts
@@ -1,0 +1,81 @@
+import { RoadmapFollowProjectRequestSchema } from '@lightdash/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../../api';
+import { mockRoadmapProject, mockRoadmapResults } from './roadmap.mock';
+import { roadmapApi } from './roadmapApi';
+
+vi.mock('../../../api', () => ({ lightdashApi: vi.fn() }));
+
+describe('roadmap API', () => {
+    beforeEach(() => vi.resetAllMocks());
+
+    it('posts only the note to the authenticated backend endpoint', async () => {
+        const result = { message: 'Request received' };
+        vi.mocked(lightdashApi).mockResolvedValue(result);
+        expect(
+            await roadmapApi.followProject({
+                projectId: 'project/id',
+                note: 'Our use case',
+            }),
+        ).toEqual(result);
+        expect(lightdashApi).toHaveBeenCalledExactlyOnceWith({
+            url: '/org/roadmap/projects/project%2Fid/follow',
+            method: 'POST',
+            sensitive: true,
+            body: JSON.stringify({ note: 'Our use case' }),
+            version: 'v1',
+        });
+    });
+
+    it('keeps server filtering and pagination without reading mock storage', async () => {
+        sessionStorage.setItem(
+            'ld.roadmap.mockFollows.org-1',
+            JSON.stringify(['alpha']),
+        );
+        const result = mockRoadmapResults([mockRoadmapProject('alpha')]);
+        vi.mocked(lightdashApi).mockResolvedValue(result);
+        expect(
+            await roadmapApi.getProjects({
+                page: 2,
+                pageSize: 10,
+                onlyInterested: true,
+                search: 'AI',
+                statuses: 'planned',
+            }),
+        ).toEqual(result);
+        expect(lightdashApi).toHaveBeenCalledExactlyOnceWith({
+            url: '/org/roadmap/projects?page=2&pageSize=10&onlyInterested=true&search=AI&statuses=planned',
+            method: 'GET',
+            body: undefined,
+            version: 'v1',
+        });
+        sessionStorage.clear();
+    });
+
+    it('propagates failures and rejects invalid confirmations', async () => {
+        vi.mocked(lightdashApi).mockRejectedValueOnce(new Error('Unavailable'));
+        await expect(
+            roadmapApi.followProject({ projectId: 'alpha', note: 'Use case' }),
+        ).rejects.toThrow('Unavailable');
+        vi.mocked(lightdashApi).mockResolvedValue({ message: '' });
+        await expect(
+            roadmapApi.followProject({ projectId: 'alpha', note: 'Use case' }),
+        ).rejects.toThrow();
+    });
+
+    it('requires a trimmed note with at most 2000 characters', () => {
+        expect(
+            RoadmapFollowProjectRequestSchema.parse({ note: '  Use case  ' }),
+        ).toEqual({ note: 'Use case' });
+        for (const note of ['', '   ', 'a'.repeat(2001)]) {
+            expect(
+                RoadmapFollowProjectRequestSchema.safeParse({ note }).success,
+            ).toBe(false);
+        }
+        expect(
+            RoadmapFollowProjectRequestSchema.safeParse({
+                note: 'a'.repeat(2000),
+            }).success,
+        ).toBe(true);
+    });
+});

--- a/packages/frontend/src/ee/features/roadmap/roadmapApi.ts
+++ b/packages/frontend/src/ee/features/roadmap/roadmapApi.ts
@@ -1,5 +1,8 @@
 import {
     RoadmapProjectResultsSchema,
+    RoadmapFollowProjectResultsSchema,
+    type RoadmapFollowProjectRequest,
+    type RoadmapFollowProjectResults,
     RoadmapProjectRequestsResultsSchema,
     type RoadmapProjectQuery,
     type RoadmapQuery,
@@ -7,14 +10,6 @@ import {
     type RoadmapProjectRequestsResults,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
-
-interface RoadmapApi {
-    getProjects: (query: RoadmapProjectQuery) => Promise<RoadmapProjectResults>;
-    getRequests: (
-        query: RoadmapQuery,
-    ) => Promise<RoadmapProjectRequestsResults>;
-}
-
 function queryString(query: RoadmapProjectQuery | RoadmapQuery) {
     return new URLSearchParams(
         Object.entries(query)
@@ -23,17 +18,33 @@ function queryString(query: RoadmapProjectQuery | RoadmapQuery) {
     ).toString();
 }
 
-export const roadmapApi: RoadmapApi = {
-    getProjects: async (query) =>
-        RoadmapProjectResultsSchema.parse(
-            await lightdashApi<RoadmapProjectResults>({
-                url: `/org/roadmap/projects?${queryString(query)}`,
-                method: 'GET',
-                body: undefined,
+async function getProjects(query: RoadmapProjectQuery) {
+    return RoadmapProjectResultsSchema.parse(
+        await lightdashApi<RoadmapProjectResults>({
+            url: `/org/roadmap/projects?${queryString(query)}`,
+            method: 'GET',
+            body: undefined,
+            version: 'v1',
+        }),
+    );
+}
+
+export const roadmapApi = {
+    followProject: async ({
+        projectId,
+        note,
+    }: RoadmapFollowProjectRequest & { projectId: string }) =>
+        RoadmapFollowProjectResultsSchema.parse(
+            await lightdashApi<RoadmapFollowProjectResults>({
+                url: `/org/roadmap/projects/${encodeURIComponent(projectId)}/follow`,
+                method: 'POST',
+                sensitive: true,
+                body: JSON.stringify({ note }),
                 version: 'v1',
             }),
         ),
-    getRequests: async (query) =>
+    getProjects,
+    getRequests: async (query: RoadmapQuery) =>
         RoadmapProjectRequestsResultsSchema.parse(
             await lightdashApi<RoadmapProjectRequestsResults>({
                 url: `/org/roadmap?${queryString(query)}`,

--- a/packages/frontend/src/ee/features/roadmap/useFollowRoadmapProject.ts
+++ b/packages/frontend/src/ee/features/roadmap/useFollowRoadmapProject.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
+import useToaster from '../../../hooks/toaster/useToaster';
+import { roadmapApi } from './roadmapApi';
+export function useFollowRoadmapProject(cacheKey: string) {
+    const queryClient = useQueryClient();
+    const { showToastError, showToastSuccess } = useToaster();
+    const inFlight = useRef(new Set<string>());
+    const [pendingProjectIds, setPendingProjectIds] = useState<string[]>([]);
+    const [submittedProjectIds, setSubmittedProjectIds] = useState<string[]>(
+        [],
+    );
+    const { mutateAsync } = useMutation({
+        mutationFn: roadmapApi.followProject,
+        retry: false,
+        onSuccess: ({ message }, { projectId }) => {
+            setSubmittedProjectIds((ids) => [...new Set([...ids, projectId])]);
+            showToastSuccess({ title: 'Request sent', subtitle: message });
+            void queryClient.invalidateQueries({
+                queryKey: ['roadmap-projects', cacheKey],
+            });
+        },
+    });
+
+    const follow = async (
+        interest: Parameters<typeof roadmapApi.followProject>[0],
+    ): Promise<boolean> => {
+        const { projectId } = interest;
+        if (inFlight.current.has(projectId)) return false;
+        inFlight.current.add(projectId);
+        setPendingProjectIds([...inFlight.current]);
+        try {
+            await mutateAsync(interest);
+            return true;
+        } catch {
+            showToastError({
+                title: 'Could not send request',
+                subtitle: 'Your note has been kept. Please try again.',
+            });
+            return false;
+        } finally {
+            inFlight.current.delete(projectId);
+            setPendingProjectIds([...inFlight.current]);
+        }
+    };
+
+    return { follow, submittedProjectIds, pendingProjectIds };
+}

--- a/packages/frontend/src/ee/features/roadmap/useFollowRoadmapProject.ts
+++ b/packages/frontend/src/ee/features/roadmap/useFollowRoadmapProject.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRef, useState } from 'react';
 import useToaster from '../../../hooks/toaster/useToaster';
 import { roadmapApi } from './roadmapApi';
+
 export function useFollowRoadmapProject(cacheKey: string) {
     const queryClient = useQueryClient();
     const { showToastError, showToastSuccess } = useToaster();

--- a/packages/frontend/src/ee/features/roadmap/useRoadmapBoard.ts
+++ b/packages/frontend/src/ee/features/roadmap/useRoadmapBoard.ts
@@ -81,11 +81,6 @@ function useColumn(
                     : undefined,
                 options.showTickets ? fetchRemainingPages(tickets) : undefined,
             ]),
-        refetch: () =>
-            Promise.all([
-                options.showProjects ? projects.refetch() : undefined,
-                options.showTickets ? tickets.refetch() : undefined,
-            ]),
     };
 }
 

--- a/packages/frontend/src/ee/pages/Roadmap.test.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.test.tsx
@@ -1,0 +1,60 @@
+import { Ability, AbilityBuilder } from '@casl/ability';
+import { OrganizationMemberRole, type MemberAbility } from '@lightdash/common';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Roadmap from './Roadmap';
+
+const { useApp, renderProjects } = vi.hoisted(() => ({
+    useApp: vi.fn(),
+    renderProjects: vi.fn(() => null),
+}));
+vi.mock('../../providers/App/useApp', () => ({ default: useApp }));
+vi.mock('../features/roadmap/RoadmapProjects', () => ({
+    RoadmapProjects: renderProjects,
+}));
+
+describe('roadmap follow access', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it.each([
+        {
+            role: OrganizationMemberRole.MEMBER,
+            action: 'manage',
+            organizationUuid: 'org-1',
+            allowed: true,
+        },
+        {
+            role: OrganizationMemberRole.ADMIN,
+            action: 'view',
+            organizationUuid: 'org-1',
+            allowed: false,
+        },
+        {
+            role: OrganizationMemberRole.MEMBER,
+            action: 'manage',
+            organizationUuid: 'org-2',
+            allowed: false,
+        },
+    ] as const)(
+        'uses the current organization ability: %j',
+        ({ role, action, organizationUuid, allowed }) => {
+            const builder = new AbilityBuilder<MemberAbility>(Ability);
+            builder.can(action, 'Roadmap', { organizationUuid });
+            useApp.mockReturnValue({
+                user: {
+                    data: {
+                        organizationUuid: 'org-1',
+                        userUuid: 'user-1',
+                        role,
+                        ability: builder.build(),
+                    },
+                },
+            });
+            render(<Roadmap />);
+            expect(renderProjects).toHaveBeenCalledWith(
+                expect.objectContaining({ canFollow: allowed }),
+                undefined,
+            );
+        },
+    );
+});

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -1,4 +1,4 @@
-import { OrganizationMemberRole } from '@lightdash/common';
+import { subject } from '@casl/ability';
 import EmptyStateLoader from '../../components/common/EmptyStateLoader';
 import useApp from '../../providers/App/useApp';
 import { RoadmapProjects } from '../features/roadmap/RoadmapProjects';
@@ -11,7 +11,12 @@ export default function Roadmap() {
         <RoadmapProjects
             key={user.data.organizationUuid}
             cacheKey={`${user.data.organizationUuid}:${user.data.userUuid}`}
-            canFollow={user.data.role === OrganizationMemberRole.ADMIN}
+            canFollow={user.data.ability.can(
+                'manage',
+                subject('Roadmap', {
+                    organizationUuid: user.data.organizationUuid,
+                }),
+            )}
         />
     );
 }

--- a/packages/frontend/src/ee/pages/Roadmap.tsx
+++ b/packages/frontend/src/ee/pages/Roadmap.tsx
@@ -1,3 +1,4 @@
+import { OrganizationMemberRole } from '@lightdash/common';
 import EmptyStateLoader from '../../components/common/EmptyStateLoader';
 import useApp from '../../providers/App/useApp';
 import { RoadmapProjects } from '../features/roadmap/RoadmapProjects';
@@ -10,6 +11,7 @@ export default function Roadmap() {
         <RoadmapProjects
             key={user.data.organizationUuid}
             cacheKey={`${user.data.organizationUuid}:${user.data.userUuid}`}
+            canFollow={user.data.role === OrganizationMemberRole.ADMIN}
         />
     );
 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-11018

### Description:

Users with the organization-level `manage:Roadmap` permission can request to follow projects from hover actions or project details, with a required note.
The new scope is granted to admins by default and supports custom roles and service accounts, with organization checks in both frontend and backend and no custom-role migration required.
Following state refreshes from the server, project pages fetch 100 items, roadmap fetch errors no longer offer retry, and the README explains the request flow.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.
