### PR TITLE
feat(roadmap): remove organization-roadmap flag, gate on valid license

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -569,10 +569,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                     }),
                 }),
-            roadmapService: ({ context, repository }) =>
+            roadmapService: ({ context }) =>
                 new RoadmapService({
                     lightdashConfig: context.lightdashConfig,
-                    featureFlagService: repository.getFeatureFlagService(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.test.ts
@@ -84,17 +84,13 @@ const roadmapServiceResponse: RoadmapResponse = {
 
 const buildService = ({
     licenseKey = 'test-license-key',
-    flagEnabled = true,
     baseUrl = 'https://roadmap.lightdash.com',
-}: { licenseKey?: string; flagEnabled?: boolean; baseUrl?: string } = {}) =>
+}: { licenseKey?: string; baseUrl?: string } = {}) =>
     new RoadmapService({
         lightdashConfig: {
             license: { licenseKey },
             roadmap: { baseUrl },
         } as LightdashConfig,
-        featureFlagService: {
-            get: vi.fn().mockResolvedValue({ enabled: flagEnabled }),
-        },
     });
 
 describe('RoadmapService', () => {
@@ -154,15 +150,6 @@ describe('RoadmapService', () => {
         expect(fetchMock.mock.calls[0][0]).toBe(
             `http://127.0.0.1:8081/api/v1/roadmap/organizations/${sessionOrgUuid}?pageSize=100`,
         );
-    });
-
-    it('denies access when the feature flag is disabled', async () => {
-        const account = buildAccount(viewRoadmapAbility(sessionOrgUuid));
-
-        await expect(
-            buildService({ flagEnabled: false }).getRoadmap(account),
-        ).rejects.toThrow(ForbiddenError);
-        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('denies access when the user cannot view the roadmap for their organization', async () => {
@@ -347,10 +334,7 @@ describe('RoadmapService', () => {
     it('gates both endpoints before provider requests and keeps authorization errors stable', async () => {
         const account = buildAccount(viewRoadmapAbility(sessionOrgUuid));
         await Promise.all(
-            [
-                buildService({ flagEnabled: false }),
-                buildService({ licenseKey: '' }),
-            ].map(async (service) => {
+            [buildService({ licenseKey: '' })].map(async (service) => {
                 await expect(service.getProjects(account)).rejects.toThrow();
                 await expect(
                     service.getRoadmap(account, { projectId: 'null' }),
@@ -623,7 +607,7 @@ describe('RoadmapService', () => {
             expect(fetchMock).not.toHaveBeenCalled();
         });
 
-        it('requires roadmap access, its feature flag and a configured license', async () => {
+        it('requires roadmap access and a configured license key', async () => {
             const wrongOrg = account();
             wrongOrg.user.ability = viewRoadmapAbility(otherOrgUuid);
             wrongOrg.user.abilityRules = wrongOrg.user.ability.rules;
@@ -631,13 +615,6 @@ describe('RoadmapService', () => {
                 buildService().followProject(wrongOrg, projectId, {
                     note: 'Use case',
                 }),
-            ).rejects.toThrow(ForbiddenError);
-            await expect(
-                buildService({ flagEnabled: false }).followProject(
-                    account(),
-                    projectId,
-                    { note: 'Use case' },
-                ),
             ).rejects.toThrow(ForbiddenError);
             await expect(
                 buildService({ licenseKey: '' }).followProject(

--- a/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
+++ b/packages/backend/src/ee/services/RoadmapService/RoadmapService.ts
@@ -2,7 +2,6 @@ import { subject } from '@casl/ability';
 import {
     assertIsAccountWithOrg,
     assertRegisteredAccount,
-    FeatureFlags,
     ForbiddenError,
     NotFoundError,
     ParameterError,
@@ -27,41 +26,28 @@ import {
 import { z } from 'zod';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import { BaseService } from '../../../services/BaseService';
-import type { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 
 const ROADMAP_REQUEST_TIMEOUT_MS = 10_000;
 
 type Dependencies = {
     lightdashConfig: LightdashConfig;
-    featureFlagService: Pick<FeatureFlagService, 'get'>;
 };
 
 export class RoadmapService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
-    private readonly featureFlagService: Pick<FeatureFlagService, 'get'>;
-
-    constructor({ lightdashConfig, featureFlagService }: Dependencies) {
+    constructor({ lightdashConfig }: Dependencies) {
         super();
         this.lightdashConfig = lightdashConfig;
-        this.featureFlagService = featureFlagService;
     }
 
     private async authorize(account: Account) {
         assertRegisteredAccount(account);
         assertIsAccountWithOrg(account);
         const { organizationUuid } = account.organization;
-        const roadmapFlag = await this.featureFlagService.get({
-            user: {
-                userUuid: account.user.userUuid,
-                organizationUuid,
-            },
-            featureFlagId: FeatureFlags.OrganizationRoadmap,
-        });
         const ability = this.createAuditedAbility(account);
 
         if (
-            !roadmapFlag.enabled ||
             ability.cannot(
                 'view',
                 subject('Roadmap', {

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -189,11 +189,6 @@ export enum FeatureFlags {
     ProLimits = 'pro-limits',
 
     /**
-     * Show the organization roadmap and enable its read-only API proxy.
-     */
-    OrganizationRoadmap = 'organization-roadmap',
-
-    /**
      * Allow a single Lightdash project to connect to multiple dbt sources
      * (repos/CLI deploys). Each source stores its latest compiled manifest in
      * S3; on every deploy or preview the backend merges all sources' manifests

--- a/packages/frontend/src/hooks/settings/types.ts
+++ b/packages/frontend/src/hooks/settings/types.ts
@@ -66,7 +66,6 @@ export type SettingsContext = {
     canAccessAnalyticsSettings: boolean;
     isAnalyticsProjectFlagLoading: boolean;
     isOrganizationRoadmapEnabled: boolean;
-    isOrganizationRoadmapLoading: boolean;
     isSsoOrganizationSettingsEnabled: boolean;
     isEmailWhitelabelEnabled: boolean;
     isScimTokenManagementEnabled: FeatureFlag | undefined;

--- a/packages/frontend/src/hooks/settings/useSettingsContext.ts
+++ b/packages/frontend/src/hooks/settings/useSettingsContext.ts
@@ -86,12 +86,8 @@ export const useSettingsContext = (): SettingsContext => {
     );
     const isProLimitsEnabled = proLimitsFlag?.enabled ?? false;
 
-    const organizationRoadmapFlagQuery = useServerFeatureFlag(
-        FeatureFlags.OrganizationRoadmap,
-    );
-    const { data: organizationRoadmapFlag } = organizationRoadmapFlagQuery;
-    const isOrganizationRoadmapEnabled =
-        organizationRoadmapFlag?.enabled ?? false;
+    // The roadmap proxy is only registered behind a validated enterprise license.
+    const isOrganizationRoadmapEnabled = health?.license?.valid === true;
 
     const { data: ssoOrganizationSettingsFlag } = useServerFeatureFlag(
         FeatureFlags.SsoOrganizationSettings,
@@ -210,8 +206,6 @@ export const useSettingsContext = (): SettingsContext => {
         canAccessAnalyticsSettings,
         isAnalyticsProjectFlagLoading,
         isOrganizationRoadmapEnabled,
-        isOrganizationRoadmapLoading:
-            organizationRoadmapFlagQuery.isInitialLoading,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
         isScimTokenManagementEnabled,

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -167,7 +167,6 @@ const Settings: FC = () => {
         canAccessAnalyticsSettings,
         isAnalyticsProjectFlagLoading,
         isOrganizationRoadmapEnabled,
-        isOrganizationRoadmapLoading,
         isSsoOrganizationSettingsEnabled,
         isEmailWhitelabelEnabled,
         isServiceAccountsEnabled,
@@ -929,9 +928,6 @@ const Settings: FC = () => {
     const isAwaitingAiSettingsRoute =
         isAiOrganizationSettingsLoading &&
         Boolean(matchPath('/generalSettings/ai/*', location.pathname));
-    const isAwaitingRoadmapRoute =
-        isOrganizationRoadmapLoading &&
-        Boolean(matchPath('/generalSettings/roadmap', location.pathname));
     const isAwaitingDataAppsRoute =
         isDataAppsFlagLoading &&
         Boolean(matchPath('/generalSettings/dataApps/*', location.pathname));
@@ -948,7 +944,6 @@ const Settings: FC = () => {
         isActiveProjectUuidLoading ||
         isProjectLoading ||
         isAwaitingAiSettingsRoute ||
-        isAwaitingRoadmapRoute ||
         isAwaitingDataAppsRoute ||
         isAwaitingAnalyticsRoute
     ) {

--- a/release-safety.declarations.json
+++ b/release-safety.declarations.json
@@ -20,6 +20,10 @@
         "mobile-push-installation-uuid-path-params": {
             "reason": "PUT and DELETE /api/v1/mobile/push-notifications/installations/{installationUuid} now validate installationUuid as a UUID and reject other strings with a 400. Installation identifiers are server-generated UUIDs, and only the Lightdash mobile apps call these endpoints with the identifier they received, so no existing caller is affected.",
             "requiredStop": false
+        },
+        "organization-roadmap-flag-removed": {
+            "reason": "The OrganizationRoadmap member is removed from the exported FeatureFlags enum. TypeScript consumers referencing this rollout flag must remove it when upgrading; the enterprise roadmap is now available to every organization on an instance whose license key validated at boot, gated per user by the existing view:Roadmap permission.",
+            "requiredStop": false
         }
     }
 }


### PR DESCRIPTION
Closes: PROD-10989
Relates: PROD-11016

### Description:

Removes the `organization-roadmap` feature flag so the enterprise roadmap is available to every organization on an instance whose license key validated at boot, with per-user access still governed by the existing `view:Roadmap` permission (admins, or an org-level custom role). The backend roadmap service is only registered after license validation, so `RoadmapService.authorize()` now checks the ability alone instead of resolving a per-org flag. The frontend settings nav and route are gated on `health.license.valid`, which is needed because the existing `isEnterprise` checks compare the key against `undefined` while the config value is `string | null` and are therefore always true. Stale `feature_flag_overrides` rows for the removed flag id are inert, so no migration is included.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.