### PR TITLE
fix(chart-types): rebuild the icon picker on the theme ActionIcon

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeGalleryCard.tsx
@@ -78,11 +78,10 @@ const ChartTypeGalleryCard: FC<Props> = ({
                 </Box>
                 <Stack gap="xs" p="sm">
                     <Group gap="xs" wrap="nowrap" justify="space-between">
-                        <Group gap={6} wrap="nowrap" miw={0}>
+                        <Group gap="xs" wrap="nowrap" miw={0}>
                             <MantineIcon
                                 icon={getChartTypeIcon(dataAppViz.icon)}
                                 color="dimmed"
-                                size="sm"
                             />
                             <Text fz="sm" fw={600} truncate="end">
                                 {displayName}

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeIconPicker.module.css
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeIconPicker.module.css
@@ -1,78 +1,10 @@
-.target {
-    display: grid;
-    place-items: center;
-    width: 34px;
-    height: 34px;
-    border: 1px solid
-        light-dark(var(--mantine-color-ldGray-3), var(--mantine-color-ldDark-5));
-    border-radius: var(--mantine-radius-sm);
-    background: light-dark(
-        var(--mantine-color-ldGray-0),
-        var(--mantine-color-ldDark-3)
-    );
-    color: var(--mantine-color-ldGray-7);
-    transition:
-        border-color 120ms ease,
-        background-color 120ms ease;
-}
-
-.target:hover:not(:disabled) {
-    border-color: light-dark(
-        var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-6)
-    );
-    background: light-dark(
-        var(--mantine-color-ldGray-1),
-        var(--mantine-color-ldDark-4)
-    );
-}
-
-.target:disabled {
-    opacity: 0.5;
+/* Six rows of md ActionIcons, so the fold lands on a row edge */
+.scroll {
+    max-height: calc(6 * rem(28px) + 5 * var(--mantine-spacing-xs));
 }
 
 .grid {
     display: grid;
-    grid-template-columns: repeat(7, 30px);
-    gap: 4px;
-}
-
-.cell {
-    display: grid;
-    place-items: center;
-    width: 30px;
-    height: 30px;
-    border: 1px solid transparent;
-    border-radius: var(--mantine-radius-sm);
-    color: var(--mantine-color-ldGray-7);
-    transition:
-        border-color 120ms ease,
-        background-color 120ms ease;
-}
-
-.cell:hover {
-    border-color: light-dark(
-        var(--mantine-color-ldGray-4),
-        var(--mantine-color-ldDark-6)
-    );
-    background: light-dark(
-        var(--mantine-color-ldGray-1),
-        var(--mantine-color-ldDark-4)
-    );
-}
-
-.cell[data-selected='true'] {
-    border-color: light-dark(
-        var(--mantine-color-blue-5),
-        var(--mantine-color-blue-7)
-    );
-    background: light-dark(
-        var(--mantine-color-blue-0),
-        color-mix(
-            in srgb,
-            var(--mantine-color-blue-9) 30%,
-            var(--mantine-color-ldDark-3)
-        )
-    );
-    color: light-dark(var(--mantine-color-blue-7), var(--mantine-color-blue-4));
+    grid-template-columns: repeat(7, 1fr);
+    gap: var(--mantine-spacing-xs);
 }

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeIconPicker.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeIconPicker.tsx
@@ -1,5 +1,6 @@
 import { CHART_TYPE_ICONS, type ChartTypeIcon } from '@lightdash/common';
 import {
+    ActionIcon,
     Box,
     Button,
     Popover,
@@ -8,7 +9,6 @@ import {
     Text,
     TextInput,
     Tooltip,
-    UnstyledButton,
 } from '@mantine/core';
 import { IconSearch } from '@tabler/icons-react';
 import { useMemo, useState, type FC } from 'react';
@@ -55,15 +55,16 @@ const ChartTypeIconPicker: FC<Props> = ({ value, onChange, disabled }) => {
         >
             <Popover.Target>
                 <Tooltip label="Choose an icon" disabled={isOpen}>
-                    <UnstyledButton
-                        type="button"
-                        className={classes.target}
+                    <ActionIcon
+                        variant="default"
+                        size="lg"
+                        display="flex"
                         aria-label="Chart type icon"
                         disabled={disabled}
                         onClick={() => setIsOpen((opened) => !opened)}
                     >
                         <MantineIcon icon={getChartTypeIcon(value)} />
-                    </UnstyledButton>
+                    </ActionIcon>
                 </Tooltip>
             </Popover.Target>
 
@@ -72,9 +73,7 @@ const ChartTypeIconPicker: FC<Props> = ({ value, onChange, disabled }) => {
                     <TextInput
                         size="xs"
                         autoFocus
-                        leftSection={
-                            <MantineIcon icon={IconSearch} size="sm" />
-                        }
+                        leftSection={<MantineIcon icon={IconSearch} />}
                         placeholder="Search icons"
                         value={search}
                         onChange={(event) =>
@@ -82,7 +81,10 @@ const ChartTypeIconPicker: FC<Props> = ({ value, onChange, disabled }) => {
                         }
                     />
 
-                    <ScrollArea.Autosize mah={200} type="scroll">
+                    <ScrollArea.Autosize
+                        className={classes.scroll}
+                        type="scroll"
+                    >
                         {filteredIcons.length === 0 ? (
                             <Text size="xs" c="dimmed" ta="center" py="xs">
                                 No icons match
@@ -92,17 +94,21 @@ const ChartTypeIconPicker: FC<Props> = ({ value, onChange, disabled }) => {
                                 {filteredIcons.map((iconName) => {
                                     const label =
                                         getChartTypeIconLabel(iconName);
+                                    const isSelected = value === iconName;
                                     return (
                                         <Tooltip key={iconName} label={label}>
-                                            <UnstyledButton
-                                                type="button"
-                                                className={classes.cell}
-                                                data-selected={
-                                                    value === iconName
+                                            <ActionIcon
+                                                variant={
+                                                    isSelected
+                                                        ? 'light'
+                                                        : 'subtle'
                                                 }
-                                                aria-pressed={
-                                                    value === iconName
+                                                color={
+                                                    isSelected
+                                                        ? 'blue'
+                                                        : undefined
                                                 }
+                                                aria-pressed={isSelected}
                                                 aria-label={label}
                                                 onClick={() =>
                                                     handleSelect(iconName)
@@ -112,9 +118,8 @@ const ChartTypeIconPicker: FC<Props> = ({ value, onChange, disabled }) => {
                                                     icon={getChartTypeIcon(
                                                         iconName,
                                                     )}
-                                                    size="sm"
                                                 />
-                                            </UnstyledButton>
+                                            </ActionIcon>
                                         </Tooltip>
                                     );
                                 })}


### PR DESCRIPTION
## Summary

Follow-up polish to the custom chart type icon picker that shipped with the icon stack.

- The picker trigger and the icon cells are Mantine `ActionIcon`s now (`default` for the trigger, `subtle` for cells, `light` blue when selected) instead of `UnstyledButton`s with hand-written styles.
- The CSS module keeps only the grid rule. Hover, disabled and selected states, and the dark mode colours, come from the theme instead of the deleted `light-dark()` rules.
- Grid columns and gaps use theme spacing. The gallery card icon and the search icon use the default `MantineIcon` size, and the card uses an `xs` gap.
- The scroll area height is derived from six rows of cells, so the fold lands on a row edge instead of clipping the sixth row.

## Verification

- `pnpm -F frontend typecheck` passes, oxlint on the changed files is clean, and the picker and update modal unit tests pass (2 files, 7 tests).
- Headless run against the branch in light and dark mode: open the edit details modal, open the picker, search filters the grid, clicking a cell selects it and closes the popover, the trigger shows the new icon, reopening shows it as selected, Save sends the PATCH (200) and the icon persists on the chart type. Measured the grid after the change: six rows of 28px cells with an 8px gap fill the 208px viewport exactly.

Relates: PROD-11066