### PR TITLE
fix(roadmap): show shared catalog when org has no private requests

### DIFF
--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.test.tsx
@@ -297,6 +297,23 @@ describe('following roadmap projects', () => {
         ).not.toBeInTheDocument();
     });
 
+    it('renders the shared catalog when private requests return 403', async () => {
+        vi.spyOn(roadmapApi, 'getRequests').mockRejectedValue({
+            status: 'error',
+            error: { statusCode: 403, name: 'ForbiddenError' },
+        });
+        renderRoadmap();
+        expect(
+            await screen.findByRole('button', { name: 'Open Project direct' }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText('Your organization has no feature requests yet.'),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("Your roadmap isn't set up yet"),
+        ).not.toBeInTheDocument();
+    });
+
     it('does not offer following inside an already followed project modal', async () => {
         renderRoadmap();
         await userEvent.click(

--- a/packages/frontend/src/ee/features/roadmap/RoadmapProjects.tsx
+++ b/packages/frontend/src/ee/features/roadmap/RoadmapProjects.tsx
@@ -774,14 +774,21 @@ export function RoadmapProjects({
             ? boardQueries.some((column) => column.loading)
             : projectsQuery.isInitialLoading ||
               (showTickets && ticketsQuery.isInitialLoading));
-    const errors =
+    const projectErrors =
         initializingInterest || view === 'table'
-            ? [projectsQuery.error, showTickets ? ticketsQuery.error : null]
-            : boardQueries.map((column) => column.error);
-    const unavailable = errors.some(
-        (error) => error?.error?.statusCode === 403,
-    );
-    const failed = errors.some(Boolean);
+            ? [projectsQuery.error]
+            : boardQueries.map((column) => column.projectError);
+    const requestErrors =
+        initializingInterest || view === 'table'
+            ? [showTickets ? ticketsQuery.error : null]
+            : boardQueries.map((column) => column.requestError);
+    const isForbidden = (error: (typeof projectErrors)[number]) =>
+        error?.error?.statusCode === 403;
+    const unavailable = projectErrors.some(isForbidden);
+    const requestsForbidden = requestErrors.some(isForbidden);
+    const failed =
+        projectErrors.some(Boolean) ||
+        requestErrors.some((error) => Boolean(error) && !isForbidden(error));
     const back = () => {
         setSelectedProject(null);
         setProjectSearch('');
@@ -1058,14 +1065,18 @@ export function RoadmapProjects({
                                     ? hasFilters
                                         ? 'No matching tickets'
                                         : 'No followed tickets in this project'
-                                    : hasFilters
-                                      ? 'No matching projects or tickets'
-                                      : 'No roadmap items yet'
+                                    : requestsForbidden && !showProjects
+                                      ? 'No feature requests yet'
+                                      : hasFilters
+                                        ? 'No matching projects or tickets'
+                                        : 'No roadmap items yet'
                             }
                             description={
                                 projectBoard
                                     ? 'Only your organization’s visible requests in this project appear here.'
-                                    : 'Projects and tickets you follow will appear here.'
+                                    : requestsForbidden && !showProjects
+                                      ? 'Your organization has no feature requests yet.'
+                                      : 'Projects and tickets you follow will appear here.'
                             }
                             action={
                                 hasFilters ? (
@@ -1082,6 +1093,11 @@ export function RoadmapProjects({
                 </Box>
             ) : (
                 <>
+                    {requestsForbidden && showTickets && (
+                        <Text fz="xs" c="dimmed" px="xl" pt="md">
+                            Your organization has no feature requests yet.
+                        </Text>
+                    )}
                     {view === 'board' ? (
                         <Board
                             key={selectedProjectId ?? 'roadmap'}

--- a/packages/frontend/src/ee/features/roadmap/useRoadmapBoard.ts
+++ b/packages/frontend/src/ee/features/roadmap/useRoadmapBoard.ts
@@ -64,10 +64,8 @@ function useColumn(
             enabled &&
             ((options.showProjects && projects.isInitialLoading) ||
                 (options.showTickets && tickets.isInitialLoading)),
-        error: enabled
-            ? ((options.showProjects ? projects.error : null) ??
-              (options.showTickets ? tickets.error : null))
-            : null,
+        projectError: enabled && options.showProjects ? projects.error : null,
+        requestError: enabled && options.showTickets ? tickets.error : null,
         hasNextPage:
             (options.showProjects && projects.hasNextPage) ||
             (options.showTickets && tickets.hasNextPage),


### PR DESCRIPTION
Closes: PROD-11177

### Description:
Every org on a validly-licensed instance can now open Settings → Roadmap, but an org without a Control Center mapping is entitled only to the shared project catalog and gets a 403 from the private-requests endpoint. The roadmap page previously marked the whole page unavailable on any 403, hiding the catalog these orgs can legitimately see. This splits the page's error handling so a projects 403 still shows the page-level "not set up" state while a requests 403 degrades to an empty-requests state, keeping the catalog, board/table and Following/All control working with a short note explaining the org has no requests yet. Added a test covering projects 200 + requests 403.

### Risk assessment:

- [ ] This is a high-risk change

High-risk changes require approval from a reviewer other than the author before merging.