### PR TITLE
fix: explain skipped joins in compile warnings and query errors

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -4,8 +4,10 @@ import {
     CompiledMetricQuery,
     CompileError,
     CustomDimensionType,
+    DEFAULT_SPOTLIGHT_CONFIG,
     DimensionType,
     Explore,
+    ExploreCompiler,
     FieldType,
     FilterOperator,
     ForbiddenError,
@@ -98,6 +100,51 @@ const buildQuery = (
         ...args,
         parameterDefinitions: {},
     }).compileQuery();
+
+describe('skipped joins', () => {
+    it('returns an actionable compile error for a metric query depending on a skipped join', () => {
+        const explore = new ExploreCompiler(warehouseClientMock, {
+            allowPartialCompilation: true,
+        }).compileExplore({
+            ...EXPLORE,
+            meta: {},
+            spotlightConfig: DEFAULT_SPOTLIGHT_CONFIG,
+            tables: {
+                ...EXPLORE.tables,
+                table1: {
+                    ...EXPLORE.tables.table1,
+                    sqlWhere: '${details.dim2} IS NOT NULL',
+                },
+            },
+            joinedTables: [
+                {
+                    table: 'accounts',
+                    alias: 'account',
+                    sqlOn: '${table1.dim1} = ${account.id}',
+                },
+                {
+                    table: 'table2',
+                    alias: 'details',
+                    sqlOn: '${account.id} = ${details.dim2}',
+                },
+            ],
+        });
+        expect(explore.joinedTables).toEqual([]);
+
+        const query = () =>
+            buildQuery({
+                explore,
+                compiledMetricQuery: METRIC_QUERY,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: {},
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+        expect(query).toThrow(CompileError);
+        expect(query).toThrow(/Join "details" is not available/);
+        expect(query).toThrow(/account.*accounts/);
+        expect(query).toThrow(/tags\/selector/);
+    });
+});
 
 describe('field compilation errors', () => {
     const exploreWithErroredDimension: Explore = {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2740,6 +2740,7 @@ export class MetricQueryBuilder {
         const { tablesWithMetricInflation, joinWithoutRelationship } =
             findTablesWithMetricInflation({
                 tables: explore.tables,
+                warnings: explore.warnings,
                 possibleJoins: explore.joinedTables,
                 baseTable: explore.baseTable,
                 joinedTables,

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -165,6 +165,57 @@ test('Should throw error when missing base table', () => {
     );
 });
 
+test('Missing joins explain model selection and identify the alias', () => {
+    const partialCompiler = new ExploreCompiler(warehouseClientMock, {
+        allowPartialCompilation: true,
+    });
+    const result = partialCompiler.compileExplore({
+        ...exploreMissingJoinTable,
+        joinedTables: [{ table: 'b', alias: 'account', sqlOn: '' }],
+    });
+
+    expect(result.joinedTables).toEqual([]);
+    expect(result.warnings).toEqual([
+        {
+            type: InlineErrorType.MISSING_TABLE,
+            message:
+                'Join "account" to table "b" was skipped because the model is not available in this Lightdash project. Check that the model exists, is included by the project\'s tags/selector, and compiles successfully, then refresh the project.',
+        },
+    ]);
+});
+
+test('Dependent joins point to the skipped alias and its unavailable model', () => {
+    const partialCompiler = new ExploreCompiler(warehouseClientMock, {
+        allowPartialCompilation: true,
+    });
+    const result = partialCompiler.compileExplore({
+        ...simpleJoinedExplore,
+        joinedTables: [
+            {
+                table: 'accounts',
+                alias: 'account',
+                sqlOn: '${a.dim1} = ${account.dim1}',
+            },
+            {
+                table: 'b',
+                alias: 'details',
+                sqlOn: '${account.dim1} = ${details.dim1}',
+            },
+        ],
+    });
+
+    expect(result.joinedTables).toEqual([]);
+    expect(Object.keys(result.tables)).toEqual(['a']);
+    expect(result.warnings).toEqual([
+        expect.objectContaining({ type: InlineErrorType.MISSING_TABLE }),
+        {
+            type: InlineErrorType.SKIPPED_JOIN,
+            message:
+                'Join "details" was skipped because it depends on skipped join "account" (table "accounts"). Resolve the missing-table warning for that join, then refresh the project.',
+        },
+    ]);
+});
+
 test('Should throw error when missing joined table', () => {
     expect(() => compiler.compileExplore(exploreMissingJoinTable)).toThrowError(
         CompileError,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -462,7 +462,7 @@ export class ExploreCompiler {
                   if (tables[join.table] === undefined) {
                       exploreWarnings.push({
                           type: InlineErrorType.MISSING_TABLE,
-                          message: `Join to table "${join.table}" was skipped because the table does not exist`,
+                          message: `Join "${join.alias || join.table}" to table "${join.table}" was skipped because the model is not available in this Lightdash project. Check that the model exists, is included by the project's tags/selector, and compiles successfully, then refresh the project.`,
                       });
                       return false;
                   }
@@ -664,6 +664,20 @@ export class ExploreCompiler {
             const tableName = j.alias || j.table;
             if (this.options.allowPartialCompilation) {
                 try {
+                    const references = parseAllReferences(j.sqlOn, tableName);
+                    const missingJoin = joinedTables.find(
+                        (join) =>
+                            !tables[join.table] &&
+                            references.some(
+                                ({ refTable }) =>
+                                    refTable === (join.alias || join.table),
+                            ),
+                    );
+                    if (missingJoin) {
+                        throw new CompileError(
+                            `Join "${tableName}" was skipped because it depends on skipped join "${missingJoin.alias || missingJoin.table}" (table "${missingJoin.table}"). Resolve the missing-table warning for that join, then refresh the project.`,
+                        );
+                    }
                     return {
                         join: j,
                         compiled: this.compileJoin(

--- a/packages/common/src/compiler/joinInflation.test.ts
+++ b/packages/common/src/compiler/joinInflation.test.ts
@@ -1,0 +1,35 @@
+import { CompileError } from '../types/errors';
+import { JoinRelationship } from '../types/explore';
+import { findTablesWithMetricInflation } from './joinInflation';
+
+describe('findTablesWithMetricInflation', () => {
+    it.each([JoinRelationship.ONE_TO_MANY, JoinRelationship.MANY_TO_MANY])(
+        'rejects missing joins without cached warnings, even with a %s join',
+        (relationship) => {
+            const analyze = () =>
+                findTablesWithMetricInflation({
+                    baseTable: 'orders',
+                    joinedTables: new Set(['orders', 'items', 'account']),
+                    possibleJoins: [
+                        {
+                            table: 'items',
+                            sqlOn: '',
+                            compiledSqlOn: '',
+                            relationship,
+                            tablesReferences: ['orders', 'items'],
+                        },
+                    ],
+                    tables: {
+                        orders: { primaryKey: ['id'] },
+                        items: { primaryKey: ['id'] },
+                    },
+                });
+
+            expect(analyze).toThrow(CompileError);
+            expect(analyze).toThrow(
+                /Join "account" is not available for base table "orders"/,
+            );
+            expect(analyze).toThrow(/compilation warnings.*tags\/selector/);
+        },
+    );
+});

--- a/packages/common/src/compiler/joinInflation.ts
+++ b/packages/common/src/compiler/joinInflation.ts
@@ -1,5 +1,7 @@
 import { intersection } from 'lodash';
+import { CompileError } from '../types/errors';
 import {
+    InlineErrorType,
     JoinRelationship,
     type CompiledExploreJoin,
     type CompiledTable,
@@ -17,6 +19,7 @@ export type FindTablesWithMetricInflationArgs = {
     baseTable: Explore['baseTable'];
     /** Tables the query actually joins. */
     joinedTables: Set<string>;
+    warnings?: Explore['warnings'];
 };
 
 /*
@@ -140,6 +143,7 @@ export const findTablesWithMetricInflation = ({
     joinedTables,
     possibleJoins,
     tables,
+    warnings,
 }: FindTablesWithMetricInflationArgs): {
     tablesWithMetricInflation: Set<string>;
     joinWithoutRelationship: Set<string>;
@@ -148,6 +152,26 @@ export const findTablesWithMetricInflation = ({
     const tablesWithMetricInflation = new Set<string>();
     const joinWithoutRelationship = new Set<string>();
     const tablesWithoutPrimaryKey = new Set<string>();
+
+    const missingJoin = [...joinedTables].find(
+        (table) =>
+            table !== baseTable &&
+            !possibleJoins.some((join) => join.table === table),
+    );
+    if (missingJoin) {
+        const joinWarnings = (warnings ?? []).filter(
+            ({ type }) =>
+                type === InlineErrorType.MISSING_TABLE ||
+                type === InlineErrorType.SKIPPED_JOIN,
+        );
+        throw new CompileError(
+            `Join "${missingJoin}" is not available for base table "${baseTable}". Check the model's compilation warnings and the project's tags/selector, then refresh the project.${
+                joinWarnings.length > 0
+                    ? ` Join compilation warnings: ${joinWarnings.map(({ message }) => message).join(' ')}`
+                    : ''
+            }`,
+        );
+    }
 
     // Check if any join has a many-to-many relationship
     const hasManyToManyJoin = Array.from(joinedTables).some((joinedTable) => {
@@ -181,12 +205,10 @@ export const findTablesWithMetricInflation = ({
                 return;
             }
 
+            // All query joins were validated above.
             const join = possibleJoins.find(
                 (possibleJoin) => possibleJoin.table === joinedTable,
-            );
-            if (!join) {
-                throw new Error(`Join ${joinedTable} not found`);
-            }
+            )!;
             if (!join.tablesReferences) {
                 // Skip, as we can't detect inflation without knowing table references in join SQL
                 return;

--- a/packages/e2e/cypress/cli/integration/cli.cy.ts
+++ b/packages/e2e/cypress/cli/integration/cli.cy.ts
@@ -63,8 +63,15 @@ describe('deploy', () => {
 describe('preview', () => {
     const previewName = `e2e preview ${new Date().getTime()}`;
 
+    after(() => {
+        cy.login();
+        cy.deleteProjectsByName([previewName]);
+    });
+
     it('Should start-preview', () => {
         cy.login();
+        // A failed attempt may have created the preview before timing out.
+        cy.deleteProjectsByName([previewName]);
         cy.getApiToken().then((apiToken) => {
             cy.exec(
                 `${cliCommand} start-preview --project-dir ${projectDir} --profiles-dir ${profilesDir} --name "${previewName}"`,


### PR DESCRIPTION
## What changed

## Summary
- Explain skipped joins with their alias/model and actionable guidance on model selection, compilation, and refresh.
- Point dependent-join warnings at the unavailable intermediate join, and return a user-facing `CompileError` with available diagnostics without bypassing fanout protection.
- Cover partial compilation through query building, older explores without warnings, and missing joins alongside many-to-many joins.
- Fix the CLI creation test's retry-state leak: remove only its uniquely named leftover preview before each creation attempt, then clean up after the suite. Keep creation, credential-refresh, and deletion assertions unchanged.

## CI follow-up
The retry failure was reproduced by forcing an interruption after preview creation: the old test then reported `Project updated` instead of `New project created`; the cleanup allows the retry to succeed. No timeouts, credentials, permissions, or required checks were weakened.

**The green-CI acceptance gate remains outstanding.** Local reproduction passed the affected flows listed below, but the broader remote timing failures are not established as resolved by this patch.

## Verification

Follow-up commit: 8ff012bccfcf915150049706545c072bfbd63582. Worktree clean; commit hooks and `git diff --check` passed.

Passed on the private local runtime:
- `CYPRESS_RETRIES=0 pnpm -F e2e exec cypress run --browser electron --config 'baseUrl=http://127.0.0.1:3000,video=false' --spec 'cypress/cli/integration/cli.cy.ts'` — 5/5 tests passed, including creation, same-name credential refresh, and stop-preview.
- Retry red/green experiment using the same spec with `CYPRESS_RETRIES=1`: temporarily force the first attempt to fail after successful creation and focus the preview suite. Without pre-attempt cleanup: 2 passed, 1 failed with `Project updated` versus the required creation message. With cleanup: all 3 passed, including recovery on retry. All temporary fault-injection/focus edits were removed before review and commit.
- `CYPRESS_RETRIES=0 pnpm -F e2e exec cypress run --browser electron --config 'baseUrl=http://127.0.0.1:3000,video=false' --spec 'cypress/e2e/app/fullscreenModal.cy.ts,cypress/e2e/app/login.cy.ts,cypress/e2e/app/pivotTables.cy.ts,cypress/e2e/app/savedDashboards.cy.ts'` — 4 specs passed; 8 passing tests, 4 existing pending tests.
- Same Cypress command with `--spec 'cypress/e2e/app/globalSearch.cy.ts,cypress/e2e/app/minimal.cy.ts,cypress/e2e/app/dateZoom.cy.ts'` — 3 specs, 8 tests passed.
- `SITE_URL=http://127.0.0.1:3000 pnpm -F api-tests test:api tests/mergeQuery.test.ts` — 1 file, 12 Postgres tests passed. Remote warehouse parity was not exercised locally.
- Correlated live API logs and Maple traces: the local merge-query request completed successfully; the CI slowdown was not reproduced by this local run.

Static validation:
- `pnpm -F e2e exec oxfmt cypress/cli/integration/cli.cy.ts --check` — passed.
- `pnpm -F e2e lint` — passed.
- `pnpm -F e2e exec tsc6 --ignoreConfig --noEmit --skipLibCheck --strict --target ES2020 --moduleResolution node --types cypress,@testing-library/cypress,node --ignoreDeprecations 6.0 --module commonjs --esModuleInterop cypress/cli/integration/cli.cy.ts cypress/support/commands.ts` — passed on final code.
- `pnpm cli-build`, `pnpm -F cli typecheck`, `pnpm -F query-sdk typecheck` — passed after installing the missing workspace dependencies with Socket Firewall (`sfw pnpm install --frozen-lockfile --no-runtime`). No dependency manifests or lockfiles changed.
- Full e2e `pnpm -F e2e exec tsc6 --noEmit` remains failing in untouched files (duplicate script globals, dates/minimal implicit-any errors, and other existing package-wide type errors). The package does not define a typecheck script; the changed spec and its helper typecheck successfully with the focused command above.

Outstanding verification:
- Last inspected remote run 34505123664 on da3d7b061903f7ccabcf2bd1a676f8e1053fd445 is still failed: all five App shards, CLI Integration, CLI Without dbt; API cancelled at its 25-minute limit. Build & Test passed. No new remote run can occur until host publication; no green-CI claim is made.
- Local `contentAsCode.cy.ts` run: 1 passed, 6 failed during download, before the upload timeout seen in CI. Direct `pnpm exec lightdash download` identified a local fixture/runtime limitation: seeded custom chart `seed-data-app-visualization` cannot be downloaded because `appGenerateService` has no factory/provider. No unrelated service/authorization changes were made. This does not reproduce or resolve the remote upload timeout.
- Initial local browser attempts were blocked by missing Xvfb/CLI executable setup and a stale runtime after dependency installation; the passing runs above followed toolchain setup and runtime reconciliation.

Previously completed checks for the unchanged production patch: common related tests 18 files/808 tests; backend related tests 29 files/950 tests; common lint/build/typecheck and backend/frontend/warehouses typechecks passed.

Independent reviews of this follow-up: Standards — no findings; Spec — no code findings, with the remote green-CI acceptance gate explicitly outstanding.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-11166-e25207f547e5.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-11166](https://linear.app/lightdash/issue/PROD-11166)

