### PR TITLE
feat(ai-agent): open chart references from AI threads in a view/edit modal

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -136,8 +136,8 @@ const UnsavedChangesBridge: FC<{
 
 type Props = {
     opened: boolean;
-    dashboardUuid: string;
-    dashboardName: string;
+    /** Null when hosted outside a dashboard (e.g. the AI agent thread view). */
+    dashboard: { uuid: string; name: string } | null;
     editChart?: SavedChart;
     /** Shared-metrics layer: seed, collect, badge, registry mutations */
     customMetricsEnabled: boolean;
@@ -153,8 +153,7 @@ type Props = {
  */
 const DashboardChartEditorModal: FC<Props> = ({
     opened,
-    dashboardUuid,
-    dashboardName,
+    dashboard,
     editChart,
     customMetricsEnabled,
     onChartSaved,
@@ -174,7 +173,9 @@ const DashboardChartEditorModal: FC<Props> = ({
     );
 
     const { showToastSuccess, showToastError } = useToaster();
-    const deleteRegistryMetric = useDeleteDashboardCustomMetric(dashboardUuid);
+    const deleteRegistryMetric = useDeleteDashboardCustomMetric(
+        dashboard?.uuid,
+    );
     const [registryDeletePreview, setRegistryDeletePreview] = useState<{
         metric: AdditionalMetric;
         affectedCharts: DashboardCustomMetricAffectedChart[];
@@ -251,7 +252,7 @@ const DashboardChartEditorModal: FC<Props> = ({
         () => ({
             isModalHosted: true,
             onChartSaved: handleChartSaved,
-            dashboard: { uuid: dashboardUuid, name: dashboardName },
+            dashboard: dashboard ?? undefined,
             dashboardMetricIds: customMetricsEnabled
                 ? dashboardMetricIds
                 : undefined,
@@ -260,8 +261,7 @@ const DashboardChartEditorModal: FC<Props> = ({
         }),
         [
             handleChartSaved,
-            dashboardUuid,
-            dashboardName,
+            dashboard,
             dashboardMetricIds,
             customMetricsEnabled,
             onRegistryMetricEdited,
@@ -297,19 +297,23 @@ const DashboardChartEditorModal: FC<Props> = ({
             onClose={handleClose}
             title={
                 <Group gap={6} wrap="nowrap">
-                    <Anchor
-                        c="dimmed"
-                        fw={500}
-                        underline="hover"
-                        truncate="end"
-                        maw={300}
-                        onClick={handleClose}
-                    >
-                        {dashboardName}
-                    </Anchor>
-                    <Text c="dimmed" fw={500}>
-                        /
-                    </Text>
+                    {dashboard && (
+                        <>
+                            <Anchor
+                                c="dimmed"
+                                fw={500}
+                                underline="hover"
+                                truncate="end"
+                                maw={300}
+                                onClick={handleClose}
+                            >
+                                {dashboard.name}
+                            </Anchor>
+                            <Text c="dimmed" fw={500}>
+                                /
+                            </Text>
+                        </>
+                    )}
                     {editChart ? (
                         <TruncatedText fw={600} fz="md" maxWidth="100%" miw={0}>
                             {`Edit ${editChart.name}`}
@@ -329,9 +333,9 @@ const DashboardChartEditorModal: FC<Props> = ({
                     <PageSpinner />
                 ) : (
                     <DashboardChartEditorContent
-                        key={`${dashboardUuid}-${exploreId ?? 'picker'}-${
-                            editChart?.uuid ?? 'new'
-                        }`}
+                        key={`${dashboard?.uuid ?? 'standalone'}-${
+                            exploreId ?? 'picker'
+                        }-${editChart?.uuid ?? 'new'}`}
                         exploreId={exploreId ?? ''}
                         editChart={editChart}
                         seededMetrics={seededMetrics}

--- a/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
+++ b/packages/frontend/src/components/Explorer/ChartGallery/ExplorerAlternateHosts.test.tsx
@@ -158,8 +158,10 @@ describe('Explorer chart configuration in alternate hosts', () => {
             <MemoryRouter>
                 <DashboardChartEditorModal
                     opened
-                    dashboardUuid="dashboard-uuid"
-                    dashboardName="Orders dashboard"
+                    dashboard={{
+                        uuid: 'dashboard-uuid',
+                        name: 'Orders dashboard',
+                    }}
                     customMetricsEnabled={false}
                     onChartSaved={vi.fn()}
                     onRegistryMetricEdited={vi.fn()}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -2,7 +2,7 @@ import { type AiAgentMessageUser, type AiAgentUser } from '@lightdash/common';
 import { Anchor, Box, Card, Group, Stack, Text, Tooltip } from '@mantine/core';
 import MDEditor from '@uiw/react-md-editor';
 import { format, parseISO } from 'date-fns';
-import { type FC } from 'react';
+import { type FC, type MouseEvent } from 'react';
 import { Link, useParams } from 'react-router';
 import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useTimeAgo } from '../../../../../hooks/useTimeAgo';
@@ -10,6 +10,7 @@ import useApp from '../../../../../providers/App/useApp';
 import { PinnedContextCard } from '../PinnedContextCard/PinnedContextCard';
 import { PinnedReviewContextGroup } from '../PinnedContextCard/PinnedReviewEntityCard';
 import { isReviewEntityItem } from '../PinnedContextCard/reviewEntityItem';
+import { useAiThreadChartEdit } from '../ThreadChartEditor/useAiThreadChartEdit';
 import styles from './AgentChatUserBubble.module.css';
 import { ContentReferenceLink } from './ContentReferenceLink';
 import {
@@ -17,6 +18,7 @@ import {
     getPromptContextItemHref,
     getPromptContextItemKey,
 } from './contentReferenceUtils';
+import { isPlainLeftClick } from './useDataAppPreviewLink';
 
 type Props = {
     message: AiAgentMessageUser<AiAgentUser>;
@@ -47,6 +49,7 @@ export const UserBubble: FC<Props> = ({
     const paramsProjectUuid = useProjectUuid();
     const projectUuid = projectUuidProp ?? paramsProjectUuid;
     const agentUuid = agentUuidProp ?? paramsAgentUuid;
+    const openChartEditor = useAiThreadChartEdit();
     const timeAgo = useTimeAgo(message.createdAt);
     const name = getVisibleUserName(message.user.name);
     const app = useApp();
@@ -160,6 +163,21 @@ export const UserBubble: FC<Props> = ({
                                 segment.item,
                                 projectUuid,
                             );
+                            // Chart references open the in-place editor when
+                            // the host provides one; the href keeps modified
+                            // clicks (new tab) working.
+                            const chartUuid =
+                                segment.item.type === 'chart'
+                                    ? segment.item.chartUuid
+                                    : null;
+                            const handleClick =
+                                chartUuid && openChartEditor
+                                    ? (e: MouseEvent<HTMLAnchorElement>) => {
+                                          if (!isPlainLeftClick(e)) return;
+                                          e.preventDefault();
+                                          openChartEditor(chartUuid);
+                                      }
+                                    : undefined;
                             return (
                                 <ContentReferenceLink
                                     key={`${segment.key}-${idx}`}
@@ -170,6 +188,7 @@ export const UserBubble: FC<Props> = ({
                                             : undefined
                                     }
                                     kind={segment.item.type}
+                                    onClick={handleClick}
                                     rel={href ? 'noreferrer' : undefined}
                                     target={href ? '_blank' : undefined}
                                     to={href ?? undefined}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatUserBubble.tsx
@@ -1,5 +1,6 @@
 import { type AiAgentMessageUser, type AiAgentUser } from '@lightdash/common';
 import { Anchor, Box, Card, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { IconWindowMaximize } from '@tabler/icons-react';
 import MDEditor from '@uiw/react-md-editor';
 import { format, parseISO } from 'date-fns';
 import { type FC, type MouseEvent } from 'react';
@@ -193,6 +194,11 @@ export const UserBubble: FC<Props> = ({
                                     target={href ? '_blank' : undefined}
                                     to={href ?? undefined}
                                     showArrow={href !== null}
+                                    trailingIcon={
+                                        handleClick
+                                            ? IconWindowMaximize
+                                            : undefined
+                                    }
                                 >
                                     {segment.label}
                                 </ContentReferenceLink>

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ContentReferenceLink.tsx
@@ -44,6 +44,8 @@ type Props = {
     children: ReactNode;
     kind: ContentReferenceKind;
     showArrow?: boolean;
+    /** Replaces the trailing arrow, e.g. to signal opening in a modal. */
+    trailingIcon?: Icon;
     to?: LinkProps['to'];
 } & Omit<
     AnchorProps,
@@ -155,6 +157,7 @@ export const ContentReferenceLink = ({
     children,
     kind,
     showArrow = true,
+    trailingIcon,
     to,
     ...props
 }: Props) => {
@@ -177,7 +180,7 @@ export const ContentReferenceLink = ({
 
             {showArrow && (
                 <MantineIcon
-                    icon={IconArrowRight}
+                    icon={trailingIcon ?? IconArrowRight}
                     color="dimmed"
                     size={11}
                     stroke={1.5}

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,4 +1,5 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
+import { IconWindowMaximize } from '@tabler/icons-react';
 import { type FC, type MouseEvent } from 'react';
 import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
@@ -113,6 +114,7 @@ const PinnedChartCard: FC<{
             target="_blank"
             onClick={handleClick}
             showArrow
+            trailingIcon={handleClick ? IconWindowMaximize : undefined}
         >
             {item.displayName ?? 'Chart'}
         </ContentReferenceLink>

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedContextCard.tsx
@@ -1,10 +1,14 @@
 import { assertUnreachable, type AiPromptContextItem } from '@lightdash/common';
-import { type FC } from 'react';
+import { type FC, type MouseEvent } from 'react';
 import { dataAppHref } from '../../../../../features/apps/utils/appUrls';
 import { elementRefChipLabel } from '../../../../../features/apps/utils/elementRefs';
 import { ContentReferenceLink } from '../ChatElements/ContentReferenceLink';
 import { getDataAppContextItemLabel } from '../ChatElements/contentReferenceUtils';
-import { useDataAppPreviewLink } from '../ChatElements/useDataAppPreviewLink';
+import {
+    isPlainLeftClick,
+    useDataAppPreviewLink,
+} from '../ChatElements/useDataAppPreviewLink';
+import { useAiThreadChartEdit } from '../ThreadChartEditor/useAiThreadChartEdit';
 import { PinnedReviewEntityCard } from './PinnedReviewEntityCard';
 
 // The sent thread message the chip belongs to; lets a data app chip open the
@@ -23,7 +27,6 @@ type Props = {
 
 type ItemMeta = {
     kind:
-        | 'chart'
         | 'dashboard'
         | 'thread'
         | 'file'
@@ -39,7 +42,6 @@ const getItemMeta = (
         AiPromptContextItem,
         {
             type:
-                | 'chart'
                 | 'dashboard'
                 | 'thread'
                 | 'file'
@@ -51,12 +53,6 @@ const getItemMeta = (
     projectUuid: string,
 ): ItemMeta => {
     switch (item.type) {
-        case 'chart':
-            return {
-                kind: 'chart',
-                label: item.displayName ?? 'Chart',
-                href: `/projects/${projectUuid}/saved/${item.chartUuid}`,
-            };
         case 'dashboard':
             return {
                 kind: 'dashboard',
@@ -93,6 +89,36 @@ const getItemMeta = (
     }
 };
 
+// Opens the in-place chart editor when the host provides one; the href keeps
+// modified clicks (new tab) working.
+const PinnedChartCard: FC<{
+    item: Extract<AiPromptContextItem, { type: 'chart' }>;
+    projectUuid: string;
+}> = ({ item, projectUuid }) => {
+    const openChartEditor = useAiThreadChartEdit();
+    const handleClick = openChartEditor
+        ? (e: MouseEvent<HTMLAnchorElement>) => {
+              if (!isPlainLeftClick(e)) return;
+              e.preventDefault();
+              openChartEditor(item.chartUuid);
+          }
+        : undefined;
+
+    return (
+        <ContentReferenceLink
+            kind="chart"
+            chartKind={item.chartKind ?? undefined}
+            rel="noreferrer"
+            to={`/projects/${projectUuid}/saved/${item.chartUuid}`}
+            target="_blank"
+            onClick={handleClick}
+            showArrow
+        >
+            {item.displayName ?? 'Chart'}
+        </ContentReferenceLink>
+    );
+};
+
 const PinnedDataAppCard: FC<{
     item: Extract<AiPromptContextItem, { type: 'data_app' }>;
     projectUuid: string;
@@ -125,6 +151,7 @@ export const PinnedContextCard: FC<Props> = ({
 }) => {
     switch (item.type) {
         case 'chart':
+            return <PinnedChartCard item={item} projectUuid={projectUuid} />;
         case 'dashboard':
         case 'thread':
         case 'file':

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
@@ -1,6 +1,51 @@
-import { type FC } from 'react';
-import DashboardChartEditorModal from '../../../../../components/DashboardTiles/DashboardChartEditorModal';
+import { type SavedChart } from '@lightdash/common';
+import { IconChartBar } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { Provider } from 'react-redux';
+import MantineModal from '../../../../../components/common/MantineModal';
+import Page from '../../../../../components/common/Page/Page';
+import Explorer from '../../../../../components/Explorer';
+import {
+    buildInitialExplorerState,
+    createExplorerStore,
+} from '../../../../../features/explorer/store';
+import { MergeProvider } from '../../../../../features/mergeQuery/context/MergeContext';
+import { useExplorerQueryEffects } from '../../../../../hooks/useExplorerQueryEffects';
 import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
+import useApp from '../../../../../providers/App/useApp';
+import { ExplorerSection } from '../../../../../providers/Explorer/types';
+
+// Query effects must run inside the store Provider.
+const ExplorerEffects: FC = () => {
+    useExplorerQueryEffects();
+    return null;
+};
+
+const ChartViewContent: FC<{ chart: SavedChart }> = ({ chart }) => {
+    const { health } = useApp();
+    // Store initializes once; the parent key remounts it per chart.
+    const [store] = useState(() =>
+        createExplorerStore({
+            explorer: buildInitialExplorerState({
+                savedChart: chart,
+                isEditMode: false,
+                expandedSections: [ExplorerSection.VISUALIZATION],
+                defaultLimit: health.data?.query.defaultLimit,
+            }),
+        }),
+    );
+
+    return (
+        <Provider store={store}>
+            <ExplorerEffects />
+            <Page withContainerHeight withFullHeight withPaddedContent>
+                <MergeProvider savedMerge={chart.merge ?? null}>
+                    <Explorer />
+                </MergeProvider>
+            </Page>
+        </Provider>
+    );
+};
 
 type Props = {
     chartUuid: string | null;
@@ -8,12 +53,10 @@ type Props = {
     onClose: () => void;
 };
 
-const noop = () => {};
-
 /**
- * Hosts the chart editor over the AI agent thread view, so a chart the agent
- * created or edited can be tweaked without leaving the conversation. Save
- * propagation is handled by the version mutation's cache invalidation.
+ * Read-only saved-chart view over the AI agent thread, so a chart the agent
+ * created or edited can be inspected without leaving the conversation.
+ * Mirrors the /saved/:uuid view page: same Explorer in view mode.
  */
 const AiThreadChartEditorModal: FC<Props> = ({
     chartUuid,
@@ -29,16 +72,17 @@ const AiThreadChartEditorModal: FC<Props> = ({
     if (!chartUuid || !chart || chart.uuid !== chartUuid) return null;
 
     return (
-        <DashboardChartEditorModal
+        <MantineModal
             opened
-            dashboard={null}
-            editChart={chart}
-            customMetricsEnabled={false}
-            onChartSaved={onClose}
-            onRegistryMetricEdited={noop}
-            onRegistryMetricDeleted={noop}
             onClose={onClose}
-        />
+            title={chart.name}
+            icon={IconChartBar}
+            fullScreen
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
+        >
+            <ChartViewContent key={chart.uuid} chart={chart} />
+        </MantineModal>
     );
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
@@ -1,0 +1,45 @@
+import { type FC } from 'react';
+import DashboardChartEditorModal from '../../../../../components/DashboardTiles/DashboardChartEditorModal';
+import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
+
+type Props = {
+    chartUuid: string | null;
+    projectUuid: string | undefined;
+    onClose: () => void;
+};
+
+const noop = () => {};
+
+/**
+ * Hosts the chart editor over the AI agent thread view, so a chart the agent
+ * created or edited can be tweaked without leaving the conversation. Save
+ * propagation is handled by the version mutation's cache invalidation.
+ */
+const AiThreadChartEditorModal: FC<Props> = ({
+    chartUuid,
+    projectUuid,
+    onClose,
+}) => {
+    const { data: chart } = useSavedQuery({
+        uuidOrSlug: chartUuid ?? undefined,
+        projectUuid,
+        useQueryOptions: { enabled: !!chartUuid && !!projectUuid },
+    });
+
+    if (!chartUuid || !chart || chart.uuid !== chartUuid) return null;
+
+    return (
+        <DashboardChartEditorModal
+            opened
+            dashboard={null}
+            editChart={chart}
+            customMetricsEnabled={false}
+            onChartSaved={onClose}
+            onRegistryMetricEdited={noop}
+            onRegistryMetricDeleted={noop}
+            onClose={onClose}
+        />
+    );
+};
+
+export default AiThreadChartEditorModal;

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal.tsx
@@ -1,9 +1,13 @@
-import { type SavedChart } from '@lightdash/common';
-import { IconChartBar } from '@tabler/icons-react';
+import { subject } from '@casl/ability';
+import { canMutateVerifiedContent, type SavedChart } from '@lightdash/common';
+import { Button } from '@mantine/core';
+import { IconChartBar, IconPencil } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Provider } from 'react-redux';
+import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import Page from '../../../../../components/common/Page/Page';
+import DashboardChartEditorModal from '../../../../../components/DashboardTiles/DashboardChartEditorModal';
 import Explorer from '../../../../../components/Explorer';
 import {
     buildInitialExplorerState,
@@ -23,7 +27,7 @@ const ExplorerEffects: FC = () => {
 
 const ChartViewContent: FC<{ chart: SavedChart }> = ({ chart }) => {
     const { health } = useApp();
-    // Store initializes once; the parent key remounts it per chart.
+    // Store initializes once; the parent key remounts it per chart version.
     const [store] = useState(() =>
         createExplorerStore({
             explorer: buildInitialExplorerState({
@@ -47,6 +51,77 @@ const ChartViewContent: FC<{ chart: SavedChart }> = ({ chart }) => {
     );
 };
 
+const noop = () => {};
+
+// Keyed by chart uuid from the parent, so mode resets per chart.
+const ThreadChartModalInner: FC<{ chart: SavedChart; onClose: () => void }> = ({
+    chart,
+    onClose,
+}) => {
+    const [mode, setMode] = useState<'view' | 'edit'>('view');
+    const { user } = useApp();
+
+    // Mirrors the saved-chart view page's gate for its "Edit chart" button.
+    const userCanManageChart =
+        !!user.data?.ability?.can(
+            'manage',
+            subject('SavedChart', { ...chart }),
+        ) &&
+        canMutateVerifiedContent(
+            user.data.ability,
+            {
+                organizationUuid: chart.organizationUuid,
+                projectUuid: chart.projectUuid,
+            },
+            chart.verification,
+            user.data.userUuid,
+        );
+
+    if (mode === 'edit') {
+        return (
+            <DashboardChartEditorModal
+                opened
+                dashboard={null}
+                editChart={chart}
+                customMetricsEnabled={false}
+                onChartSaved={() => setMode('view')}
+                onRegistryMetricEdited={noop}
+                onRegistryMetricDeleted={noop}
+                onClose={() => setMode('view')}
+            />
+        );
+    }
+
+    return (
+        <MantineModal
+            opened
+            onClose={onClose}
+            title={chart.name}
+            icon={IconChartBar}
+            fullScreen
+            cancelLabel={false}
+            modalBodyProps={{ px: 0, py: 0 }}
+            headerActions={
+                userCanManageChart ? (
+                    <Button
+                        variant="default"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconPencil} />}
+                        onClick={() => setMode('edit')}
+                    >
+                        Edit chart
+                    </Button>
+                ) : undefined
+            }
+        >
+            <ChartViewContent
+                key={`${chart.uuid}-${chart.updatedAt}`}
+                chart={chart}
+            />
+        </MantineModal>
+    );
+};
+
 type Props = {
     chartUuid: string | null;
     projectUuid: string | undefined;
@@ -54,9 +129,10 @@ type Props = {
 };
 
 /**
- * Read-only saved-chart view over the AI agent thread, so a chart the agent
- * created or edited can be inspected without leaving the conversation.
- * Mirrors the /saved/:uuid view page: same Explorer in view mode.
+ * Saved-chart view over the AI agent thread, so a chart the agent created or
+ * edited can be inspected without leaving the conversation. Mirrors the
+ * /saved/:uuid view page; "Edit chart" switches to the modal-hosted editor,
+ * and saving or leaving the editor returns to the refreshed view.
  */
 const AiThreadChartEditorModal: FC<Props> = ({
     chartUuid,
@@ -72,17 +148,11 @@ const AiThreadChartEditorModal: FC<Props> = ({
     if (!chartUuid || !chart || chart.uuid !== chartUuid) return null;
 
     return (
-        <MantineModal
-            opened
+        <ThreadChartModalInner
+            key={chart.uuid}
+            chart={chart}
             onClose={onClose}
-            title={chart.name}
-            icon={IconChartBar}
-            fullScreen
-            cancelLabel={false}
-            modalBodyProps={{ px: 0, py: 0 }}
-        >
-            <ChartViewContent key={chart.uuid} chart={chart} />
-        </MantineModal>
+        />
     );
 };
 

--- a/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/useAiThreadChartEdit.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ThreadChartEditor/useAiThreadChartEdit.ts
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+/** Set when the thread view can edit a chart in place; absent falls back to navigation. */
+export const AiThreadChartEditContext = createContext<
+    ((chartUuid: string) => void) | undefined
+>(undefined);
+
+export const useAiThreadChartEdit = ():
+    | ((chartUuid: string) => void)
+    | undefined => useContext(AiThreadChartEditContext);

--- a/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentPage.tsx
@@ -25,6 +25,8 @@ import { launcherSession } from '../../features/aiCopilot/components/Launcher/la
 import { useLauncherDock } from '../../features/aiCopilot/components/Launcher/useLauncherDock';
 import { MyMemoriesModal } from '../../features/aiCopilot/components/MyMemories/MyMemoriesModal';
 import { MEMORY_TOUR_STEPS } from '../../features/aiCopilot/components/MyMemories/onboarding';
+import AiThreadChartEditorModal from '../../features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal';
+import { AiThreadChartEditContext } from '../../features/aiCopilot/components/ThreadChartEditor/useAiThreadChartEdit';
 import {
     getAiAgentPageBase,
     isEmbedAiAgentRoute,
@@ -177,6 +179,13 @@ const AgentPage = () => {
         setShareUrl(null);
     }, []);
 
+    // Chart references edit in place; embed viewers keep plain navigation.
+    const [editChartUuid, setEditChartUuid] = useState<string | null>(null);
+    const openChartEditor = useCallback(
+        (chartUuid: string) => setEditChartUuid(chartUuid),
+        [],
+    );
+
     const handleShare = useCallback(async () => {
         if (!projectUuid || !agentUuid || !threadUuid) return;
         setIsShareModalOpen(true);
@@ -327,13 +336,22 @@ const AgentPage = () => {
                     setIsMemoriesModalOpen(stepIndex === 1)
                 }
             />
-            <Outlet
-                context={{
-                    agent,
-                    agents: agentsList ?? [],
-                    navigateFromAgentChat: handleMinimize,
-                }}
+            <AiThreadChartEditorModal
+                chartUuid={editChartUuid}
+                projectUuid={projectUuid}
+                onClose={() => setEditChartUuid(null)}
             />
+            <AiThreadChartEditContext.Provider
+                value={isEmbed ? undefined : openChartEditor}
+            >
+                <Outlet
+                    context={{
+                        agent,
+                        agents: agentsList ?? [],
+                        navigateFromAgentChat: handleMinimize,
+                    }}
+                />
+            </AiThreadChartEditContext.Provider>
         </AiAgentPageLayout>
     );
 };

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { Box, Center, Flex, Loader } from '@mantine/core';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -15,6 +15,8 @@ import {
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { ThreadWorkstreamsPanel } from '../../features/aiCopilot/components/ChatElements/ThreadWorkstreamsPanel';
+import AiThreadChartEditorModal from '../../features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal';
+import { AiThreadChartEditContext } from '../../features/aiCopilot/components/ThreadChartEditor/useAiThreadChartEdit';
 import { ThreadRetentionNotice } from '../../features/aiCopilot/components/ThreadRetentionNotice';
 import { findRetryableDeepResearchRun } from '../../features/aiCopilot/deepResearch/deepResearchRegistry';
 import { runDeepResearchAgain } from '../../features/aiCopilot/deepResearch/runAgain';
@@ -106,6 +108,13 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         action: 'manage',
         projectUuid,
     });
+
+    // Chart references edit in place; embed viewers keep plain navigation.
+    const [editChartUuid, setEditChartUuid] = useState<string | null>(null);
+    const openChartEditor = useCallback(
+        (chartUuid: string) => setEditChartUuid(chartUuid),
+        [],
+    );
 
     const handleToolResult = useCallback(
         (toolResult: AiAgentToolResult) => {
@@ -388,71 +397,80 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
 
     return (
         <Flex h="100%" gap={0} wrap="nowrap" align="stretch">
+            <AiThreadChartEditorModal
+                chartUuid={editChartUuid}
+                projectUuid={projectUuid}
+                onClose={() => setEditChartUuid(null)}
+            />
             <Box flex={1} miw={0} h="100%">
-                <AgentChatDisplay
-                    thread={thread}
-                    agentName={agentQuery.data?.name ?? 'AI'}
-                    enableAutoScroll={!isEmbed}
-                    promptUuid={promptUuid}
-                    debug={debug}
-                    projectUuid={projectUuid}
-                    agentUuid={agentUuid}
-                    showAddToEvalsButton={canManage}
-                    onDashboardLinkClick={handleDashboardLinkClick}
-                    canRetryDeepResearch={
-                        canStartDeepResearch && !inputDisabled && !isBusy
-                    }
-                    onRunDeepResearchAgain={(registration) => {
-                        void handleRunDeepResearchAgain(registration).catch(
-                            () => undefined,
-                        );
-                    }}
+                <AiThreadChartEditContext.Provider
+                    value={isEmbed ? undefined : openChartEditor}
                 >
-                    {workstreams && workstreams.length > 0 && (
-                        <ThreadWorkstreamsPanel workstreams={workstreams} />
-                    )}
-                    <AgentChatInput
-                        disabled={inputDisabled}
-                        disabledReason={inputDisabledReason}
-                        footerNotice={
-                            <ThreadRetentionNotice
-                                agentThreadRetentionHours={
-                                    agent.threadRetentionHours ?? null
-                                }
-                            />
-                        }
-                        loading={isBusy}
-                        onSubmit={handleSubmit}
-                        onStartDeepResearch={
-                            canStartDeepResearch
-                                ? handleStartDeepResearch
-                                : undefined
-                        }
-                        placeholder={`Ask ${agent.name} anything about your data...`}
-                        messageCount={thread.messages?.length || 0}
+                    <AgentChatDisplay
+                        thread={thread}
+                        agentName={agentQuery.data?.name ?? 'AI'}
+                        enableAutoScroll={!isEmbed}
+                        promptUuid={promptUuid}
+                        debug={debug}
                         projectUuid={projectUuid}
                         agentUuid={agentUuid}
-                        threadUuid={threadUuid}
-                        contentMentionPriorityItems={contentMentionItems}
-                        latestAssistantMessageUuid={
-                            [...(thread.messages ?? [])]
-                                .reverse()
-                                .find((m) => m.role === 'assistant')?.uuid
+                        showAddToEvalsButton={canManage}
+                        onDashboardLinkClick={handleDashboardLinkClick}
+                        canRetryDeepResearch={
+                            canStartDeepResearch && !inputDisabled && !isBusy
                         }
-                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
-                        onSqlModeChange={
-                            sqlModeAvailable && threadUuid
-                                ? (enabled) =>
-                                      dispatch(
-                                          setThreadSqlMode({
-                                              threadUuid,
-                                              enabled,
-                                          }),
-                                      )
-                                : undefined
-                        }
-                    />
-                </AgentChatDisplay>
+                        onRunDeepResearchAgain={(registration) => {
+                            void handleRunDeepResearchAgain(registration).catch(
+                                () => undefined,
+                            );
+                        }}
+                    >
+                        {workstreams && workstreams.length > 0 && (
+                            <ThreadWorkstreamsPanel workstreams={workstreams} />
+                        )}
+                        <AgentChatInput
+                            disabled={inputDisabled}
+                            disabledReason={inputDisabledReason}
+                            footerNotice={
+                                <ThreadRetentionNotice
+                                    agentThreadRetentionHours={
+                                        agent.threadRetentionHours ?? null
+                                    }
+                                />
+                            }
+                            loading={isBusy}
+                            onSubmit={handleSubmit}
+                            onStartDeepResearch={
+                                canStartDeepResearch
+                                    ? handleStartDeepResearch
+                                    : undefined
+                            }
+                            placeholder={`Ask ${agent.name} anything about your data...`}
+                            messageCount={thread.messages?.length || 0}
+                            projectUuid={projectUuid}
+                            agentUuid={agentUuid}
+                            threadUuid={threadUuid}
+                            contentMentionPriorityItems={contentMentionItems}
+                            latestAssistantMessageUuid={
+                                [...(thread.messages ?? [])]
+                                    .reverse()
+                                    .find((m) => m.role === 'assistant')?.uuid
+                            }
+                            sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                            onSqlModeChange={
+                                sqlModeAvailable && threadUuid
+                                    ? (enabled) =>
+                                          dispatch(
+                                              setThreadSqlMode({
+                                                  threadUuid,
+                                                  enabled,
+                                              }),
+                                          )
+                                    : undefined
+                            }
+                        />
+                    </AgentChatDisplay>
+                </AiThreadChartEditContext.Provider>
             </Box>
             {reviewItem && (
                 <ReviewVerificationPanel

--- a/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentThreadPage.tsx
@@ -1,6 +1,6 @@
 import { subject } from '@casl/ability';
 import { Box, Center, Flex, Loader } from '@mantine/core';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useOutletContext, useParams, useSearchParams } from 'react-router';
 import { matchesModelConfig } from '../../../components/common/ModelSelector/utils';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
@@ -15,8 +15,6 @@ import {
     mergeContentMentionSuggestionItems,
 } from '../../features/aiCopilot/components/ChatElements/contentMentions';
 import { ThreadWorkstreamsPanel } from '../../features/aiCopilot/components/ChatElements/ThreadWorkstreamsPanel';
-import AiThreadChartEditorModal from '../../features/aiCopilot/components/ThreadChartEditor/AiThreadChartEditorModal';
-import { AiThreadChartEditContext } from '../../features/aiCopilot/components/ThreadChartEditor/useAiThreadChartEdit';
 import { ThreadRetentionNotice } from '../../features/aiCopilot/components/ThreadRetentionNotice';
 import { findRetryableDeepResearchRun } from '../../features/aiCopilot/deepResearch/deepResearchRegistry';
 import { runDeepResearchAgain } from '../../features/aiCopilot/deepResearch/runAgain';
@@ -108,13 +106,6 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
         action: 'manage',
         projectUuid,
     });
-
-    // Chart references edit in place; embed viewers keep plain navigation.
-    const [editChartUuid, setEditChartUuid] = useState<string | null>(null);
-    const openChartEditor = useCallback(
-        (chartUuid: string) => setEditChartUuid(chartUuid),
-        [],
-    );
 
     const handleToolResult = useCallback(
         (toolResult: AiAgentToolResult) => {
@@ -397,80 +388,71 @@ const AiAgentThreadPage = ({ debug }: { debug?: boolean }) => {
 
     return (
         <Flex h="100%" gap={0} wrap="nowrap" align="stretch">
-            <AiThreadChartEditorModal
-                chartUuid={editChartUuid}
-                projectUuid={projectUuid}
-                onClose={() => setEditChartUuid(null)}
-            />
             <Box flex={1} miw={0} h="100%">
-                <AiThreadChartEditContext.Provider
-                    value={isEmbed ? undefined : openChartEditor}
+                <AgentChatDisplay
+                    thread={thread}
+                    agentName={agentQuery.data?.name ?? 'AI'}
+                    enableAutoScroll={!isEmbed}
+                    promptUuid={promptUuid}
+                    debug={debug}
+                    projectUuid={projectUuid}
+                    agentUuid={agentUuid}
+                    showAddToEvalsButton={canManage}
+                    onDashboardLinkClick={handleDashboardLinkClick}
+                    canRetryDeepResearch={
+                        canStartDeepResearch && !inputDisabled && !isBusy
+                    }
+                    onRunDeepResearchAgain={(registration) => {
+                        void handleRunDeepResearchAgain(registration).catch(
+                            () => undefined,
+                        );
+                    }}
                 >
-                    <AgentChatDisplay
-                        thread={thread}
-                        agentName={agentQuery.data?.name ?? 'AI'}
-                        enableAutoScroll={!isEmbed}
-                        promptUuid={promptUuid}
-                        debug={debug}
+                    {workstreams && workstreams.length > 0 && (
+                        <ThreadWorkstreamsPanel workstreams={workstreams} />
+                    )}
+                    <AgentChatInput
+                        disabled={inputDisabled}
+                        disabledReason={inputDisabledReason}
+                        footerNotice={
+                            <ThreadRetentionNotice
+                                agentThreadRetentionHours={
+                                    agent.threadRetentionHours ?? null
+                                }
+                            />
+                        }
+                        loading={isBusy}
+                        onSubmit={handleSubmit}
+                        onStartDeepResearch={
+                            canStartDeepResearch
+                                ? handleStartDeepResearch
+                                : undefined
+                        }
+                        placeholder={`Ask ${agent.name} anything about your data...`}
+                        messageCount={thread.messages?.length || 0}
                         projectUuid={projectUuid}
                         agentUuid={agentUuid}
-                        showAddToEvalsButton={canManage}
-                        onDashboardLinkClick={handleDashboardLinkClick}
-                        canRetryDeepResearch={
-                            canStartDeepResearch && !inputDisabled && !isBusy
+                        threadUuid={threadUuid}
+                        contentMentionPriorityItems={contentMentionItems}
+                        latestAssistantMessageUuid={
+                            [...(thread.messages ?? [])]
+                                .reverse()
+                                .find((m) => m.role === 'assistant')?.uuid
                         }
-                        onRunDeepResearchAgain={(registration) => {
-                            void handleRunDeepResearchAgain(registration).catch(
-                                () => undefined,
-                            );
-                        }}
-                    >
-                        {workstreams && workstreams.length > 0 && (
-                            <ThreadWorkstreamsPanel workstreams={workstreams} />
-                        )}
-                        <AgentChatInput
-                            disabled={inputDisabled}
-                            disabledReason={inputDisabledReason}
-                            footerNotice={
-                                <ThreadRetentionNotice
-                                    agentThreadRetentionHours={
-                                        agent.threadRetentionHours ?? null
-                                    }
-                                />
-                            }
-                            loading={isBusy}
-                            onSubmit={handleSubmit}
-                            onStartDeepResearch={
-                                canStartDeepResearch
-                                    ? handleStartDeepResearch
-                                    : undefined
-                            }
-                            placeholder={`Ask ${agent.name} anything about your data...`}
-                            messageCount={thread.messages?.length || 0}
-                            projectUuid={projectUuid}
-                            agentUuid={agentUuid}
-                            threadUuid={threadUuid}
-                            contentMentionPriorityItems={contentMentionItems}
-                            latestAssistantMessageUuid={
-                                [...(thread.messages ?? [])]
-                                    .reverse()
-                                    .find((m) => m.role === 'assistant')?.uuid
-                            }
-                            sqlMode={sqlModeAvailable ? sqlMode : undefined}
-                            onSqlModeChange={
-                                sqlModeAvailable && threadUuid
-                                    ? (enabled) =>
-                                          dispatch(
-                                              setThreadSqlMode({
-                                                  threadUuid,
-                                                  enabled,
-                                              }),
-                                          )
-                                    : undefined
-                            }
-                        />
-                    </AgentChatDisplay>
-                </AiThreadChartEditContext.Provider>
+                        sqlMode={sqlModeAvailable ? sqlMode : undefined}
+                        onSqlModeChange={
+                            sqlModeAvailable && threadUuid
+                                ? (enabled) =>
+                                      dispatch(
+                                          setThreadSqlMode({
+                                              threadUuid,
+                                              enabled,
+                                          }),
+                                      )
+                                : undefined
+                        }
+                    />
+                </AgentChatDisplay>
             </Box>
             {reviewItem && (
                 <ReviewVerificationPanel

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentsRootLayout.tsx
@@ -9,7 +9,9 @@ const AiAgentsRootLayout = () => {
     const isMobile = useMediaQuery('(max-width: 768px)');
     return (
         <>
-            {isMobile ? <MobileNavBar /> : <NavBar />}
+            {/* Static navbar: its z-index stays inert so the in-thread chart
+                editor modal can cover it, matching dashboard views. */}
+            {isMobile ? <MobileNavBar /> : <NavBar isFixed={false} />}
             {/* A walkthrough that clicked into Ask AI continues here. */}
             <Sentry.ErrorBoundary fallback={<></>}>
                 <ScopeTourHost />

--- a/packages/frontend/src/hooks/dashboard/useDashboardCustomMetricSeed.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardCustomMetricSeed.ts
@@ -1,17 +1,28 @@
-import { getCompatibleDashboardMetrics, getItemId } from '@lightdash/common';
+import {
+    getCompatibleDashboardMetrics,
+    getItemId,
+    type AdditionalMetric,
+} from '@lightdash/common';
 import { useMemo } from 'react';
-import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import { useContextSelector } from 'use-context-selector';
+import DashboardContext from '../../providers/Dashboard/context';
 import { useExplore } from '../useExplore';
+
+const NO_REGISTRY: AdditionalMetric[] = [];
 
 /**
  * Registry metrics compatible with the given Explore, ready to seed a chart
  * built inside the dashboard. Host-agnostic: reads the staged registry from
  * the dashboard context and knows nothing about who hosts the Explorer.
+ * Hosts without a DashboardProvider (e.g. the AI thread editor) get no seed.
  */
 export const useDashboardCustomMetricSeed = (
     exploreName: string | undefined,
 ) => {
-    const registry = useDashboardContext((c) => c.dashboardCustomMetrics);
+    const registry = useContextSelector(
+        DashboardContext,
+        (c) => c?.dashboardCustomMetrics ?? NO_REGISTRY,
+    );
     const { data: explore, isInitialLoading } = useExplore(
         registry.length > 0 ? exploreName : undefined,
     );

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -1237,8 +1237,10 @@ const Dashboard: FC = () => {
                     {isChartEditorEnabled && dashboard.uuid ? (
                         <DashboardChartEditorModal
                             opened={isNewChartOpen || chartToEdit !== undefined}
-                            dashboardUuid={dashboard.uuid}
-                            dashboardName={dashboard.name}
+                            dashboard={{
+                                uuid: dashboard.uuid,
+                                name: dashboard.name,
+                            }}
                             editChart={chartToEdit}
                             customMetricsEnabled={
                                 isDashboardCustomMetricsEnabled


### PR DESCRIPTION
## Summary

Saved-chart references in AI agent threads currently open in a new tab. This PR opens them **in place**, in a modal over the conversation — view first, with an opt-in switch to full editing.

- **Chart pills open a modal**: user-message inline chart references and pinned-context chart chips (thread page and new-thread page) open a fullscreen modal on plain left-click. Modified clicks (cmd/ctrl) keep opening the chart page in a new tab.
- **View mode first**: the modal renders the same Explorer body as the `/saved/:uuid` view page (Filters / Chart / Results / SQL, drill-down intact), read-only.
- **Edit toggle**: an "Edit chart" button — gated by the same permission check as the view page (`manage SavedChart` + `canMutateVerifiedContent`) — switches to the modal-hosted editor (field tree, run query, save with dirty guard). Saving or closing the editor returns to the refreshed view.
- **Distinct affordance**: modal-opening chart pills show a window icon instead of the navigation arrow, so they read differently from dashboard pills that navigate away.

## Implementation notes

- `DashboardChartEditorModal` now takes `dashboard: { uuid; name } | null` — with `null` it hosts a standalone chart edit (no breadcrumb dashboard segment, registry-metric wiring inert). `useDashboardCustomMetricSeed` tolerates a missing `DashboardProvider` (empty seed) instead of throwing.
- New `AiThreadChartEditorModal` + `AiThreadChartEditContext` (mirrors the `DashboardChartEditContext` pattern). `AgentPage` provides the context around its outlet (disabled on embed routes) so both the thread and new-thread pages get it; surfaces without a host (launcher panel, admin views) keep plain links automatically.
- `AiAgentsRootLayout` renders the navbar non-fixed, matching dashboard views — a fixed navbar sits at popover z-index and would paint over the modal.
- `ContentReferenceLink` gains an optional `trailingIcon` prop.

## Out of scope (tracked on the ticket)

Dashboards (no modal-hosted dashboard editor exists), unsaved artifacts, and a modal host for the launcher panel.

Closes: GLITCH-772
