### PR TITLE
feat(sql-runner): show the relation type in the table browser

### DIFF
--- a/packages/api-tests/tests/sqlRunner.test.ts
+++ b/packages/api-tests/tests/sqlRunner.test.ts
@@ -169,18 +169,18 @@ for (const [warehouseName, warehouseConfig] of warehouseEntries) {
                         Object.keys(resp.body.results[database][schema]),
                     ).toContain(table);
                 }
-                expect(
-                    Object.keys(resp.body.results[database][schema].ORDERS),
-                ).toEqual([]);
+                expect(resp.body.results[database][schema].ORDERS).toEqual({
+                    tableType: 'table',
+                });
             } else {
                 for (const table of ['customers', 'orders', 'payments']) {
                     expect(
                         Object.keys(resp.body.results[database][schema]),
                     ).toContain(table);
                 }
-                expect(
-                    Object.keys(resp.body.results[database][schema].orders),
-                ).toEqual([]);
+                expect(resp.body.results[database][schema].orders).toEqual({
+                    tableType: 'table',
+                });
             }
         });
 

--- a/packages/backend/src/database/entities/warehouseAvailableTables.ts
+++ b/packages/backend/src/database/entities/warehouseAvailableTables.ts
@@ -9,6 +9,7 @@ export type DbWarehouseAvailableTables = {
     project_warehouse_credentials_id: number | null;
     user_warehouse_credentials_uuid: string | null;
     partition_column: PartitionColumn | null;
+    table_type: string | null;
 };
 
 export const WarehouseAvailableTablesTableName =

--- a/packages/backend/src/database/migrations/20260910160000_add_table_type_to_warehouse_available_tables.ts
+++ b/packages/backend/src/database/migrations/20260910160000_add_table_type_to_warehouse_available_tables.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+const TABLE_NAME = 'warehouse_credentials_available_tables';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.string('table_type').nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.dropColumn('table_type');
+    });
+}

--- a/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
+++ b/packages/backend/src/models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel.ts
@@ -1,4 +1,5 @@
 import {
+    isWarehouseTableType,
     NotFoundError,
     WarehouseCatalog,
     WarehouseTables,
@@ -20,12 +21,13 @@ export class WarehouseAvailableTablesModel {
     static toWarehouseCatalog(
         rows: Pick<
             DbWarehouseAvailableTables,
-            'database' | 'schema' | 'table' | 'partition_column'
+            'database' | 'schema' | 'table' | 'partition_column' | 'table_type'
         >[],
     ): WarehouseTablesCatalog {
         return rows.reduce((acc, row) => {
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            const { database, schema, table, partition_column } = row;
+            const { database, schema, table, partition_column, table_type } =
+                row;
             if (!acc[database]) {
                 acc[database] = {};
             }
@@ -34,6 +36,10 @@ export class WarehouseAvailableTablesModel {
             }
             acc[database][schema][table] = {
                 partitionColumn: partition_column || undefined,
+                // Rows cached before the column existed have no type
+                tableType: isWarehouseTableType(table_type)
+                    ? table_type
+                    : undefined,
             };
             return acc;
         }, {} as WarehouseTablesCatalog);
@@ -47,7 +53,13 @@ export class WarehouseAvailableTablesModel {
                 'user_warehouse_credentials_uuid',
                 userWarehouseCredentialsId,
             )
-            .select(['database', 'schema', 'table', 'partition_column']);
+            .select([
+                'database',
+                'schema',
+                'table',
+                'partition_column',
+                'table_type',
+            ]);
         return WarehouseAvailableTablesModel.toWarehouseCatalog(rows);
     }
 
@@ -64,7 +76,13 @@ export class WarehouseAvailableTablesModel {
                 `${WarehouseAvailableTablesTableName}.project_warehouse_credentials_id`,
             )
             .where('project_uuid', projectUuid)
-            .select(['database', 'schema', 'table', 'partition_column']);
+            .select([
+                'database',
+                'schema',
+                'table',
+                'partition_column',
+                'table_type',
+            ]);
         return WarehouseAvailableTablesModel.toWarehouseCatalog(rows);
     }
 
@@ -88,7 +106,7 @@ export class WarehouseAvailableTablesModel {
             throw new NotFoundError('Warehouse credentials not found');
         }
         const rows = tables.map(
-            ({ database, schema, table, partitionColumn }) => ({
+            ({ database, schema, table, partitionColumn, tableType }) => ({
                 database,
                 schema,
                 table,
@@ -96,6 +114,7 @@ export class WarehouseAvailableTablesModel {
                     warehouseCredentialsId.warehouse_credentials_id,
                 user_warehouse_credentials_uuid: null,
                 partition_column: partitionColumn || null,
+                table_type: tableType,
             }),
         );
 
@@ -118,12 +137,12 @@ export class WarehouseAvailableTablesModel {
         tables: WarehouseTables,
     ) {
         const rows = tables.map(
-            ({ database, schema, table, partitionColumn }) => ({
+            ({ database, schema, table, partitionColumn, tableType }) => ({
                 database,
                 schema,
                 table,
                 partition_column: partitionColumn || null,
-
+                table_type: tableType,
                 project_warehouse_credentials_id: null,
                 user_warehouse_credentials_uuid: userWarehouseCredentialsUuid,
             }),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -10001,6 +10001,7 @@ export class ProjectService extends BaseService {
             warehouseTables.map((t) => ({
                 ...t,
                 partition_column: t.partitionColumn || null,
+                table_type: t.tableType,
             })),
         );
 

--- a/packages/common/src/types/warehouse.test.ts
+++ b/packages/common/src/types/warehouse.test.ts
@@ -4,9 +4,12 @@ import {
     ensureCatalogTimestampDomainsKey,
     getCatalogTimestampDomain,
     getUserAttributeQueryTags,
+    getWarehouseTableType,
+    isWarehouseTableType,
     sanitizeQueryTagKey,
     sanitizeQueryTagValue,
     setCatalogTimestampDomain,
+    WarehouseTableType,
     type WarehouseCatalog,
 } from './warehouse';
 
@@ -123,5 +126,37 @@ describe('catalog timestamp domain sidecar', () => {
                 'created_at',
             ),
         ).toEqual('aware');
+    });
+});
+
+describe('getWarehouseTableType', () => {
+    it.each([
+        ['BASE TABLE', WarehouseTableType.TABLE],
+        ['MANAGED', WarehouseTableType.TABLE],
+        ['STREAMING_TABLE', WarehouseTableType.TABLE],
+        ['MergeTree', WarehouseTableType.TABLE],
+        ['VIEW', WarehouseTableType.VIEW],
+        ['View', WarehouseTableType.VIEW],
+        ['VIRTUAL_VIEW', WarehouseTableType.VIEW],
+        ['MATERIALIZED VIEW', WarehouseTableType.MATERIALIZED_VIEW],
+        ['MATERIALIZED_VIEW', WarehouseTableType.MATERIALIZED_VIEW],
+        ['MaterializedView', WarehouseTableType.MATERIALIZED_VIEW],
+        ['EXTERNAL', WarehouseTableType.EXTERNAL],
+        ['EXTERNAL TABLE', WarehouseTableType.EXTERNAL],
+        ['EXTERNAL_TABLE', WarehouseTableType.EXTERNAL],
+        ['FOREIGN', WarehouseTableType.EXTERNAL],
+        [null, WarehouseTableType.TABLE],
+        [undefined, WarehouseTableType.TABLE],
+        [42, WarehouseTableType.TABLE],
+    ])('maps %s to %s', (raw, expected) => {
+        expect(getWarehouseTableType(raw)).toBe(expected);
+    });
+});
+
+describe('isWarehouseTableType', () => {
+    it('accepts stored enum values and rejects raw warehouse strings', () => {
+        expect(isWarehouseTableType('view')).toBe(true);
+        expect(isWarehouseTableType('VIEW')).toBe(false);
+        expect(isWarehouseTableType(null)).toBe(false);
     });
 });

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -247,10 +247,52 @@ export const setCatalogNestedColumnShape = (
     ] = shape;
 };
 
+export enum WarehouseTableType {
+    TABLE = 'table',
+    VIEW = 'view',
+    MATERIALIZED_VIEW = 'materialized_view',
+    EXTERNAL = 'external',
+}
+
+export const isWarehouseTableType = (
+    value: unknown,
+): value is WarehouseTableType =>
+    typeof value === 'string' &&
+    Object.values<string>(WarehouseTableType).includes(value);
+
+// Maps the table_type strings and engine names warehouses report onto one vocabulary
+export const getWarehouseTableType = (rawType: unknown): WarehouseTableType => {
+    const normalized =
+        typeof rawType === 'string'
+            ? rawType
+                  .trim()
+                  .toUpperCase()
+                  .replace(/[\s_]+/g, ' ')
+            : '';
+    switch (normalized) {
+        case 'VIEW':
+        case 'VIRTUAL VIEW':
+            return WarehouseTableType.VIEW;
+        case 'MATERIALIZED VIEW':
+        case 'MATERIALIZEDVIEW':
+            return WarehouseTableType.MATERIALIZED_VIEW;
+        case 'EXTERNAL':
+        case 'EXTERNAL TABLE':
+        case 'FOREIGN':
+        case 'FOREIGN TABLE':
+            return WarehouseTableType.EXTERNAL;
+        default:
+            return WarehouseTableType.TABLE;
+    }
+};
+
 export type WarehouseTablesCatalog = {
     [database: string]: {
         [schema: string]: {
-            [table: string]: { partitionColumn?: PartitionColumn };
+            [table: string]: {
+                partitionColumn?: PartitionColumn;
+                tableType?: WarehouseTableType;
+            };
         };
     };
 };
@@ -259,6 +301,7 @@ export type WarehouseTables = {
     database: string;
     schema: string;
     table: string;
+    tableType: WarehouseTableType;
     partitionColumn?: PartitionColumn;
 }[];
 

--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -1,4 +1,9 @@
-import { PartitionType, type PartitionColumn } from '@lightdash/common';
+import {
+    assertUnreachable,
+    PartitionType,
+    WarehouseTableType,
+    type PartitionColumn,
+} from '@lightdash/common';
 import {
     TextInput,
     Box,
@@ -16,9 +21,13 @@ import { useDebouncedValue, useHover } from '@mantine/hooks';
 import {
     IconChevronDown,
     IconChevronRight,
+    IconCloudDataConnection,
+    IconEye,
+    IconEyeTable,
     IconSearch,
     IconTable,
     IconX,
+    type Icon,
 } from '@tabler/icons-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import dayjs from 'dayjs';
@@ -50,7 +59,27 @@ interface TableItemProps {
     database: string;
     isActive: boolean;
     partitionColumn: PartitionColumn | undefined;
+    tableType: WarehouseTableType | undefined;
 }
+
+// Rows cached before the type was stored fall back to the table icon
+const getTableTypeDisplay = (
+    tableType: WarehouseTableType | undefined,
+): { icon: Icon; label: string } => {
+    switch (tableType) {
+        case WarehouseTableType.VIEW:
+            return { icon: IconEye, label: 'View' };
+        case WarehouseTableType.MATERIALIZED_VIEW:
+            return { icon: IconEyeTable, label: 'Materialized view' };
+        case WarehouseTableType.EXTERNAL:
+            return { icon: IconCloudDataConnection, label: 'External table' };
+        case WarehouseTableType.TABLE:
+        case undefined:
+            return { icon: IconTable, label: 'Table' };
+        default:
+            return assertUnreachable(tableType, 'Unknown table type');
+    }
+};
 
 const partitionFilter = (partitionColumn: PartitionColumn | undefined) => {
     if (partitionColumn) {
@@ -70,8 +99,17 @@ const partitionFilter = (partitionColumn: PartitionColumn | undefined) => {
 };
 
 const TableItem: FC<TableItemProps> = memo(
-    ({ table, search, schema, database, isActive, partitionColumn }) => {
+    ({
+        table,
+        search,
+        schema,
+        database,
+        isActive,
+        partitionColumn,
+        tableType,
+    }) => {
         const { ref: hoverRef, hovered } = useHover();
+        const typeDisplay = getTableTypeDisplay(tableType);
         const { ref: truncatedRef, isTruncated } =
             useIsTruncated<HTMLDivElement>();
         const dispatch = useAppDispatch();
@@ -103,11 +141,14 @@ const TableItem: FC<TableItemProps> = memo(
                     className={styles.tableButton}
                 >
                     <Group gap="xs" wrap="nowrap">
-                        <MantineIcon
-                            icon={IconTable}
-                            size="sm"
-                            className={styles.tableIcon}
-                        />
+                        <Tooltip label={typeDisplay.label} openDelay={400}>
+                            <MantineIcon
+                                icon={typeDisplay.icon}
+                                size="sm"
+                                className={styles.tableIcon}
+                                aria-label={typeDisplay.label}
+                            />
+                        </Tooltip>
                         <Tooltip
                             label={table}
                             disabled={!isTruncated}
@@ -203,6 +244,7 @@ const VirtualRow: FC<{
             search={search}
             isActive={row.table === activeTable && row.schema === activeSchema}
             partitionColumn={row.partitionColumn}
+            tableType={row.tableType}
         />
     );
 };

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
@@ -1,4 +1,4 @@
-import { PartitionType } from '@lightdash/common';
+import { PartitionType, WarehouseTableType } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     buildTableRows,
@@ -14,7 +14,11 @@ const partitionColumn = {
 const tablesBySchema: SchemaTables[] = [
     {
         schema: 'jaffle',
-        tables: { customers: {}, orders: { partitionColumn }, payments: {} },
+        tables: {
+            customers: {},
+            orders: { partitionColumn },
+            payments: { tableType: WarehouseTableType.VIEW },
+        },
     },
     { schema: 'staging', tables: { stg_orders: {} } },
 ];
@@ -60,6 +64,11 @@ describe('buildTableRows', () => {
             schema: 'jaffle',
             table: 'orders',
             partitionColumn,
+            tableType: undefined,
+        });
+        expect(rows[3]).toMatchObject({
+            table: 'payments',
+            tableType: WarehouseTableType.VIEW,
         });
     });
 });

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
@@ -1,4 +1,7 @@
-import { type PartitionColumn } from '@lightdash/common';
+import {
+    type PartitionColumn,
+    type WarehouseTableType,
+} from '@lightdash/common';
 import Fuse from 'fuse.js';
 import { type TablesBySchema } from '../hooks/useTables';
 
@@ -18,6 +21,7 @@ export type TableRow =
           schema: string;
           table: string;
           partitionColumn: PartitionColumn | undefined;
+          tableType: WarehouseTableType | undefined;
       };
 
 export const filterTablesBySchema = (
@@ -67,6 +71,7 @@ export const buildTableRows = (
                     schema: schemaName,
                     table,
                     partitionColumn: tables[table].partitionColumn,
+                    tableType: tables[table].tableType,
                 }),
             ),
         ];

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -14,6 +14,7 @@ import {
     CreateAthenaCredentials,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     setCatalogTimestampDomain,
@@ -22,6 +23,7 @@ import {
     WarehouseConnectionError,
     WarehouseQueryError,
     WarehouseResults,
+    WarehouseTables,
     WarehouseTypes,
     type ResultNumericKind,
     type TimestampDomain,
@@ -614,11 +616,8 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
         }, {});
     }
 
-    async getAllTables(): Promise<
-        { database: string; schema: string; table: string }[]
-    > {
-        const tables: { database: string; schema: string; table: string }[] =
-            [];
+    async getAllTables(): Promise<WarehouseTables> {
+        const tables: WarehouseTables = [];
 
         try {
             let nextToken: string | undefined;
@@ -640,6 +639,9 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                             database: this.credentials.database,
                             schema: this.credentials.schema,
                             table: tableMeta.Name,
+                            tableType: getWarehouseTableType(
+                                tableMeta.TableType,
+                            ),
                         });
                     }
                 });

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -23,6 +23,7 @@ import {
     CreateBigqueryCredentials,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     PartitionColumn,
@@ -814,6 +815,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                     database: t.bigQuery.projectId,
                     schema: t.dataset.id!,
                     table: t.id!,
+                    tableType: getWarehouseTableType(t.metadata?.type),
                     partitionColumn,
                 };
             }),

--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -9,6 +9,7 @@ import {
     CreateClickhouseCredentials,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     setCatalogTimestampDomain,
@@ -549,7 +550,8 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
             SELECT 
                 '' as "table_catalog",
                 database as "table_schema",
-                name as "table_name"
+                name as "table_name",
+                engine as "table_type"
             FROM system.tables
             WHERE database = {databaseName: String}
             ORDER BY database, name
@@ -561,6 +563,7 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
             database: row.table_catalog,
             schema: row.table_schema || 'default',
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.test.ts
@@ -451,6 +451,7 @@ describe('DatabricksWarehouseClient getAllTables', () => {
                     table_catalog: 'main',
                     table_schema: 'analytics',
                     table_name: 'orders_view',
+                    table_type: 'MATERIALIZED_VIEW',
                 },
             ],
             fields: {},
@@ -459,10 +460,15 @@ describe('DatabricksWarehouseClient getAllTables', () => {
         const tables = await warehouse.getAllTables();
 
         const [query] = runQuery.mock.calls[0];
-        expect(query).not.toContain('table_type');
+        expect(query).not.toContain('table_type =');
         expect(query).toContain("table_schema <> 'information_schema'");
         expect(tables).toEqual([
-            { database: 'main', schema: 'analytics', table: 'orders_view' },
+            {
+                database: 'main',
+                schema: 'analytics',
+                table: 'orders_view',
+                tableType: 'materialized_view',
+            },
         ]);
     });
 });

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -12,6 +12,7 @@ import {
     DatabricksAuthenticationType,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     ParseError,
@@ -677,7 +678,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
     // tables, views, materialized views, streaming tables and foreign tables
     async getAllTables() {
         const query = `
-            SELECT table_catalog, table_schema, table_name
+            SELECT table_catalog, table_schema, table_name, table_type
             FROM information_schema.tables
             WHERE table_schema <> 'information_schema'
             ORDER BY 1,2,3
@@ -687,6 +688,7 @@ export class DatabricksWarehouseClient extends WarehouseBaseClient<CreateDatabri
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -16,6 +16,7 @@ import {
     DucklakeDataPathType,
     formatMilliseconds,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     NotImplementedError,
@@ -25,6 +26,7 @@ import {
     WarehouseCatalog,
     WarehouseQueryError,
     WarehouseResults,
+    WarehouseTables,
     WarehouseTypes,
     type ResultNumericKind,
     type TimestampDomain,
@@ -2679,15 +2681,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
     async getAllTables(
         schema?: string,
         tags?: Record<string, string>,
-    ): Promise<
-        {
-            database: string;
-            schema: string;
-            table: string;
-        }[]
-    > {
+    ): Promise<WarehouseTables> {
         return this.withSession(async (db) => {
-            let sql = `SELECT table_catalog AS database, table_schema AS schema, table_name AS table
+            let sql = `SELECT table_catalog AS database, table_schema AS schema, table_name AS table, table_type
                         FROM information_schema.tables
                         WHERE table_type IN ('BASE TABLE', 'VIEW')`;
 
@@ -2704,6 +2700,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbMothe
                 database: row.database as string,
                 schema: row.schema as string,
                 table: row.table as string,
+                tableType: getWarehouseTableType(row.table_type),
             }));
         });
     }

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.test.ts
@@ -185,6 +185,13 @@ describe('PostgresWarehouseClient', () => {
                             table_catalog: 'warehouse',
                             table_schema: 'public',
                             table_name: 'orders_view',
+                            table_type: 'VIEW',
+                        },
+                        {
+                            table_catalog: 'warehouse',
+                            table_schema: 'public',
+                            table_name: 'orders_mv',
+                            table_type: 'MATERIALIZED VIEW',
                         },
                     ],
                     fields: {},
@@ -202,6 +209,13 @@ describe('PostgresWarehouseClient', () => {
                     database: 'warehouse',
                     schema: 'public',
                     table: 'orders_view',
+                    tableType: 'view',
+                },
+                {
+                    database: 'warehouse',
+                    schema: 'public',
+                    table: 'orders_mv',
+                    tableType: 'materialized_view',
                 },
             ]);
         });

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -4,6 +4,7 @@ import {
     CreatePostgresLikeCredentials,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     Metric,
     MetricType,
     setCatalogTimestampDomain,
@@ -714,7 +715,7 @@ export class PostgresClient<
     async getAllTables() {
         const supportsMatviews = await this.supportsMatviews();
         const query = `
-            SELECT table_catalog, table_schema, table_name
+            SELECT table_catalog, table_schema, table_name, table_type
             FROM information_schema.tables
             WHERE table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')
                 AND table_schema NOT IN ('information_schema', 'pg_catalog')
@@ -724,7 +725,8 @@ export class PostgresClient<
             UNION ALL
             SELECT current_database() AS table_catalog,
                    schemaname AS table_schema,
-                   matviewname AS table_name
+                   matviewname AS table_name,
+                   'MATERIALIZED VIEW' AS table_type
             FROM pg_catalog.pg_matviews
             WHERE schemaname NOT IN ('information_schema', 'pg_catalog')`
                     : ''
@@ -736,6 +738,7 @@ export class PostgresClient<
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.test.ts
@@ -56,6 +56,13 @@ describe('RedshiftWarehouseClient', () => {
                         table_catalog: 'warehouse',
                         table_schema: 'public',
                         table_name: 'orders_lbv',
+                        table_type: 'VIEW',
+                    },
+                    {
+                        table_catalog: 'warehouse',
+                        table_schema: 'spectrum',
+                        table_name: 'sales',
+                        table_type: 'EXTERNAL TABLE',
                     },
                 ],
                 fields: {},
@@ -68,7 +75,18 @@ describe('RedshiftWarehouseClient', () => {
         expect(query).toContain('table_catalog = $1');
         expect(values).toEqual(['warehouse']);
         expect(tables).toEqual([
-            { database: 'warehouse', schema: 'public', table: 'orders_lbv' },
+            {
+                database: 'warehouse',
+                schema: 'public',
+                table: 'orders_lbv',
+                tableType: 'view',
+            },
+            {
+                database: 'warehouse',
+                schema: 'spectrum',
+                table: 'sales',
+                tableType: 'external',
+            },
         ]);
     });
 

--- a/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/RedshiftWarehouseClient.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     CreateRedshiftCredentials,
+    getWarehouseTableType,
     RedshiftAuthenticationType,
     SupportedDbtAdapter,
     WarehouseCatalog,
@@ -137,7 +138,7 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
     async getAllTables() {
         if (!(await this.isRedshift())) return super.getAllTables();
         const query = `
-            SELECT table_catalog, table_schema, table_name
+            SELECT table_catalog, table_schema, table_name, table_type
             FROM svv_tables
             WHERE table_catalog = $1
                 AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_internal')
@@ -150,6 +151,7 @@ export class RedshiftWarehouseClient extends PostgresClient<CreateRedshiftCreden
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -3,6 +3,7 @@ import {
     CreateSnowflakeCredentials,
     DimensionType,
     getErrorMessage,
+    getWarehouseTableType,
     isWeekDay,
     Metric,
     MetricType,
@@ -1818,9 +1819,10 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             SELECT
                 TABLE_CATALOG as "table_catalog",
                 TABLE_SCHEMA as "table_schema",
-                TABLE_NAME as "table_name"
+                TABLE_NAME as "table_name",
+                TABLE_TYPE as "table_type"
             FROM information_schema.tables
-            WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW')
+            WHERE TABLE_TYPE IN ('BASE TABLE', 'VIEW', 'MATERIALIZED VIEW', 'EXTERNAL TABLE')
             ${whereSql}
             ORDER BY 1,2,3
         `;
@@ -1838,6 +1840,7 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -240,6 +240,7 @@ describe('TrinoWarehouseClient getAllTables', () => {
                     table_catalog: 'hive',
                     table_schema: 'analytics',
                     table_name: 'orders_view',
+                    table_type: 'VIEW',
                 },
             ],
             fields: {},
@@ -250,7 +251,12 @@ describe('TrinoWarehouseClient getAllTables', () => {
         const [query] = runQuery.mock.calls[0];
         expect(query).toContain("table_type IN ('BASE TABLE', 'VIEW')");
         expect(tables).toEqual([
-            { database: 'hive', schema: 'analytics', table: 'orders_view' },
+            {
+                database: 'hive',
+                schema: 'analytics',
+                table: 'orders_view',
+                tableType: 'view',
+            },
         ]);
     });
 });

--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.ts
@@ -2,6 +2,7 @@ import {
     AnyType,
     CreateTrinoCredentials,
     DimensionType,
+    getWarehouseTableType,
     Metric,
     MetricType,
     getErrorMessage as originalGetErrorMessage,
@@ -537,7 +538,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             : '';
         const filterSystemTables = `AND table_schema NOT IN ('information_schema', 'pg_catalog')`;
         const query = `
-            SELECT table_catalog, table_schema, table_name
+            SELECT table_catalog, table_schema, table_name, table_type
             FROM information_schema.tables
             WHERE table_type IN ('BASE TABLE', 'VIEW')
                 ${whereSql}
@@ -549,6 +550,7 @@ export class TrinoWarehouseClient extends WarehouseBaseClient<CreateTrinoCredent
             database: row.table_catalog,
             schema: row.table_schema,
             table: row.table_name,
+            tableType: getWarehouseTableType(row.table_type),
         }));
     }
 }

--- a/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
+++ b/packages/warehouses/src/warehouseClients/WarehouseBaseClient.ts
@@ -3,13 +3,13 @@ import {
     CreateWarehouseCredentials,
     DimensionType,
     Metric,
-    PartitionColumn,
     setCatalogTimestampDomain,
     SupportedDbtAdapter,
     TimeIntervalUnit,
     WarehouseCatalog,
     WarehouseResults,
     WarehouseSqlBuilder,
+    WarehouseTables,
     WeekDay,
     type TimestampDomain,
     type WarehouseExecuteAsyncQuery,
@@ -186,14 +186,7 @@ export default abstract class WarehouseBaseClient<
     abstract getAllTables(
         schema?: string,
         tags?: Record<string, string>,
-    ): Promise<
-        {
-            database: string;
-            schema: string;
-            table: string;
-            partitionColumn?: PartitionColumn;
-        }[]
-    >;
+    ): Promise<WarehouseTables>;
 
     abstract getFields(
         tableName: string,


### PR DESCRIPTION
## Summary

Stacked on #29013. Now that views are listed, the sidebar shows what kind of relation each row is. Every warehouse client reports a normalized type, the available-tables cache stores it, the catalog API returns it, and the table browser renders an icon per type with a tooltip.

Relates: PROD-5746

## Changes

**common**
- `WarehouseTableType` enum: `table`, `view`, `materialized_view`, `external`.
- `getWarehouseTableType()` maps the strings warehouses report onto it (`BASE TABLE`, `MANAGED`, `STREAMING_TABLE` and ClickHouse engine names fall to table; `VIEW` / `VIRTUAL_VIEW` to view; `MATERIALIZED VIEW` / `MATERIALIZED_VIEW` / `MaterializedView` to materialized view; `EXTERNAL` / `EXTERNAL TABLE` / `FOREIGN` to external). Anything unknown is a table. Unit tests cover the mapping.
- `WarehouseTables` items carry a required `tableType`; the `WarehouseTablesCatalog` API shape gains an optional `tableType` per table, so the response is additive.

**warehouses**
- All nine clients select the type in `getAllTables()`: `table_type` from `information_schema` (Postgres, Redshift via `svv_tables`, Snowflake, Databricks, Trino, DuckDB), the Athena `TableMetadata.TableType`, the BigQuery table metadata `type`, and the ClickHouse `system.tables.engine`. Postgres tags its `pg_matviews` union as a materialized view.
- Snowflake's listing filter now also includes `MATERIALIZED VIEW` and `EXTERNAL TABLE`, which it previously excluded.
- The base class `getAllTables()` contract is `Promise<WarehouseTables>` instead of an inline shape.

**backend**
- Migration adds a nullable `table_type` column to `warehouse_credentials_available_tables`. Metadata-only in Postgres, no backfill: the table is a cache regenerated on refresh.
- The model stores the type and returns it only when it parses as a known enum value, so rows cached before the column existed come back without a type.

**frontend**
- `Tables.tsx` picks the icon from the type: table, view (eye), materialized view, external table (cloud). The icon has an `aria-label` and a tooltip naming the type. Rows without a type keep the table icon.

## Regression analysis

- Existing cached rows have a null type until the next refresh, and the sidebar renders them exactly as before. Nothing changes for a project until someone presses refresh.
- The migration is a nullable column add with no default, so old and new backend versions coexist during a rolling deploy. No release-safety declaration needed.
- Snowflake users will see materialized views and external tables they did not see before, after a refresh.
- The AI tools that read the catalog iterate its entries and ignore unknown keys, so the extra field does not change their output.
- Not verified live on Snowflake, BigQuery, Databricks, Trino, Athena or ClickHouse. The mapping is unit tested and each client's listing test asserts the type it returns.

## Evidence (local Postgres 18, jaffle shop dev DB)

The catalog endpoint after a refresh reports `customers` as a table, `customers_view` as a view and `orders_by_status_mv` as a materialized view. dbt staging models materialized as views pick up the view icon too.

<table><tr>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr4-icons-search.png" width="330" alt="Search results with table and view icons"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr4-matview-tooltip.png" width="330" alt="Materialized view icon with tooltip"></td>
</tr></table>

## Test plan

- [x] `pnpm -F common test` on the new mapping test (17 cases)
- [x] `pnpm -F warehouses test` (458 tests), typecheck and lint
- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F frontend test` on `tableRows.test.ts`, typecheck, oxlint
- [x] Migration run on an isolated clone of the dev database; catalog API and sidebar verified in the app (screenshots above)
- [ ] Spot-check the icon on one non-Postgres warehouse after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFNdHweoAjBXR2Gt4b4S19
