### PR TITLE
fix(underlying-data): include the explore base table in underlying data columns

### DIFF
--- a/packages/api-tests/tests/underlyingDataColumns.test.ts
+++ b/packages/api-tests/tests/underlyingDataColumns.test.ts
@@ -1,0 +1,167 @@
+import { SEED_PROJECT } from '@lightdash/common';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient, Body } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+
+const apiUrl = '/api/v2';
+const projectUuid = SEED_PROJECT.project_uuid;
+
+type QueryResults = {
+    status: string;
+    error?: { message: string } | string | null;
+};
+
+type UnderlyingDataResults = {
+    queryUuid: string;
+    metricQuery: {
+        dimensions: string[];
+        metrics: string[];
+    };
+};
+
+async function waitUntilReady(
+    client: ApiClient,
+    queryUuid: string,
+): Promise<void> {
+    // Up to 60s (300 × 200ms) to tolerate slow CI / cold caches.
+    for (let i = 0; i < 300; i += 1) {
+        const resp = await client.get<Body<QueryResults>>(
+            `${apiUrl}/projects/${projectUuid}/query/${queryUuid}?page=1&pageSize=1`,
+        );
+        const { results } = resp.body;
+        if (results.error) {
+            const message =
+                typeof results.error === 'string'
+                    ? results.error
+                    : results.error.message;
+            throw new Error(`Query failed: ${message}`);
+        }
+        if (results.status === 'ready') {
+            return;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+    }
+    throw new Error(`Query ${queryUuid} did not complete in time`);
+}
+
+async function runMetricQuery(
+    client: ApiClient,
+    exploreName: string,
+    metrics: string[],
+): Promise<string> {
+    const resp = await client.post<Body<{ queryUuid: string }>>(
+        `${apiUrl}/projects/${projectUuid}/query/metric-query`,
+        {
+            context: 'exploreView',
+            query: {
+                exploreName,
+                dimensions: [],
+                metrics,
+                filters: {},
+                sorts: [],
+                limit: 500,
+                tableCalculations: [],
+                additionalMetrics: [],
+            },
+        },
+    );
+    expect(resp.status).toBe(200);
+    const { queryUuid } = resp.body.results;
+    await waitUntilReady(client, queryUuid);
+    return queryUuid;
+}
+
+async function runUnderlyingData(
+    client: ApiClient,
+    sourceQueryUuid: string,
+    underlyingDataItemId: string,
+): Promise<UnderlyingDataResults> {
+    const resp = await client.post<Body<UnderlyingDataResults>>(
+        `${apiUrl}/projects/${projectUuid}/query/underlying-data`,
+        {
+            context: 'viewUnderlyingData',
+            underlyingDataSourceQueryUuid: sourceQueryUuid,
+            underlyingDataItemId,
+            filters: {},
+        },
+    );
+    expect(resp.status).toBe(200);
+    return resp.body.results;
+}
+
+const columnsOf = (results: UnderlyingDataResults): string[] =>
+    [...results.metricQuery.dimensions, ...results.metricQuery.metrics].sort();
+
+/**
+ * `orders.fulfillment_rate` declares `show_underlying_values` with two
+ * `orders` fields and `customers.first_name`. The columns must not depend on
+ * which table is the explore's base table.
+ */
+describe('underlying data columns', () => {
+    let admin: ApiClient;
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    it('keeps base-table show_underlying_values columns when the query has no base-table field', async () => {
+        const sourceQueryUuid = await runMetricQuery(admin, 'customers', [
+            'orders_fulfillment_rate',
+        ]);
+
+        const results = await runUnderlyingData(
+            admin,
+            sourceQueryUuid,
+            'orders_fulfillment_rate',
+        );
+
+        expect(results.metricQuery.dimensions).toContain(
+            'customers_first_name',
+        );
+        expect(columnsOf(results)).toEqual([
+            'customers_first_name',
+            'orders_status',
+            'orders_total_order_amount',
+        ]);
+        await waitUntilReady(admin, results.queryUuid);
+    });
+
+    it('returns the same columns when the metric table is the base table', async () => {
+        const sourceQueryUuid = await runMetricQuery(admin, 'orders', [
+            'orders_fulfillment_rate',
+        ]);
+
+        const results = await runUnderlyingData(
+            admin,
+            sourceQueryUuid,
+            'orders_fulfillment_rate',
+        );
+
+        expect(columnsOf(results)).toEqual([
+            'customers_first_name',
+            'orders_status',
+            'orders_total_order_amount',
+        ]);
+        await waitUntilReady(admin, results.queryUuid);
+    });
+
+    it('applies the base table default_show_underlying_values when the query only uses joined-table fields', async () => {
+        // `payments` declares `default_show_underlying_values` with
+        // `orders.customer_id` and the base-table metric `unique_payment_count`.
+        const sourceQueryUuid = await runMetricQuery(admin, 'payments', [
+            'orders_unique_order_count',
+        ]);
+
+        const results = await runUnderlyingData(
+            admin,
+            sourceQueryUuid,
+            'orders_unique_order_count',
+        );
+
+        expect(results.metricQuery.dimensions).toEqual(['orders_customer_id']);
+        expect(results.metricQuery.metrics).toEqual([
+            'payments_unique_payment_count',
+        ]);
+        await waitUntilReady(admin, results.queryUuid);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -259,6 +259,7 @@ import { type ComposeEngineClient } from './ComposeEngineClient';
 import { getValidatedDashboardSorts } from './dashboardSorts';
 import { DuckdbQueryRefusal } from './DuckdbQueryRefusal';
 import { getPivotedColumns } from './getPivotedColumns';
+import { getUnderlyingDataAvailableTables } from './getUnderlyingDataAvailableTables';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
     applyDashboardFiltersToMergeQuery,
@@ -7070,16 +7071,10 @@ export class AsyncQueryService extends ProjectService {
             ? metricQueryFields[underlyingDataItemId]
             : undefined;
 
-        const joinedTables = explore.joinedTables.map(
-            (joinedTable) => joinedTable.table,
+        const availableTables = getUnderlyingDataAvailableTables(
+            explore,
+            metricQueryFields,
         );
-
-        const availableTables = new Set([
-            ...joinedTables,
-            ...Object.values(metricQueryFields)
-                .filter(isField)
-                .map((field) => field.table),
-        ]);
 
         const itemShowUnderlyingValues =
             isField(underlyingDataItem) && isMetric(underlyingDataItem)

--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
@@ -1,0 +1,106 @@
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CompiledExploreJoin,
+    type Dimension,
+    type Explore,
+    type ItemsMap,
+    type Metric,
+    type TableCalculation,
+} from '@lightdash/common';
+import { getUnderlyingDataAvailableTables } from './getUnderlyingDataAvailableTables';
+
+const join = (table: string): CompiledExploreJoin => ({
+    table,
+    sqlOn: `\${customers.customer_id} = \${${table}.customer_id}`,
+    compiledSqlOn: `("customers".customer_id) = ("${table}".customer_id)`,
+});
+
+const customersExplore: Pick<Explore, 'baseTable' | 'joinedTables'> = {
+    baseTable: 'customers',
+    joinedTables: [join('orders'), join('payments')],
+};
+
+const ordersFulfillmentRate: Metric = {
+    fieldType: FieldType.METRIC,
+    type: MetricType.AVERAGE,
+    name: 'fulfillment_rate',
+    label: 'Fulfillment rate',
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: 'CASE WHEN ${TABLE}.is_completed THEN 1 ELSE 0 END',
+    hidden: false,
+    showUnderlyingValues: ['status', 'customers.first_name'],
+};
+
+const regionDimension: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'region',
+    label: 'Region',
+    table: 'regions',
+    tableLabel: 'Regions',
+    sql: '${TABLE}.region',
+    hidden: false,
+};
+
+const rowNumber: TableCalculation = {
+    name: 'row_number',
+    displayName: 'Row number',
+    sql: 'ROW_NUMBER() OVER ()',
+};
+
+describe('getUnderlyingDataAvailableTables', () => {
+    it('includes the base table when no queried field belongs to it', () => {
+        const fields: ItemsMap = {
+            orders_fulfillment_rate: ordersFulfillmentRate,
+        };
+
+        const tables = getUnderlyingDataAvailableTables(
+            customersExplore,
+            fields,
+        );
+
+        expect(tables.has('customers')).toBe(true);
+    });
+
+    it('includes every joined table, queried or not', () => {
+        const fields: ItemsMap = {
+            orders_fulfillment_rate: ordersFulfillmentRate,
+        };
+
+        const tables = getUnderlyingDataAvailableTables(
+            customersExplore,
+            fields,
+        );
+
+        expect(tables.has('orders')).toBe(true);
+        expect(tables.has('payments')).toBe(true);
+    });
+
+    it('includes the table of a queried field outside the explore joins', () => {
+        const fields: ItemsMap = {
+            orders_fulfillment_rate: ordersFulfillmentRate,
+            regions_region: regionDimension,
+        };
+
+        const tables = getUnderlyingDataAvailableTables(
+            customersExplore,
+            fields,
+        );
+
+        expect(tables.has('regions')).toBe(true);
+    });
+
+    it('ignores items that are not fields', () => {
+        const fields: ItemsMap = { row_number: rowNumber };
+
+        const tables = getUnderlyingDataAvailableTables(
+            customersExplore,
+            fields,
+        );
+
+        expect([...tables]).toEqual(['customers', 'orders', 'payments']);
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
@@ -1,0 +1,14 @@
+import { isField, type Explore, type ItemsMap } from '@lightdash/common';
+
+// The base table is always in the FROM clause, so it is always available.
+export const getUnderlyingDataAvailableTables = (
+    explore: Pick<Explore, 'baseTable' | 'joinedTables'>,
+    metricQueryFields: ItemsMap,
+): Set<string> =>
+    new Set([
+        explore.baseTable,
+        ...explore.joinedTables.map((joinedTable) => joinedTable.table),
+        ...Object.values(metricQueryFields)
+            .filter(isField)
+            .map((field) => field.table),
+    ]);


### PR DESCRIPTION
## Summary

"View underlying data" silently dropped any `show_underlying_values` column that belongs to the explore's **base table** whenever the chart's query had no base-table field (a big-number tile showing a joined-table metric is the common shape). The base table's `default_show_underlying_values` was dropped entirely in the same situation.

## Root cause

`executeAsyncUnderlyingDataQuery` builds the set of tables allowed to contribute columns from the explore's joined tables plus the tables of the queried fields. The base table was never added. Every candidate dimension and metric has to pass that table check before the `show_underlying_values` list is consulted, so base-table entries were filtered out before the list could keep them.

This is a regression from the move of underlying data to the paginated backend endpoint (#14114 / #14171). The frontend logic it replaced built the same set from joined tables, queried-field tables, **and** the explore's table name. The port copied the first two and lost the third.

## Change

- Extract the rule into `getUnderlyingDataAvailableTables(explore, metricQueryFields)` next to the other `AsyncQueryService` helpers, and include `explore.baseTable`. The base table is always in the `FROM` clause, so it is always available.
- Unit test for the helper.
- api-test `underlyingDataColumns.test.ts` reproducing both cases on the seed project through the v2 async query endpoints.

No API shape change. Embedded dashboards use the same `POST /api/v2/projects/:uuid/query/underlying-data` endpoint, so they are covered by the same fix.

## Who is affected

The change only widens the candidate table set by the base table. The explicit column list, or the 50-dimension cap when there is none, still governs what is selected.

| Case | Before | After |
|---|---|---|
| Metric with `show_underlying_values` naming base-table fields, query has no base-table field | base-table columns missing | base-table columns present (pre-regression behaviour) |
| Base table `default_show_underlying_values`, query has no base-table field | whole default list dropped | default list applied |
| No column list, query has no base-table field | base-table dimensions excluded | base-table dimensions included, still within the 50-column cap (pre-regression behaviour) |
| Any query that already references a base-table field | unchanged | unchanged |

## Test plan

- [x] `pnpm -F backend test src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts` (4 passed)
- [x] `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts` (175 passed)
- [x] api-test run against a worktree backend on an isolated DB seeded from `main`: with the service change reverted, 2 of 3 cases fail exactly as reported (`customers_first_name` absent on the `customers` explore, `payments_unique_payment_count` absent for the default list); with the change, 3 of 3 pass.
- [x] backend and api-tests typecheck, oxlint, oxfmt

Closes: #28536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnMsZVq1RAyU8xKRrEdNqg
