### PR TITLE
fix(sql-runner): list views and materialized views in the Postgres and Redshift catalog

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -169,6 +169,97 @@ describe('PostgresWarehouseClient', () => {
             'orders',
         ]);
     });
+
+    describe('getAllTables', () => {
+        it('lists tables, views and materialized views', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 15.4' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({
+                    rows: [
+                        {
+                            table_catalog: 'warehouse',
+                            table_schema: 'public',
+                            table_name: 'orders_view',
+                        },
+                    ],
+                    fields: {},
+                });
+
+            const tables = await warehouse.getAllTables();
+
+            const [query] = runQuery.mock.calls[1];
+            expect(query).toContain(
+                "table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')",
+            );
+            expect(query).toContain('FROM pg_catalog.pg_matviews');
+            expect(tables).toEqual([
+                {
+                    database: 'warehouse',
+                    schema: 'public',
+                    table: 'orders_view',
+                },
+            ]);
+        });
+
+        it('skips pg_matviews on servers that predate it', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 8.0.2' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({ rows: [], fields: {} });
+
+            await warehouse.getAllTables();
+
+            expect(runQuery.mock.calls[1][0]).not.toContain('pg_matviews');
+        });
+    });
+
+    describe('getFields', () => {
+        it('includes materialized view columns and binds filters in order', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 15.4' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({
+                    rows: [
+                        {
+                            table_catalog: 'warehouse',
+                            table_schema: 'public',
+                            table_name: 'orders_mv',
+                            column_name: 'amount',
+                            data_type: 'numeric',
+                        },
+                    ],
+                    fields: {},
+                });
+
+            const fields = await warehouse.getFields(
+                'orders_mv',
+                undefined,
+                'warehouse',
+            );
+
+            const [query, , , values] = runQuery.mock.calls[1];
+            expect(query).toContain("c.relkind = 'm'");
+            expect(query).toContain('table_catalog = $2');
+            expect(query).not.toContain('$3');
+            expect(values).toEqual(['orders_mv', 'warehouse']);
+            expect(fields).toEqual({
+                warehouse: { public: { orders_mv: { amount: 'number' } } },
+            });
+        });
+    });
 });
 
 describe('PostgresWarehouseClient statement timeout', () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -607,14 +607,7 @@ export class PostgresClient<
             return {};
         }
 
-        const { rows: pgVersionRows } = await this.runQuery('SELECT version()');
-        const pgVersionString = pgVersionRows[0]?.version ?? '';
-        const versionRegex = /PostgreSQL (\d+)\./;
-        const versionMatch = pgVersionString.match(versionRegex);
-        const supportsMatviews =
-            versionMatch && versionMatch[1]
-                ? parseInt(versionMatch[1], 10) >= 12
-                : false;
+        const supportsMatviews = await this.supportsMatviews();
 
         const query = `
             SELECT table_catalog,
@@ -636,7 +629,7 @@ export class PostgresClient<
                 n.nspname AS table_schema,
                 c.relname AS table_name,
                 a.attname AS column_name,
-                pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type
+                pg_catalog.format_type(a.atttypid, NULL) AS data_type
             FROM pg_catalog.pg_attribute a
             JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
             JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
@@ -696,29 +689,68 @@ export class PostgresClient<
         return catalog;
     }
 
+    private serverVersion: Promise<string> | undefined;
+
+    protected getServerVersion(): Promise<string> {
+        this.serverVersion ??= this.runQuery('SELECT version()').then(
+            ({ rows }) => String(rows[0]?.version ?? ''),
+        );
+        return this.serverVersion;
+    }
+
+    // Redshift reports itself as PostgreSQL 8.x and has no pg_matviews
+    protected async supportsMatviews(): Promise<boolean> {
+        const versionMatch = (await this.getServerVersion()).match(
+            /PostgreSQL (\d+)\./,
+        );
+        return versionMatch?.[1] ? parseInt(versionMatch[1], 10) >= 12 : false;
+    }
+
+    protected async isRedshift(): Promise<boolean> {
+        return (await this.getServerVersion()).includes('Redshift');
+    }
+
+    // A session only sees its own database, so no catalog filter is needed
     async getAllTables() {
-        const databaseName = this.config.database;
-        const whereSql = databaseName ? `AND table_catalog = $1` : '';
-        const filterSystemTables = `AND table_schema NOT IN ('information_schema', 'pg_catalog')`;
+        const supportsMatviews = await this.supportsMatviews();
         const query = `
             SELECT table_catalog, table_schema, table_name
             FROM information_schema.tables
-            WHERE table_type = 'BASE TABLE'
-                ${whereSql}
-                ${filterSystemTables}
+            WHERE table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')
+                AND table_schema NOT IN ('information_schema', 'pg_catalog')
+            ${
+                supportsMatviews
+                    ? `
+            UNION ALL
+            SELECT current_database() AS table_catalog,
+                   schemaname AS table_schema,
+                   matviewname AS table_name
+            FROM pg_catalog.pg_matviews
+            WHERE schemaname NOT IN ('information_schema', 'pg_catalog')`
+                    : ''
+            }
             ORDER BY 1, 2, 3
         `;
-        const { rows } = await this.runQuery(
-            query,
-            {},
-            undefined,
-            databaseName ? [databaseName] : [],
-        );
+        const { rows } = await this.runQuery(query);
         return rows.map((row) => ({
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
         }));
+    }
+
+    // Positional parameters for a field lookup, so optional filters keep their numbering
+    protected bindFieldsFilters(
+        tableName: string,
+        schema?: string,
+        database?: string,
+    ) {
+        const values = [tableName];
+        const schemaParam = schema ? `$${values.push(schema)}` : undefined;
+        const databaseParam = database
+            ? `$${values.push(database)}`
+            : undefined;
+        return { values, schemaParam, databaseParam };
     }
 
     async getFields(
@@ -727,6 +759,12 @@ export class PostgresClient<
         database?: string,
         tags?: Record<string, string>,
     ): Promise<WarehouseCatalog> {
+        const { values, schemaParam, databaseParam } = this.bindFieldsFilters(
+            tableName,
+            schema,
+            database,
+        );
+        const supportsMatviews = await this.supportsMatviews();
         const query = `
             SELECT table_catalog,
                    table_schema,
@@ -735,18 +773,37 @@ export class PostgresClient<
                    data_type
             FROM information_schema.columns
             WHERE table_name = $1
-            ${schema ? 'AND table_schema = $2' : ''}
-            ${database ? 'AND table_catalog = $3' : ''}
+            ${schemaParam ? `AND table_schema = ${schemaParam}` : ''}
+            ${databaseParam ? `AND table_catalog = ${databaseParam}` : ''}
+            ${
+                supportsMatviews
+                    ? `
+            UNION ALL
+            SELECT current_database() AS table_catalog,
+                   n.nspname AS table_schema,
+                   c.relname AS table_name,
+                   a.attname AS column_name,
+                   pg_catalog.format_type(a.atttypid, NULL) AS data_type
+            FROM pg_catalog.pg_attribute a
+            JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+            WHERE c.relkind = 'm'
+            AND c.relname = $1
+            ${schemaParam ? `AND n.nspname = ${schemaParam}` : ''}
+            ${databaseParam ? `AND current_database() = ${databaseParam}` : ''}
+            AND a.attnum > 0
+            AND NOT a.attisdropped`
+                    : ''
+            }
         `;
-        const values = [tableName];
-        if (schema) {
-            values.push(schema);
-        }
-        if (database) {
-            values.push(database);
-        }
         const { rows } = await this.runQuery(query, tags, undefined, values);
 
+        return this.parsePostgresCatalog(rows);
+    }
+
+    protected parsePostgresCatalog(
+        rows: Record<string, AnyType>[],
+    ): WarehouseCatalog {
         return this.parseWarehouseCatalog(
             rows,
             mapFieldType,

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
@@ -1,18 +1,31 @@
-import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import {
+    RedshiftAuthenticationType,
+    WarehouseTypes,
+    type CreateRedshiftCredentials,
+} from '@lightdash/common';
 import { RedshiftWarehouseClient } from './RedshiftWarehouseClient';
+
+const credentials: CreateRedshiftCredentials = {
+    type: WarehouseTypes.REDSHIFT,
+    host: 'localhost',
+    user: 'analytics',
+    password: 'password',
+    port: 5439,
+    dbname: 'warehouse',
+    schema: 'public',
+    authenticationType: RedshiftAuthenticationType.PASSWORD,
+};
+
+const redshiftVersion = {
+    rows: [
+        { version: 'PostgreSQL 8.0.2 on i686-pc-linux-gnu, Redshift 1.0.77' },
+    ],
+    fields: {},
+};
 
 describe('RedshiftWarehouseClient', () => {
     it('keeps catalog filters in the Redshift query', async () => {
-        const warehouse = new RedshiftWarehouseClient({
-            type: WarehouseTypes.REDSHIFT,
-            host: 'localhost',
-            user: 'analytics',
-            password: 'password',
-            port: 5439,
-            dbname: 'warehouse',
-            schema: 'public',
-            authenticationType: RedshiftAuthenticationType.PASSWORD,
-        });
+        const warehouse = new RedshiftWarehouseClient(credentials);
         const runQuery = vi
             .spyOn(warehouse, 'runQuery')
             .mockResolvedValueOnce({
@@ -30,5 +43,90 @@ describe('RedshiftWarehouseClient', () => {
         expect(catalogQuery).toContain("table_schema IN ('public')");
         expect(catalogQuery).toContain("table_name IN ('orders')");
         expect(runQuery.mock.calls[1][3]).toBeUndefined();
+    });
+
+    it('lists tables and views from svv_tables scoped to the database', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce(redshiftVersion)
+            .mockResolvedValueOnce({
+                rows: [
+                    {
+                        table_catalog: 'warehouse',
+                        table_schema: 'public',
+                        table_name: 'orders_lbv',
+                    },
+                ],
+                fields: {},
+            });
+
+        const tables = await warehouse.getAllTables();
+
+        const [query, , , values] = runQuery.mock.calls[1];
+        expect(query).toContain('FROM svv_tables');
+        expect(query).toContain('table_catalog = $1');
+        expect(values).toEqual(['warehouse']);
+        expect(tables).toEqual([
+            { database: 'warehouse', schema: 'public', table: 'orders_lbv' },
+        ]);
+    });
+
+    it('reads columns from svv_columns so late-binding views resolve', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce(redshiftVersion)
+            .mockResolvedValueOnce({
+                rows: [
+                    {
+                        table_catalog: 'warehouse',
+                        table_schema: 'public',
+                        table_name: 'orders_lbv',
+                        column_name: 'quantity',
+                        data_type: 'integer',
+                    },
+                ],
+                fields: {},
+            });
+
+        const fields = await warehouse.getFields(
+            'orders_lbv',
+            'public',
+            'warehouse',
+        );
+
+        const [query, , , values] = runQuery.mock.calls[1];
+        expect(query).toContain('FROM svv_columns');
+        expect(values).toEqual(['orders_lbv', 'public', 'warehouse']);
+        expect(fields).toEqual({
+            warehouse: {
+                public: { orders_lbv: { quantity: 'number' } },
+            },
+        });
+    });
+
+    it('keeps the Postgres catalog when the server is not Redshift', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce({
+                rows: [{ version: 'PostgreSQL 15.4' }],
+                fields: {},
+            })
+            .mockResolvedValueOnce({ rows: [], fields: {} })
+            .mockResolvedValueOnce({ rows: [], fields: {} });
+
+        await warehouse.getAllTables();
+        await warehouse.getFields('orders', 'public');
+
+        expect(runQuery).toHaveBeenCalledTimes(3);
+        expect(runQuery.mock.calls[1][0]).toContain(
+            'FROM information_schema.tables',
+        );
+        expect(runQuery.mock.calls[1][0]).not.toContain('svv_tables');
+        expect(runQuery.mock.calls[2][0]).toContain(
+            'FROM information_schema.columns',
+        );
     });
 });

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
@@ -3,6 +3,7 @@ import {
     CreateRedshiftCredentials,
     RedshiftAuthenticationType,
     SupportedDbtAdapter,
+    WarehouseCatalog,
     WarehouseResults,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -128,6 +129,58 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
             this.config = await this.resolveIamPoolConfig();
         }
         return super.streamQuery(sql, streamCallback, options);
+    }
+
+    // information_schema omits late-binding views and Spectrum external tables;
+    // the SVV_* views cover them alongside regular tables and views. A Redshift
+    // project pointed at plain Postgres keeps the Postgres catalog.
+    async getAllTables() {
+        if (!(await this.isRedshift())) return super.getAllTables();
+        const query = `
+            SELECT table_catalog, table_schema, table_name
+            FROM svv_tables
+            WHERE table_catalog = $1
+                AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_internal')
+            ORDER BY 1, 2, 3
+        `;
+        const { rows } = await this.runQuery(query, {}, undefined, [
+            this.credentials.dbname,
+        ]);
+        return rows.map((row) => ({
+            database: row.table_catalog,
+            schema: row.table_schema,
+            table: row.table_name,
+        }));
+    }
+
+    async getFields(
+        tableName: string,
+        schema?: string,
+        database?: string,
+        tags?: Record<string, string>,
+    ): Promise<WarehouseCatalog> {
+        if (!(await this.isRedshift())) {
+            return super.getFields(tableName, schema, database, tags);
+        }
+        const { values, schemaParam, databaseParam } = this.bindFieldsFilters(
+            tableName,
+            schema,
+            database,
+        );
+        const query = `
+            SELECT table_catalog,
+                   table_schema,
+                   table_name,
+                   column_name,
+                   data_type
+            FROM svv_columns
+            WHERE table_name = $1
+            ${schemaParam ? `AND table_schema = ${schemaParam}` : ''}
+            ${databaseParam ? `AND table_catalog = ${databaseParam}` : ''}
+            ORDER BY ordinal_position
+        `;
+        const { rows } = await this.runQuery(query, tags, undefined, values);
+        return this.parsePostgresCatalog(rows);
     }
 
     private async resolveIamPoolConfig(): Promise<PoolConfig> {


### PR DESCRIPTION
## Summary

The SQL runner table browser only listed `BASE TABLE` objects for Postgres and Redshift, so views were missing from the sidebar even though they could be queried by typing the name. Both clients share `PostgresClient.getAllTables()`.

Closes: PROD-5746
Closes: #20813

## Changes

**Postgres** (`PostgresWarehouseClient.ts`)
- `getAllTables()` lists `BASE TABLE`, `VIEW` and `FOREIGN` from `information_schema.tables`, and unions materialized views from `pg_catalog.pg_matviews` (they are not in `information_schema` at all).
- `getFields()` unions materialized view columns from `pg_attribute`; without it, expanding a materialized view showed no columns. Column types come from `format_type(oid, NULL)` so `numeric(10,2)` maps to `number` instead of falling through to `string`. The same change is applied to the existing union in `getCatalog`.
- The `pg_matviews` union is gated on the server-version check `getCatalog` already used, because Redshift reports itself as PostgreSQL 8.x and has no `pg_matviews`.
- Dropped a dead `table_catalog = $1` filter: the pool is built from a connection string so `config.database` was never set, and a session only sees its own database anyway.

**Redshift** (`RedshiftWarehouseClient.ts`)
- Overrides `getAllTables()` to read `svv_tables` and `getFields()` to read `svv_columns`. These are the documented catalogs that include late-binding views and Spectrum external tables, which `information_schema` omits (`information_schema.columns` returns nothing for a late-binding view).
- Both overrides check the server version string for "Redshift" first and otherwise fall back to the Postgres catalog. A Redshift-typed project pointed at plain Postgres (which the API tests do in CI) keeps working; the version probe is memoized per client instance.

## Regression analysis

- Postgres and Redshift SQL runner users see more objects in the sidebar: views, materialized views, foreign tables, and on Redshift late-binding views and external tables. Everything that was listed before is still listed.
- The list is cached per credentials in `warehouse_credentials_available_tables`; existing projects see the new objects after pressing refresh. No migration.
- `getCatalog` (dbt compile path) only changes in the type names of materialized view columns, which turns previously mis-typed `string` columns into their real types.
- Snowflake, BigQuery and DuckDB already listed views. Trino and Databricks still filter on `BASE TABLE`; follow-up.
- Not verified on a live Redshift cluster (none available locally). The Redshift queries follow the AWS docs for `SVV_TABLES`, `SVV_COLUMNS` and late-binding views, and unit tests pin them.

## Evidence (local Postgres 18, jaffle shop dev DB)

Before: a view and a materialized view in `jaffle`, and a schema containing only views, are absent.

<table><tr>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/before-search-view.png" width="330" alt="Searching for a view finds nothing"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/before-schemas.png" width="330" alt="A schema with only views is not listed"></td>
</tr></table>

After: both are listed, the materialized view's columns resolve with the right types, and a query on it runs.

<table><tr>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/after-view-fields.png" width="330" alt="View listed with its fields"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/after-matview-fields.png" width="330" alt="Materialized view listed with typed fields"></td>
</tr></table>

<img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/after-matview-query.png" width="900" alt="Query on the materialized view returns rows">

## Test plan

- [x] `pnpm -F warehouses test` (new tests for Postgres `getAllTables`/`getFields` and the Redshift `svv_*` queries)
- [x] `pnpm -F warehouses typecheck` and lint
- [x] Verified in the app against the local Postgres dev DB (screenshots above)
- [ ] Redshift: confirm late-binding views list and expand on a real cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFNdHweoAjBXR2Gt4b4S19
