### PR TITLE
feat(sql-runner): filter the table browser by relation type

### DIFF
--- a/packages/frontend/src/features/sqlRunner/components/Tables.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Tables.tsx
@@ -42,9 +42,11 @@ import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { setSql, toggleActiveTable } from '../store/sqlRunnerSlice';
 import {
     buildTableRows,
+    catalogHasViews,
     filterTablesBySchema,
     type SchemaTables,
     type TableRow,
+    type TableTypeFilter,
 } from '../utils/tableRows';
 import styles from './Tables.module.css';
 
@@ -193,8 +195,9 @@ const TableItem: FC<TableItemProps> = memo(
 const SchemaItem: FC<{
     schema: string;
     isExpanded: boolean;
+    count: number | null;
     onToggle: (schema: string, isExpanded: boolean) => void;
-}> = memo(({ schema, isExpanded, onToggle }) => (
+}> = memo(({ schema, isExpanded, count, onToggle }) => (
     <UnstyledButton
         onClick={() => onToggle(schema, isExpanded)}
         className={styles.schemaButton}
@@ -209,29 +212,83 @@ const SchemaItem: FC<{
             <Text fz="sm" fw={500} truncate>
                 {schema}
             </Text>
+            {count !== null && (
+                <Text fz="xs" c="dimmed" ml="auto" pr="xs">
+                    {count}
+                </Text>
+            )}
         </Group>
     </UnstyledButton>
 ));
 
+// Manual expand/collapse choices, keyed by the search and type filter they were made under
 type SchemaExpansion = {
-    search: string;
+    key: string;
     overrides: Record<string, boolean>;
 };
 const NO_OVERRIDES: Record<string, boolean> = {};
 
+const TYPE_FILTER_TOGGLES: {
+    filter: TableTypeFilter;
+    icon: Icon;
+    label: string;
+}[] = [
+    { filter: 'tables', icon: IconTable, label: 'Only tables' },
+    { filter: 'views', icon: IconEye, label: 'Only views' },
+];
+
+// One toggle active at a time; clicking the active one shows everything again
+const TableTypeToggle: FC<{
+    value: TableTypeFilter | null;
+    onChange: (value: TableTypeFilter | null) => void;
+}> = ({ value, onChange }) => (
+    <ActionIcon.Group>
+        {TYPE_FILTER_TOGGLES.map(({ filter, icon, label }) => {
+            const isActive = value === filter;
+            return (
+                <Tooltip
+                    key={filter}
+                    label={isActive ? 'Show all' : label}
+                    openDelay={400}
+                >
+                    <ActionIcon
+                        variant={isActive ? 'light' : 'default'}
+                        size="input-sm"
+                        aria-label={label}
+                        aria-pressed={isActive}
+                        onClick={() => onChange(isActive ? null : filter)}
+                    >
+                        <MantineIcon icon={icon} />
+                    </ActionIcon>
+                </Tooltip>
+            );
+        })}
+    </ActionIcon.Group>
+);
+
 const VirtualRow: FC<{
     row: TableRow;
     search: string;
+    showCounts: boolean;
     database: string;
     activeTable: string | undefined;
     activeSchema: string | undefined;
     onToggleSchema: (schema: string, isExpanded: boolean) => void;
-}> = ({ row, search, database, activeTable, activeSchema, onToggleSchema }) => {
+}> = ({
+    row,
+    search,
+    showCounts,
+    database,
+    activeTable,
+    activeSchema,
+    onToggleSchema,
+}) => {
     if (row.type === 'schema') {
         return (
             <SchemaItem
                 schema={row.schema}
                 isExpanded={row.isExpanded}
+                count={showCounts ? row.tableCount : null}
                 onToggle={onToggleSchema}
             />
         );
@@ -263,31 +320,30 @@ export const Tables: FC = () => {
             ? debouncedSearch
             : '';
 
-    // Manual expand/collapse choices, discarded whenever the search changes
+    const [typeFilter, setTypeFilter] = useState<TableTypeFilter | null>(null);
+    const isFiltering = effectiveSearch !== '' || typeFilter !== null;
+    const filterKey = `${typeFilter ?? 'all'}:${effectiveSearch}`;
+
     const [expansion, setExpansion] = useState<SchemaExpansion>({
-        search: '',
+        key: filterKey,
         overrides: {},
     });
     const overrides = useMemo(
         () =>
-            expansion.search === effectiveSearch
-                ? expansion.overrides
-                : NO_OVERRIDES,
-        [expansion, effectiveSearch],
+            expansion.key === filterKey ? expansion.overrides : NO_OVERRIDES,
+        [expansion, filterKey],
     );
     const toggleSchema = useCallback(
         (schema: string, isExpanded: boolean) => {
             setExpansion((previous) => ({
-                search: effectiveSearch,
+                key: filterKey,
                 overrides: {
-                    ...(previous.search === effectiveSearch
-                        ? previous.overrides
-                        : {}),
+                    ...(previous.key === filterKey ? previous.overrides : {}),
                     [schema]: !isExpanded,
                 },
             }));
         },
-        [effectiveSearch],
+        [filterKey],
     );
 
     const { data, isLoading, isSuccess } = useTables({ projectUuid });
@@ -307,19 +363,34 @@ export const Tables: FC = () => {
         return { database, tablesBySchema };
     }, [data]);
 
+    const hasViews = useMemo(
+        () => (catalog ? catalogHasViews(catalog.tablesBySchema) : false),
+        [catalog],
+    );
+
     const rows = useMemo<TableRow[]>(() => {
         if (!catalog) return [];
-        const tablesBySchema = effectiveSearch
-            ? filterTablesBySchema(catalog.tablesBySchema, effectiveSearch)
+        const tablesBySchema = isFiltering
+            ? filterTablesBySchema(
+                  catalog.tablesBySchema,
+                  effectiveSearch,
+                  typeFilter,
+              )
             : catalog.tablesBySchema;
-        // Searching expands every matching schema; otherwise only the active one
+        // Filtering expands every matching schema; otherwise only the active one
         return buildTableRows(
             tablesBySchema,
             (schema) =>
-                overrides[schema] ??
-                (effectiveSearch !== '' || schema === activeSchema),
+                overrides[schema] ?? (isFiltering || schema === activeSchema),
         );
-    }, [catalog, effectiveSearch, overrides, activeSchema]);
+    }, [
+        catalog,
+        isFiltering,
+        effectiveSearch,
+        typeFilter,
+        overrides,
+        activeSchema,
+    ]);
 
     const viewportRef = useRef<HTMLDivElement>(null);
     const virtualizer = useVirtualizer({
@@ -335,7 +406,7 @@ export const Tables: FC = () => {
 
     return (
         <>
-            <Box>
+            <Group gap="xs" wrap="nowrap">
                 <Tooltip
                     opened={
                         search.length > 0 && search.length < MIN_SEARCH_LENGTH
@@ -344,6 +415,7 @@ export const Tables: FC = () => {
                 >
                     <TextInput
                         size="sm"
+                        flex={1}
                         disabled={!data && !debouncedSearch}
                         leftSection={
                             isLoading ? (
@@ -372,7 +444,13 @@ export const Tables: FC = () => {
                         onChange={(e) => setSearch(e.target.value)}
                     />
                 </Tooltip>
-            </Box>
+                {hasViews && (
+                    <TableTypeToggle
+                        value={typeFilter}
+                        onChange={setTypeFilter}
+                    />
+                )}
+            </Group>
 
             <ScrollArea
                 viewportRef={viewportRef}
@@ -408,6 +486,7 @@ export const Tables: FC = () => {
                                     <VirtualRow
                                         row={row}
                                         search={effectiveSearch}
+                                        showCounts={typeFilter !== null}
                                         database={catalog.database}
                                         activeTable={activeTable}
                                         activeSchema={activeSchema}

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.test.ts
@@ -2,6 +2,7 @@ import { PartitionType, WarehouseTableType } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
 import {
     buildTableRows,
+    catalogHasViews,
     filterTablesBySchema,
     type SchemaTables,
 } from './tableRows';
@@ -75,7 +76,7 @@ describe('buildTableRows', () => {
 
 describe('filterTablesBySchema', () => {
     it('keeps matching tables and drops schemas without matches', () => {
-        const filtered = filterTablesBySchema(tablesBySchema, 'orders');
+        const filtered = filterTablesBySchema(tablesBySchema, 'orders', null);
 
         expect(filtered).toEqual([
             { schema: 'jaffle', tables: { orders: { partitionColumn } } },
@@ -84,6 +85,45 @@ describe('filterTablesBySchema', () => {
     });
 
     it('returns nothing when no table matches', () => {
-        expect(filterTablesBySchema(tablesBySchema, 'zzz')).toEqual([]);
+        expect(filterTablesBySchema(tablesBySchema, 'zzz', null)).toEqual([]);
+    });
+
+    it('keeps only views, treating untyped rows as tables', () => {
+        expect(filterTablesBySchema(tablesBySchema, '', 'views')).toEqual([
+            {
+                schema: 'jaffle',
+                tables: { payments: { tableType: WarehouseTableType.VIEW } },
+            },
+        ]);
+        expect(filterTablesBySchema(tablesBySchema, '', 'tables')).toEqual([
+            {
+                schema: 'jaffle',
+                tables: { customers: {}, orders: { partitionColumn } },
+            },
+            { schema: 'staging', tables: { stg_orders: {} } },
+        ]);
+    });
+
+    it('combines the type filter with the search', () => {
+        expect(filterTablesBySchema(tablesBySchema, 'orders', 'views')).toEqual(
+            [],
+        );
+        expect(
+            filterTablesBySchema(tablesBySchema, 'payments', 'views'),
+        ).toEqual([
+            {
+                schema: 'jaffle',
+                tables: { payments: { tableType: WarehouseTableType.VIEW } },
+            },
+        ]);
+    });
+});
+
+describe('catalogHasViews', () => {
+    it('is true only when some table is a view or materialized view', () => {
+        expect(catalogHasViews(tablesBySchema)).toBe(true);
+        expect(
+            catalogHasViews([{ schema: 'raw', tables: { a: {}, b: {} } }]),
+        ).toBe(false);
     });
 });

--- a/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
+++ b/packages/frontend/src/features/sqlRunner/utils/tableRows.ts
@@ -1,6 +1,7 @@
 import {
+    assertUnreachable,
+    WarehouseTableType,
     type PartitionColumn,
-    type WarehouseTableType,
 } from '@lightdash/common';
 import Fuse from 'fuse.js';
 import { type TablesBySchema } from '../hooks/useTables';
@@ -24,18 +25,56 @@ export type TableRow =
           tableType: WarehouseTableType | undefined;
       };
 
+export type TableTypeFilter = 'tables' | 'views';
+
+const isView = (tableType: WarehouseTableType | undefined) =>
+    tableType === WarehouseTableType.VIEW ||
+    tableType === WarehouseTableType.MATERIALIZED_VIEW;
+
+// Untyped rows (cached before the type existed) count as tables
+const matchesTableTypeFilter = (
+    tableType: WarehouseTableType | undefined,
+    filter: TableTypeFilter | null,
+): boolean => {
+    switch (filter) {
+        case null:
+            return true;
+        case 'views':
+            return isView(tableType);
+        case 'tables':
+            return !isView(tableType);
+        default:
+            return assertUnreachable(filter, 'Unknown table type filter');
+    }
+};
+
+export const catalogHasViews = (tablesBySchema: SchemaTables[]): boolean =>
+    tablesBySchema.some(({ tables }) =>
+        Object.values(tables).some(({ tableType }) => isView(tableType)),
+    );
+
+const searchTableNames = (tableNames: string[], search: string): string[] => {
+    if (!search) return tableNames;
+    const fuse = new Fuse(tableNames, {
+        threshold: 0.3,
+        isCaseSensitive: false,
+        ignoreLocation: true,
+    });
+    return fuse.search(search).map((result) => result.item);
+};
+
+// Schemas left with no matching table are dropped
 export const filterTablesBySchema = (
     tablesBySchema: SchemaTables[],
     search: string,
+    typeFilter: TableTypeFilter | null,
 ): SchemaTables[] =>
     tablesBySchema
         .map(({ schema, tables }) => {
-            const fuse = new Fuse(Object.keys(tables), {
-                threshold: 0.3,
-                isCaseSensitive: false,
-                ignoreLocation: true,
-            });
-            const matches = fuse.search(search).map((result) => result.item);
+            const typed = Object.keys(tables).filter((table) =>
+                matchesTableTypeFilter(tables[table].tableType, typeFilter),
+            );
+            const matches = searchTableNames(typed, search);
             return {
                 schema,
                 tables: Object.fromEntries(


### PR DESCRIPTION
## Summary

Stacked on #29014. With the relation type in the catalog, the sidebar can filter by it without another fetch. Two icon toggles, tables and views, sit next to the search box and only appear when the catalog contains at least one view, so projects with plain tables see no new chrome. One is active at a time; clicking the active one shows everything again.

Relates: PROD-5746

## Changes

- `utils/tableRows.ts`: `filterTablesBySchema` takes a `TableTypeFilter` next to the search string. Views covers views and materialized views; Tables covers everything else, including rows cached before the type column existed. Schemas left with no matching table are dropped, so the search and the type filter compose.
- `catalogHasViews` decides whether to render the toggles.
- `Tables.tsx`: an `ActionIcon.Group` with a table and an eye icon, `aria-pressed` on the active one and tooltips ("Only tables", "Only views", "Show all"). An active type filter expands matching schemas the same way a search does, and schema headers show the count of matching rows while a type filter is active. Manual expand and collapse choices reset whenever the search or the filter changes.
- Filter state is component state and resets when the SQL runner is reopened, same as the search.

## Regression analysis

- Nothing changes for a catalog without views: the toggles are not rendered and the row list is identical.
- With no toggle active, filtering and expansion behave exactly as on #29014.
- The per-schema count only renders while a toggle is active, so default headers are untouched.

## Evidence (local Postgres 18, jaffle shop dev DB)

<table><tr>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr5-filter-all.png" width="300" alt="Toggles next to the search box, tooltip on the views toggle"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr5-filter-views.png" width="300" alt="Views toggle active: only views listed with counts per schema"></td>
<td><img src="https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-5746-sql-runner-views/pr5-filter-views-search.png" width="300" alt="Views combined with a search for orders"></td>
</tr></table>

The views toggle alone lists 17 relations under `jaffle` (the materialized view and the dbt staging models) and all 2,500 under the fixture schema. Views plus the search "orders" narrows `jaffle` to 5.

## Test plan

- [x] `pnpm -F frontend test src/features/sqlRunner/utils/tableRows.test.ts` (7 tests)
- [x] `pnpm -F frontend typecheck`, oxlint on the changed files
- [x] Verified in the app: toggles appear, views and tables filter the list, search composes, clicking the active toggle restores the full list (screenshots above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFNdHweoAjBXR2Gt4b4S19
