### PR TITLE
perf(sql-runner): virtualize the table browser and drop the 100-table cap

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -5,8 +5,6 @@ import {
     Center,
     Group,
     Loader,
-    Stack,
-    type BoxProps,
     Text,
     UnstyledButton,
     ActionIcon,
@@ -22,22 +20,30 @@ import {
     IconTable,
     IconX,
 } from '@tabler/icons-react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import dayjs from 'dayjs';
-import Fuse from 'fuse.js';
 import isEmpty from 'lodash/isEmpty';
-import { memo, useEffect, useMemo, useState, type FC } from 'react';
+import { memo, useCallback, useMemo, useRef, useState, type FC } from 'react';
 import { CopyActionIcon } from '../../../components/common/CopyActionIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { useIsTruncated } from '../../../hooks/useIsTruncated';
 import scrollAreaClasses from '../../../styles/ScrollArea.module.css';
-import { useTables, type TablesBySchema } from '../hooks/useTables';
+import { useTables } from '../hooks/useTables';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql, toggleActiveTable } from '../store/sqlRunnerSlice';
+import {
+    buildTableRows,
+    filterTablesBySchema,
+    type SchemaTables,
+    type TableRow,
+} from '../utils/tableRows';
 import styles from './Tables.module.css';
 
-const limitTableResults = 100;
+const SCHEMA_ROW_HEIGHT = 34;
+const TABLE_ROW_HEIGHT = 30;
+const MIN_SEARCH_LENGTH = 3;
 
-interface TableItemProps extends BoxProps {
+interface TableItemProps {
     table: string;
     search: string;
     schema: string;
@@ -64,15 +70,7 @@ const partitionFilter = (partitionColumn: PartitionColumn | undefined) => {
 };
 
 const TableItem: FC<TableItemProps> = memo(
-    ({
-        table,
-        search,
-        schema,
-        database,
-        isActive,
-        partitionColumn,
-        ...rest
-    }) => {
+    ({ table, search, schema, database, isActive, partitionColumn }) => {
         const { ref: hoverRef, hovered } = useHover();
         const { ref: truncatedRef, isTruncated } =
             useIsTruncated<HTMLDivElement>();
@@ -83,7 +81,7 @@ const TableItem: FC<TableItemProps> = memo(
             ? `${quoteChar}${database}${quoteChar}.${quoteChar}${schema}${quoteChar}.${quoteChar}${table}${quoteChar}`
             : `${quoteChar}${schema}${quoteChar}.${quoteChar}${table}${quoteChar}`;
         return (
-            <Box ref={hoverRef} pos="relative" {...rest}>
+            <Box ref={hoverRef} pos="relative">
                 <UnstyledButton
                     ff="inherit"
                     onClick={() => {
@@ -115,18 +113,18 @@ const TableItem: FC<TableItemProps> = memo(
                             disabled={!isTruncated}
                             maw={300}
                         >
-                            {search.length > 2 ? (
+                            {search ? (
                                 <Text ref={truncatedRef} truncate fz="sm">
                                     <Highlight
                                         component="span"
-                                        highlight={search || ''}
+                                        highlight={search}
                                         inherit
                                     >
                                         {table}
                                     </Highlight>
                                 </Text>
                             ) : (
-                                <Text fz="sm" truncate>
+                                <Text ref={truncatedRef} fz="sm" truncate>
                                     {table}
                                 </Text>
                             )}
@@ -151,88 +149,61 @@ const TableItem: FC<TableItemProps> = memo(
     },
 );
 
-const Table: FC<{
-    schema: NonNullable<TablesBySchema>[number]['schema'];
-    tables: NonNullable<TablesBySchema>[number]['tables'];
+const SchemaItem: FC<{
+    schema: string;
+    isExpanded: boolean;
+    onToggle: (schema: string, isExpanded: boolean) => void;
+}> = memo(({ schema, isExpanded, onToggle }) => (
+    <UnstyledButton
+        onClick={() => onToggle(schema, isExpanded)}
+        className={styles.schemaButton}
+        ff="inherit"
+    >
+        <Group wrap="nowrap" gap="xs">
+            <MantineIcon
+                icon={isExpanded ? IconChevronDown : IconChevronRight}
+                size="sm"
+                className={styles.chevron}
+            />
+            <Text fz="sm" fw={500} truncate>
+                {schema}
+            </Text>
+        </Group>
+    </UnstyledButton>
+));
+
+type SchemaExpansion = {
     search: string;
+    overrides: Record<string, boolean>;
+};
+const NO_OVERRIDES: Record<string, boolean> = {};
+
+const VirtualRow: FC<{
+    row: TableRow;
+    search: string;
+    database: string;
     activeTable: string | undefined;
     activeSchema: string | undefined;
-    database: string;
-}> = ({ schema, tables, search, activeTable, activeSchema, database }) => {
-    const [isExpanded, setIsExpanded] = useState(false);
-
-    const hasMatchingTable = useMemo(() => {
-        if (!search || search.trim().length <= 2) return false;
-        return Object.keys(tables).some(
-            (table) =>
-                table.toLowerCase().includes(search.toLowerCase()) ||
-                schema.toString().toLowerCase().includes(search.toLowerCase()),
+    onToggleSchema: (schema: string, isExpanded: boolean) => void;
+}> = ({ row, search, database, activeTable, activeSchema, onToggleSchema }) => {
+    if (row.type === 'schema') {
+        return (
+            <SchemaItem
+                schema={row.schema}
+                isExpanded={row.isExpanded}
+                onToggle={onToggleSchema}
+            />
         );
-    }, [tables, schema, search]);
-
-    useEffect(() => {
-        const isTableSelected =
-            activeTable &&
-            Object.keys(tables).includes(activeTable) &&
-            schema === activeSchema;
-        if (hasMatchingTable || isTableSelected) {
-            setIsExpanded(true);
-        } else {
-            // Autoclose when search is empty and no matching table is selected
-            // to avoid rendering all tables after a search
-
-            // TODO fix this edge case
-            // when this happens, there is still a render loop that is rendering all tables without search or filtering
-            // which is making the UI unresponsive for a short while until this state is updated
-            setIsExpanded(false);
-        }
-    }, [activeTable, tables, hasMatchingTable, activeSchema, schema]);
+    }
     return (
-        <Stack gap={0}>
-            <UnstyledButton
-                onClick={() => setIsExpanded(!isExpanded)}
-                className={styles.schemaButton}
-                ff="inherit"
-            >
-                <Group wrap="nowrap" gap="xs">
-                    <MantineIcon
-                        icon={isExpanded ? IconChevronDown : IconChevronRight}
-                        size="sm"
-                        className={styles.chevron}
-                    />
-                    <Text fz="sm" fw={500} truncate>
-                        {schema}
-                    </Text>
-                </Group>
-            </UnstyledButton>
-            {isExpanded && (
-                <>
-                    {Object.keys(tables)
-                        .slice(0, limitTableResults)
-                        .map((table) => (
-                            <TableItem
-                                key={table}
-                                search={search}
-                                isActive={
-                                    activeTable === table &&
-                                    schema === activeSchema
-                                }
-                                table={table}
-                                schema={`${schema}`}
-                                database={database}
-                                partitionColumn={tables[table].partitionColumn}
-                            />
-                        ))}
-                    {Object.keys(tables).length > limitTableResults && (
-                        <Text ml="md" fz="xs" c="dimmed">
-                            Filtering first {limitTableResults} of{' '}
-                            {Object.keys(tables).length} tables, search to see
-                            more
-                        </Text>
-                    )}
-                </>
-            )}
-        </Stack>
+        <TableItem
+            table={row.table}
+            schema={row.schema}
+            database={database}
+            search={search}
+            isActive={row.table === activeTable && row.schema === activeSchema}
+            partitionColumn={row.partitionColumn}
+        />
     );
 };
 
@@ -245,85 +216,89 @@ export const Tables: FC = () => {
 
     const [search, setSearch] = useState<string>('');
     const [debouncedSearch] = useDebouncedValue(search, 500);
-    const isValidSearch = Boolean(
-        debouncedSearch && debouncedSearch.trim().length > 2,
+    const effectiveSearch =
+        debouncedSearch.trim().length >= MIN_SEARCH_LENGTH
+            ? debouncedSearch
+            : '';
+
+    // Manual expand/collapse choices, discarded whenever the search changes
+    const [expansion, setExpansion] = useState<SchemaExpansion>({
+        search: '',
+        overrides: {},
+    });
+    const overrides = useMemo(
+        () =>
+            expansion.search === effectiveSearch
+                ? expansion.overrides
+                : NO_OVERRIDES,
+        [expansion, effectiveSearch],
+    );
+    const toggleSchema = useCallback(
+        (schema: string, isExpanded: boolean) => {
+            setExpansion((previous) => ({
+                search: effectiveSearch,
+                overrides: {
+                    ...(previous.search === effectiveSearch
+                        ? previous.overrides
+                        : {}),
+                    [schema]: !isExpanded,
+                },
+            }));
+        },
+        [effectiveSearch],
     );
 
-    const { data, isLoading, isSuccess } = useTables({
-        projectUuid,
-    });
+    const { data, isLoading, isSuccess } = useTables({ projectUuid });
 
-    const transformedData:
-        | { database: string; tablesBySchema: TablesBySchema }
-        | undefined = useMemo(() => {
+    const catalog = useMemo<
+        { database: string; tablesBySchema: SchemaTables[] } | undefined
+    >(() => {
         if (!data || isEmpty(data)) return undefined;
         const [database] = Object.keys(data);
         if (database === undefined) return undefined;
-
         const tablesBySchema = Object.entries(data).flatMap(([, schemas]) =>
             Object.entries(schemas).map(([schema, tables]) => ({
                 schema,
                 tables,
             })),
         );
-        return {
-            database,
-            tablesBySchema,
-        };
+        return { database, tablesBySchema };
     }, [data]);
 
-    const filteredTablesBySchema:
-        | { database: string; tablesBySchema: TablesBySchema }
-        | undefined = useMemo(() => {
-        if (
-            !transformedData?.tablesBySchema ||
-            !debouncedSearch ||
-            !isValidSearch
-        )
-            return transformedData;
+    const rows = useMemo<TableRow[]>(() => {
+        if (!catalog) return [];
+        const tablesBySchema = effectiveSearch
+            ? filterTablesBySchema(catalog.tablesBySchema, effectiveSearch)
+            : catalog.tablesBySchema;
+        // Searching expands every matching schema; otherwise only the active one
+        return buildTableRows(
+            tablesBySchema,
+            (schema) =>
+                overrides[schema] ??
+                (effectiveSearch !== '' || schema === activeSchema),
+        );
+    }, [catalog, effectiveSearch, overrides, activeSchema]);
 
-        const searchResults: TablesBySchema = transformedData.tablesBySchema
-            .map((schemaData) => {
-                const { schema, tables } = schemaData;
-                const tableNames = Object.keys(tables);
-
-                const fuse = new Fuse(tableNames, {
-                    threshold: 0.3,
-                    isCaseSensitive: false,
-                    ignoreLocation: true,
-                });
-
-                const fuseResult = fuse
-                    .search(debouncedSearch)
-                    .map((res) => res.item);
-
-                return {
-                    schema,
-                    tables: fuseResult.reduce<typeof tables>(
-                        (acc, tableName) => {
-                            acc[tableName] = tables[tableName];
-                            return acc;
-                        },
-                        {},
-                    ),
-                };
-            })
-            .filter((schemaData) => Object.keys(schemaData.tables).length > 0);
-        if (searchResults.length === 0) {
-            return undefined;
-        } else
-            return {
-                database: transformedData.database,
-                tablesBySchema: searchResults,
-            };
-    }, [isValidSearch, debouncedSearch, transformedData]);
+    const viewportRef = useRef<HTMLDivElement>(null);
+    const virtualizer = useVirtualizer({
+        count: rows.length,
+        getScrollElement: () => viewportRef.current,
+        estimateSize: (index) =>
+            rows[index]?.type === 'schema'
+                ? SCHEMA_ROW_HEIGHT
+                : TABLE_ROW_HEIGHT,
+        getItemKey: (index) => rows[index]?.id ?? index,
+        overscan: 10,
+    });
 
     return (
         <>
             <Box>
                 <Tooltip
-                    opened={search.length > 0 && search.length < 3}
-                    label="Enter at least 3 characters to search"
+                    opened={
+                        search.length > 0 && search.length < MIN_SEARCH_LENGTH
+                    }
+                    label={`Enter at least ${MIN_SEARCH_LENGTH} characters to search`}
                 >
                     <TextInput
                         size="sm"
@@ -358,30 +333,52 @@ export const Tables: FC = () => {
             </Box>
 
             <ScrollArea
+                viewportRef={viewportRef}
                 offsetScrollbars
                 scrollbars="y"
                 classNames={{ content: scrollAreaClasses.verticalContent }}
                 flex={1}
                 type="auto"
             >
-                {isSuccess &&
-                    filteredTablesBySchema &&
-                    filteredTablesBySchema.tablesBySchema?.map(
-                        ({ schema, tables }) => (
-                            <Table
-                                key={schema}
-                                schema={schema}
-                                tables={tables}
-                                search={isValidSearch ? debouncedSearch : ''}
-                                activeTable={activeTable}
-                                activeSchema={activeSchema}
-                                database={filteredTablesBySchema?.database}
-                            />
-                        ),
-                    )}
+                {catalog && (
+                    <Box
+                        style={{
+                            height: virtualizer.getTotalSize(),
+                            position: 'relative',
+                        }}
+                    >
+                        {virtualizer.getVirtualItems().map((virtualRow) => {
+                            const row = rows[virtualRow.index];
+                            if (!row) return null;
+                            return (
+                                <Box
+                                    key={virtualRow.key}
+                                    data-index={virtualRow.index}
+                                    ref={virtualizer.measureElement}
+                                    style={{
+                                        position: 'absolute',
+                                        top: 0,
+                                        left: 0,
+                                        width: '100%',
+                                        transform: `translateY(${virtualRow.start}px)`,
+                                    }}
+                                >
+                                    <VirtualRow
+                                        row={row}
+                                        search={effectiveSearch}
+                                        database={catalog.database}
+                                        activeTable={activeTable}
+                                        activeSchema={activeSchema}
+                                        onToggleSchema={toggleSchema}
+                                    />
+                                </Box>
+                            );
+                        })}
+                    </Box>
+                )}
             </ScrollArea>
 
-            {isSuccess && !data && (
+            {isSuccess && rows.length === 0 && (
                 <Center p="sm">
                     <Text c="dimmed" fz="sm">
                         No results found

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
@@ -1,0 +1,80 @@
+import { PartitionType } from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    buildTableRows,
+    filterTablesBySchema,
+    type SchemaTables,
+} from './tableRows';
+
+const partitionColumn = {
+    field: 'created_at',
+    partitionType: PartitionType.DATE,
+};
+
+const tablesBySchema: SchemaTables[] = [
+    {
+        schema: 'jaffle',
+        tables: { customers: {}, orders: { partitionColumn }, payments: {} },
+    },
+    { schema: 'staging', tables: { stg_orders: {} } },
+];
+
+describe('buildTableRows', () => {
+    it('emits only headers for collapsed schemas', () => {
+        const rows = buildTableRows(tablesBySchema, () => false);
+
+        expect(rows).toEqual([
+            {
+                type: 'schema',
+                id: 'schema:jaffle',
+                schema: 'jaffle',
+                isExpanded: false,
+                tableCount: 3,
+            },
+            {
+                type: 'schema',
+                id: 'schema:staging',
+                schema: 'staging',
+                isExpanded: false,
+                tableCount: 1,
+            },
+        ]);
+    });
+
+    it('interleaves every table under an expanded schema', () => {
+        const rows = buildTableRows(
+            tablesBySchema,
+            (schema) => schema === 'jaffle',
+        );
+
+        expect(rows.map((row) => row.id)).toEqual([
+            'schema:jaffle',
+            'table:jaffle.customers',
+            'table:jaffle.orders',
+            'table:jaffle.payments',
+            'schema:staging',
+        ]);
+        expect(rows[2]).toEqual({
+            type: 'table',
+            id: 'table:jaffle.orders',
+            schema: 'jaffle',
+            table: 'orders',
+            partitionColumn,
+        });
+    });
+});
+
+describe('filterTablesBySchema', () => {
+    it('keeps matching tables and drops schemas without matches', () => {
+        const filtered = filterTablesBySchema(tablesBySchema, 'orders');
+
+        expect(filtered).toEqual([
+            { schema: 'jaffle', tables: { orders: { partitionColumn } } },
+            { schema: 'staging', tables: { stg_orders: {} } },
+        ]);
+    });
+
+    it('returns nothing when no table matches', () => {
+        expect(filterTablesBySchema(tablesBySchema, 'zzz')).toEqual([]);
+    });
+});

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
@@ -1,0 +1,73 @@
+import { type PartitionColumn } from '@lightdash/common';
+import Fuse from 'fuse.js';
+import { type TablesBySchema } from '../hooks/useTables';
+
+export type SchemaTables = NonNullable<TablesBySchema>[number];
+
+export type TableRow =
+    | {
+          type: 'schema';
+          id: string;
+          schema: string;
+          isExpanded: boolean;
+          tableCount: number;
+      }
+    | {
+          type: 'table';
+          id: string;
+          schema: string;
+          table: string;
+          partitionColumn: PartitionColumn | undefined;
+      };
+
+export const filterTablesBySchema = (
+    tablesBySchema: SchemaTables[],
+    search: string,
+): SchemaTables[] =>
+    tablesBySchema
+        .map(({ schema, tables }) => {
+            const fuse = new Fuse(Object.keys(tables), {
+                threshold: 0.3,
+                isCaseSensitive: false,
+                ignoreLocation: true,
+            });
+            const matches = fuse.search(search).map((result) => result.item);
+            return {
+                schema,
+                tables: Object.fromEntries(
+                    matches.map((table) => [table, tables[table]]),
+                ),
+            };
+        })
+        .filter(({ tables }) => Object.keys(tables).length > 0);
+
+// Flattens the schema tree into the rows the virtualized list renders
+export const buildTableRows = (
+    tablesBySchema: SchemaTables[],
+    isSchemaExpanded: (schema: string) => boolean,
+): TableRow[] =>
+    tablesBySchema.flatMap(({ schema, tables }) => {
+        const schemaName = String(schema);
+        const tableNames = Object.keys(tables);
+        const isExpanded = isSchemaExpanded(schemaName);
+        const header: TableRow = {
+            type: 'schema',
+            id: `schema:${schemaName}`,
+            schema: schemaName,
+            isExpanded,
+            tableCount: tableNames.length,
+        };
+        if (!isExpanded) return [header];
+        return [
+            header,
+            ...tableNames.map(
+                (table): TableRow => ({
+                    type: 'table',
+                    id: `table:${schemaName}.${table}`,
+                    schema: schemaName,
+                    table,
+                    partitionColumn: tables[table].partitionColumn,
+                }),
+            ),
+        ];
+    });

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -169,6 +169,97 @@ describe('PostgresWarehouseClient', () => {
             'orders',
         ]);
     });
+
+    describe('getAllTables', () => {
+        it('lists tables, views and materialized views', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 15.4' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({
+                    rows: [
+                        {
+                            table_catalog: 'warehouse',
+                            table_schema: 'public',
+                            table_name: 'orders_view',
+                        },
+                    ],
+                    fields: {},
+                });
+
+            const tables = await warehouse.getAllTables();
+
+            const [query] = runQuery.mock.calls[1];
+            expect(query).toContain(
+                "table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')",
+            );
+            expect(query).toContain('FROM pg_catalog.pg_matviews');
+            expect(tables).toEqual([
+                {
+                    database: 'warehouse',
+                    schema: 'public',
+                    table: 'orders_view',
+                },
+            ]);
+        });
+
+        it('skips pg_matviews on servers that predate it', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 8.0.2' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({ rows: [], fields: {} });
+
+            await warehouse.getAllTables();
+
+            expect(runQuery.mock.calls[1][0]).not.toContain('pg_matviews');
+        });
+    });
+
+    describe('getFields', () => {
+        it('includes materialized view columns and binds filters in order', async () => {
+            const warehouse = new PostgresWarehouseClient(credentials);
+            const runQuery = vi
+                .spyOn(warehouse, 'runQuery')
+                .mockResolvedValueOnce({
+                    rows: [{ version: 'PostgreSQL 15.4' }],
+                    fields: {},
+                })
+                .mockResolvedValueOnce({
+                    rows: [
+                        {
+                            table_catalog: 'warehouse',
+                            table_schema: 'public',
+                            table_name: 'orders_mv',
+                            column_name: 'amount',
+                            data_type: 'numeric',
+                        },
+                    ],
+                    fields: {},
+                });
+
+            const fields = await warehouse.getFields(
+                'orders_mv',
+                undefined,
+                'warehouse',
+            );
+
+            const [query, , , values] = runQuery.mock.calls[1];
+            expect(query).toContain("c.relkind = 'm'");
+            expect(query).toContain('table_catalog = $2');
+            expect(query).not.toContain('$3');
+            expect(values).toEqual(['orders_mv', 'warehouse']);
+            expect(fields).toEqual({
+                warehouse: { public: { orders_mv: { amount: 'number' } } },
+            });
+        });
+    });
 });
 
 describe('PostgresWarehouseClient statement timeout', () => {

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -607,14 +607,7 @@ export class PostgresClient<
             return {};
         }
 
-        const { rows: pgVersionRows } = await this.runQuery('SELECT version()');
-        const pgVersionString = pgVersionRows[0]?.version ?? '';
-        const versionRegex = /PostgreSQL (\d+)\./;
-        const versionMatch = pgVersionString.match(versionRegex);
-        const supportsMatviews =
-            versionMatch && versionMatch[1]
-                ? parseInt(versionMatch[1], 10) >= 12
-                : false;
+        const supportsMatviews = await this.supportsMatviews();
 
         const query = `
             SELECT table_catalog,
@@ -636,7 +629,7 @@ export class PostgresClient<
                 n.nspname AS table_schema,
                 c.relname AS table_name,
                 a.attname AS column_name,
-                pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type
+                pg_catalog.format_type(a.atttypid, NULL) AS data_type
             FROM pg_catalog.pg_attribute a
             JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
             JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
@@ -696,29 +689,68 @@ export class PostgresClient<
         return catalog;
     }
 
+    private serverVersion: Promise<string> | undefined;
+
+    protected getServerVersion(): Promise<string> {
+        this.serverVersion ??= this.runQuery('SELECT version()').then(
+            ({ rows }) => String(rows[0]?.version ?? ''),
+        );
+        return this.serverVersion;
+    }
+
+    // Redshift reports itself as PostgreSQL 8.x and has no pg_matviews
+    protected async supportsMatviews(): Promise<boolean> {
+        const versionMatch = (await this.getServerVersion()).match(
+            /PostgreSQL (\d+)\./,
+        );
+        return versionMatch?.[1] ? parseInt(versionMatch[1], 10) >= 12 : false;
+    }
+
+    protected async isRedshift(): Promise<boolean> {
+        return (await this.getServerVersion()).includes('Redshift');
+    }
+
+    // A session only sees its own database, so no catalog filter is needed
     async getAllTables() {
-        const databaseName = this.config.database;
-        const whereSql = databaseName ? `AND table_catalog = $1` : '';
-        const filterSystemTables = `AND table_schema NOT IN ('information_schema', 'pg_catalog')`;
+        const supportsMatviews = await this.supportsMatviews();
         const query = `
             SELECT table_catalog, table_schema, table_name
             FROM information_schema.tables
-            WHERE table_type = 'BASE TABLE'
-                ${whereSql}
-                ${filterSystemTables}
+            WHERE table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')
+                AND table_schema NOT IN ('information_schema', 'pg_catalog')
+            ${
+                supportsMatviews
+                    ? `
+            UNION ALL
+            SELECT current_database() AS table_catalog,
+                   schemaname AS table_schema,
+                   matviewname AS table_name
+            FROM pg_catalog.pg_matviews
+            WHERE schemaname NOT IN ('information_schema', 'pg_catalog')`
+                    : ''
+            }
             ORDER BY 1, 2, 3
         `;
-        const { rows } = await this.runQuery(
-            query,
-            {},
-            undefined,
-            databaseName ? [databaseName] : [],
-        );
+        const { rows } = await this.runQuery(query);
         return rows.map((row) => ({
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
         }));
+    }
+
+    // Positional parameters for a field lookup, so optional filters keep their numbering
+    protected bindFieldsFilters(
+        tableName: string,
+        schema?: string,
+        database?: string,
+    ) {
+        const values = [tableName];
+        const schemaParam = schema ? `$${values.push(schema)}` : undefined;
+        const databaseParam = database
+            ? `$${values.push(database)}`
+            : undefined;
+        return { values, schemaParam, databaseParam };
     }
 
     async getFields(
@@ -727,6 +759,12 @@ export class PostgresClient<
         database?: string,
         tags?: Record<string, string>,
     ): Promise<WarehouseCatalog> {
+        const { values, schemaParam, databaseParam } = this.bindFieldsFilters(
+            tableName,
+            schema,
+            database,
+        );
+        const supportsMatviews = await this.supportsMatviews();
         const query = `
             SELECT table_catalog,
                    table_schema,
@@ -735,18 +773,37 @@ export class PostgresClient<
                    data_type
             FROM information_schema.columns
             WHERE table_name = $1
-            ${schema ? 'AND table_schema = $2' : ''}
-            ${database ? 'AND table_catalog = $3' : ''}
+            ${schemaParam ? `AND table_schema = ${schemaParam}` : ''}
+            ${databaseParam ? `AND table_catalog = ${databaseParam}` : ''}
+            ${
+                supportsMatviews
+                    ? `
+            UNION ALL
+            SELECT current_database() AS table_catalog,
+                   n.nspname AS table_schema,
+                   c.relname AS table_name,
+                   a.attname AS column_name,
+                   pg_catalog.format_type(a.atttypid, NULL) AS data_type
+            FROM pg_catalog.pg_attribute a
+            JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+            WHERE c.relkind = 'm'
+            AND c.relname = $1
+            ${schemaParam ? `AND n.nspname = ${schemaParam}` : ''}
+            ${databaseParam ? `AND current_database() = ${databaseParam}` : ''}
+            AND a.attnum > 0
+            AND NOT a.attisdropped`
+                    : ''
+            }
         `;
-        const values = [tableName];
-        if (schema) {
-            values.push(schema);
-        }
-        if (database) {
-            values.push(database);
-        }
         const { rows } = await this.runQuery(query, tags, undefined, values);
 
+        return this.parsePostgresCatalog(rows);
+    }
+
+    protected parsePostgresCatalog(
+        rows: Record<string, AnyType>[],
+    ): WarehouseCatalog {
         return this.parseWarehouseCatalog(
             rows,
             mapFieldType,

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
@@ -1,18 +1,31 @@
-import { RedshiftAuthenticationType, WarehouseTypes } from '@lightdash/common';
+import {
+    RedshiftAuthenticationType,
+    WarehouseTypes,
+    type CreateRedshiftCredentials,
+} from '@lightdash/common';
 import { RedshiftWarehouseClient } from './RedshiftWarehouseClient';
+
+const credentials: CreateRedshiftCredentials = {
+    type: WarehouseTypes.REDSHIFT,
+    host: 'localhost',
+    user: 'analytics',
+    password: 'password',
+    port: 5439,
+    dbname: 'warehouse',
+    schema: 'public',
+    authenticationType: RedshiftAuthenticationType.PASSWORD,
+};
+
+const redshiftVersion = {
+    rows: [
+        { version: 'PostgreSQL 8.0.2 on i686-pc-linux-gnu, Redshift 1.0.77' },
+    ],
+    fields: {},
+};
 
 describe('RedshiftWarehouseClient', () => {
     it('keeps catalog filters in the Redshift query', async () => {
-        const warehouse = new RedshiftWarehouseClient({
-            type: WarehouseTypes.REDSHIFT,
-            host: 'localhost',
-            user: 'analytics',
-            password: 'password',
-            port: 5439,
-            dbname: 'warehouse',
-            schema: 'public',
-            authenticationType: RedshiftAuthenticationType.PASSWORD,
-        });
+        const warehouse = new RedshiftWarehouseClient(credentials);
         const runQuery = vi
             .spyOn(warehouse, 'runQuery')
             .mockResolvedValueOnce({
@@ -30,5 +43,90 @@ describe('RedshiftWarehouseClient', () => {
         expect(catalogQuery).toContain("table_schema IN ('public')");
         expect(catalogQuery).toContain("table_name IN ('orders')");
         expect(runQuery.mock.calls[1][3]).toBeUndefined();
+    });
+
+    it('lists tables and views from svv_tables scoped to the database', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce(redshiftVersion)
+            .mockResolvedValueOnce({
+                rows: [
+                    {
+                        table_catalog: 'warehouse',
+                        table_schema: 'public',
+                        table_name: 'orders_lbv',
+                    },
+                ],
+                fields: {},
+            });
+
+        const tables = await warehouse.getAllTables();
+
+        const [query, , , values] = runQuery.mock.calls[1];
+        expect(query).toContain('FROM svv_tables');
+        expect(query).toContain('table_catalog = $1');
+        expect(values).toEqual(['warehouse']);
+        expect(tables).toEqual([
+            { database: 'warehouse', schema: 'public', table: 'orders_lbv' },
+        ]);
+    });
+
+    it('reads columns from svv_columns so late-binding views resolve', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce(redshiftVersion)
+            .mockResolvedValueOnce({
+                rows: [
+                    {
+                        table_catalog: 'warehouse',
+                        table_schema: 'public',
+                        table_name: 'orders_lbv',
+                        column_name: 'quantity',
+                        data_type: 'integer',
+                    },
+                ],
+                fields: {},
+            });
+
+        const fields = await warehouse.getFields(
+            'orders_lbv',
+            'public',
+            'warehouse',
+        );
+
+        const [query, , , values] = runQuery.mock.calls[1];
+        expect(query).toContain('FROM svv_columns');
+        expect(values).toEqual(['orders_lbv', 'public', 'warehouse']);
+        expect(fields).toEqual({
+            warehouse: {
+                public: { orders_lbv: { quantity: 'number' } },
+            },
+        });
+    });
+
+    it('keeps the Postgres catalog when the server is not Redshift', async () => {
+        const warehouse = new RedshiftWarehouseClient(credentials);
+        const runQuery = vi
+            .spyOn(warehouse, 'runQuery')
+            .mockResolvedValueOnce({
+                rows: [{ version: 'PostgreSQL 15.4' }],
+                fields: {},
+            })
+            .mockResolvedValueOnce({ rows: [], fields: {} })
+            .mockResolvedValueOnce({ rows: [], fields: {} });
+
+        await warehouse.getAllTables();
+        await warehouse.getFields('orders', 'public');
+
+        expect(runQuery).toHaveBeenCalledTimes(3);
+        expect(runQuery.mock.calls[1][0]).toContain(
+            'FROM information_schema.tables',
+        );
+        expect(runQuery.mock.calls[1][0]).not.toContain('svv_tables');
+        expect(runQuery.mock.calls[2][0]).toContain(
+            'FROM information_schema.columns',
+        );
     });
 });

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
@@ -3,6 +3,7 @@ import {
     CreateRedshiftCredentials,
     RedshiftAuthenticationType,
     SupportedDbtAdapter,
+    WarehouseCatalog,
     WarehouseResults,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -128,6 +129,58 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
             this.config = await this.resolveIamPoolConfig();
         }
         return super.streamQuery(sql, streamCallback, options);
+    }
+
+    // information_schema omits late-binding views and Spectrum external tables;
+    // the SVV_* views cover them alongside regular tables and views. A Redshift
+    // project pointed at plain Postgres keeps the Postgres catalog.
+    async getAllTables() {
+        if (!(await this.isRedshift())) return super.getAllTables();
+        const query = `
+            SELECT table_catalog, table_schema, table_name
+            FROM svv_tables
+            WHERE table_catalog = $1
+                AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_internal')
+            ORDER BY 1, 2, 3
+        `;
+        const { rows } = await this.runQuery(query, {}, undefined, [
+            this.credentials.dbname,
+        ]);
+        return rows.map((row) => ({
+            database: row.table_catalog,
+            schema: row.table_schema,
+            table: row.table_name,
+        }));
+    }
+
+    async getFields(
+        tableName: string,
+        schema?: string,
+        database?: string,
+        tags?: Record<string, string>,
+    ): Promise<WarehouseCatalog> {
+        if (!(await this.isRedshift())) {
+            return super.getFields(tableName, schema, database, tags);
+        }
+        const { values, schemaParam, databaseParam } = this.bindFieldsFilters(
+            tableName,
+            schema,
+            database,
+        );
+        const query = `
+            SELECT table_catalog,
+                   table_schema,
+                   table_name,
+                   column_name,
+                   data_type
+            FROM svv_columns
+            WHERE table_name = $1
+            ${schemaParam ? `AND table_schema = ${schemaParam}` : ''}
+            ${databaseParam ? `AND table_catalog = ${databaseParam}` : ''}
+            ORDER BY ordinal_position
+        `;
+        const { rows } = await this.runQuery(query, tags, undefined, values);
+        return this.parsePostgresCatalog(rows);
     }
 
     private async resolveIamPoolConfig(): Promise<PoolConfig> {


### PR DESCRIPTION
## Summary

Stacked on #29011. With views listed, schemas get bigger. The sidebar rendered a row per table for every expanded schema and hid everything past the first 100 tables behind "search to see more", so large schemas were either truncated or sluggish.

Relates: PROD-5746

## Changes

- `Tables.tsx` renders one virtualized flat list (`@tanstack/react-virtual`, already a dependency) of schema headers and table rows inside the existing Mantine `ScrollArea`, using its `viewportRef` as the scroll element. Rows are measured, so there are no fixed row heights.
- The 100-table cap and its "Filtering first N" hint are gone: every table in a schema is reachable by scrolling.
- Expand and collapse state is per schema and resets when the search changes. Searching expands the matching schemas and the active table's schema stays expanded, as before. This replaces the effect-driven expansion the old code left a TODO about (it re-rendered every table unfiltered whenever a search cleared).
- `utils/tableRows.ts` holds the pure search filter and row builder, with unit tests.
- "No results found" now shows for a search with no matches (previously blank).

## Regression analysis

- Small catalogs behave the same: schemas collapsed by default, click to expand, search filters and highlights.
- Row hover, copy button, truncation tooltip and active highlight are unchanged (same `TableItem`).
- Rows outside the viewport are not in the DOM, so tabbing through thousands of rows is no longer possible. This matches the virtualized explore sidebar.

## Evidence

A schema with 2,500 views. Before (with #29011 only): capped at 100. After: every row reachable, 23 rows in the DOM for a 73,784px list, scrolling stays smooth.

<table><tr>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr2-before-capped-100.png" width="300" alt="Before: capped at the first 100 tables"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr2-after-expanded.png" width="300" alt="After: schema expanded"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr2-after-scrolled-2500.png" width="300" alt="After: scrolled to the 2500th view"></td>
</tr></table>

## Test plan

- [x] `pnpm -F frontend test src/features/sqlRunner/utils/tableRows.test.ts`
- [x] `pnpm -F frontend typecheck`, oxlint on the changed files
- [x] Verified in the app with a 2,500-view schema (screenshots above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFNdHweoAjBXR2Gt4b4S19
