### PR TITLE
feat(common): declare a per-column wall clock timezone for naive timestamps

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -2949,6 +2949,487 @@ describe('convert_timezone dimension override', () => {
     });
 });
 
+describe('wall_clock_timezone dimension annotation', () => {
+    const ZONE = 'Africa/Johannesburg';
+
+    const buildModel = ({
+        wallClockTimezone = ZONE,
+        type = DimensionType.TIMESTAMP,
+        convertTimezone,
+        timestampDomain,
+        timeIntervals = [TimeFrames.DAY],
+    }: {
+        wallClockTimezone?: string;
+        type?: DimensionType;
+        convertTimezone?: boolean;
+        timestampDomain?: 'aware' | 'naive';
+        timeIntervals?: (TimeFrames | string)[];
+    }): DbtModelNode & { relation_name: string } => ({
+        ...model,
+        columns: {
+            created_at: {
+                name: 'created_at',
+                data_type: type,
+                ...(timestampDomain
+                    ? { timestamp_domain: timestampDomain }
+                    : {}),
+                meta: {
+                    dimension: {
+                        type,
+                        wall_clock_timezone: wallClockTimezone,
+                        ...(convertTimezone !== undefined
+                            ? { convert_timezone: convertTimezone }
+                            : {}),
+                        time_intervals: timeIntervals,
+                    },
+                },
+            },
+        },
+    });
+
+    it('converts the column to UTC in place on Snowflake', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            buildModel({}),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at.sql).toBe(
+            "CONVERT_TIMEZONE('Africa/Johannesburg', 'UTC', ${TABLE}.created_at)",
+        );
+        expect(result.dimensions.created_at.sourceTimezone).toBe('UTC');
+        expect(result.dimensions.created_at.timestampDomain).toBe('naive');
+        expect(result.warnings).toBeUndefined();
+    });
+
+    it('converts the column on Snowflake even when disableTimestampConversion is set', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            buildModel({}),
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            true,
+        );
+
+        expect(result.dimensions.created_at.sql).toBe(
+            "CONVERT_TIMEZONE('Africa/Johannesburg', 'UTC', ${TABLE}.created_at)",
+        );
+        expect(result.dimensions.created_at.sourceTimezone).toBe('UTC');
+        expect(result.dimensions.created_at.timestampDomain).toBe('naive');
+    });
+
+    it('leaves an unannotated Snowflake column on the session-based wrap', () => {
+        const unannotated: DbtModelNode & { relation_name: string } = {
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                    },
+                },
+            },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            unannotated,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at.sql).toBe(
+            "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.created_at))",
+        );
+        expect(result.dimensions.created_at.sourceTimezone).toBeUndefined();
+    });
+
+    it('leaves the SQL alone and stamps the zone on other warehouses', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            buildModel({}),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at.sql).toBe('${TABLE}.created_at');
+        expect(result.dimensions.created_at.sourceTimezone).toBe(ZONE);
+        expect(result.dimensions.created_at.timestampDomain).toBe('naive');
+        expect(result.warnings).toBeUndefined();
+    });
+
+    it('propagates sourceTimezone onto standard and custom-granularity children', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            buildModel({
+                timeIntervals: [TimeFrames.DAY, 'my_quarter'],
+            }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+            undefined,
+            undefined,
+            {
+                my_quarter: {
+                    label: 'My Quarter',
+                    sql: "DATE_TRUNC('QUARTER', ${COLUMN})",
+                },
+            },
+        );
+
+        expect(result.dimensions.created_at_day.sourceTimezone).toBe(ZONE);
+        expect(result.dimensions.created_at_day.timestampDomain).toBe('naive');
+        expect(result.dimensions.created_at_my_quarter.sourceTimezone).toBe(
+            ZONE,
+        );
+    });
+
+    it('warns and ignores an invalid timezone', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            buildModel({ wallClockTimezone: 'Not/AZone' }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings?.[0].type).toBe(InlineErrorType.FIELD_ERROR);
+        expect(result.warnings?.[0].message).toContain('not a valid timezone');
+        expect(result.dimensions.created_at.sourceTimezone).toBeUndefined();
+        expect(result.dimensions.created_at_day.sourceTimezone).toBeUndefined();
+    });
+
+    it('warns and ignores the annotation on a non-timestamp dimension', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            buildModel({ type: DimensionType.DATE }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings?.[0].message).toContain(
+            'only applies to timestamp dimensions',
+        );
+        expect(result.dimensions.created_at.sourceTimezone).toBeUndefined();
+        expect(result.dimensions.created_at).not.toHaveProperty(
+            'timestampDomain',
+        );
+    });
+
+    it('warns and ignores the annotation when convert_timezone is false', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            buildModel({ convertTimezone: false }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings?.[0].message).toContain(
+            'cannot be combined with "convert_timezone: false"',
+        );
+        expect(result.dimensions.created_at.sourceTimezone).toBeUndefined();
+        expect(result.dimensions.created_at.skipTimezoneConversion).toBe(true);
+        expect(result.dimensions.created_at.sql).toBe(
+            "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.created_at))",
+        );
+    });
+
+    it('carries an additional dimension wall clock to its children and does not leak the base annotation', () => {
+        const modelWithAdditionalDimensions: DbtModelNode & {
+            relation_name: string;
+        } = {
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            wall_clock_timezone: ZONE,
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                        additional_dimensions: {
+                            created_at_lisbon: {
+                                type: DimensionType.TIMESTAMP,
+                                sql: '${TABLE}.created_at_lisbon',
+                                wall_clock_timezone: 'Europe/Lisbon',
+                                time_intervals: [TimeFrames.DAY],
+                            },
+                            created_at_plain: {
+                                type: DimensionType.TIMESTAMP,
+                                sql: '${TABLE}.created_at_plain',
+                                time_intervals: [TimeFrames.DAY],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            modelWithAdditionalDimensions,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at.sourceTimezone).toBe(ZONE);
+        expect(result.dimensions.created_at_lisbon.sourceTimezone).toBe(
+            'Europe/Lisbon',
+        );
+        expect(result.dimensions.created_at_lisbon_day.sourceTimezone).toBe(
+            'Europe/Lisbon',
+        );
+        expect(
+            result.dimensions.created_at_plain.sourceTimezone,
+        ).toBeUndefined();
+        expect(
+            result.dimensions.created_at_plain_day.sourceTimezone,
+        ).toBeUndefined();
+    });
+
+    it('wraps the column once on a Snowflake standard interval child', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            buildModel({}),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at_day.sql).toBe(
+            "DATE_TRUNC('DAY', CONVERT_TIMEZONE('Africa/Johannesburg', 'UTC', ${TABLE}.created_at))",
+        );
+        expect(result.dimensions.created_at_day.sourceTimezone).toBe('UTC');
+        expect(result.dimensions.created_at_day.wallClockTimezone).toBe(ZONE);
+        expect(result.dimensions.created_at.wallClockTimezone).toBe(ZONE);
+    });
+
+    it('wraps the custom sql expression, not the column, on Snowflake', () => {
+        const withCustomSql: DbtModelNode & { relation_name: string } = {
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            sql: 'COALESCE(${TABLE}.created_at, ${TABLE}.updated_at)',
+                            wall_clock_timezone: ZONE,
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                    },
+                },
+            },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            withCustomSql,
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.dimensions.created_at.sql).toBe(
+            "CONVERT_TIMEZONE('Africa/Johannesburg', 'UTC', COALESCE(${TABLE}.created_at, ${TABLE}.updated_at))",
+        );
+        expect(result.dimensions.created_at_day.sql).toBe(
+            "DATE_TRUNC('DAY', CONVERT_TIMEZONE('Africa/Johannesburg', 'UTC', COALESCE(${TABLE}.created_at, ${TABLE}.updated_at)))",
+        );
+    });
+
+    it('warns and ignores an offset-style zone', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            buildModel({ wallClockTimezone: '+05:00' }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings?.[0].message).toContain('not a valid timezone');
+        expect(result.dimensions.created_at.sourceTimezone).toBeUndefined();
+        expect(result.dimensions.created_at.wallClockTimezone).toBeUndefined();
+        expect(result.dimensions.created_at.sql).toBe(
+            "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.created_at))",
+        );
+    });
+
+    describe('additional dimensions', () => {
+        const buildAdditionalDimensionModel = ({
+            baseConvertTimezone,
+            wallClockTimezone,
+        }: {
+            baseConvertTimezone?: boolean;
+            wallClockTimezone?: string;
+        }): DbtModelNode & { relation_name: string } => ({
+            ...model,
+            columns: {
+                created_at: {
+                    name: 'created_at',
+                    data_type: DimensionType.TIMESTAMP,
+                    meta: {
+                        dimension: {
+                            type: DimensionType.TIMESTAMP,
+                            ...(baseConvertTimezone !== undefined
+                                ? { convert_timezone: baseConvertTimezone }
+                                : {}),
+                            time_intervals: [TimeFrames.DAY],
+                        },
+                        additional_dimensions: {
+                            alt_lisbon: {
+                                type: DimensionType.TIMESTAMP,
+                                sql: '${TABLE}.alt',
+                                ...(wallClockTimezone
+                                    ? {
+                                          wall_clock_timezone:
+                                              wallClockTimezone,
+                                      }
+                                    : {}),
+                                time_intervals: [TimeFrames.DAY],
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        it('wraps an annotated additional dimension and its child exactly once on Snowflake', () => {
+            const result = convertTable(
+                SupportedDbtAdapter.SNOWFLAKE,
+                buildAdditionalDimensionModel({
+                    wallClockTimezone: 'Europe/Lisbon',
+                }),
+                DEFAULT_SPOTLIGHT_CONFIG,
+            );
+
+            expect(result.dimensions.alt_lisbon.sql).toBe(
+                "CONVERT_TIMEZONE('Europe/Lisbon', 'UTC', ${TABLE}.alt)",
+            );
+            expect(result.dimensions.alt_lisbon_day.sql).toBe(
+                "DATE_TRUNC('DAY', CONVERT_TIMEZONE('Europe/Lisbon', 'UTC', ${TABLE}.alt))",
+            );
+            [
+                result.dimensions.alt_lisbon,
+                result.dimensions.alt_lisbon_day,
+            ].forEach((dimension) => {
+                expect(dimension.sourceTimezone).toBe('UTC');
+                expect(dimension.wallClockTimezone).toBe('Europe/Lisbon');
+                expect(dimension.timestampDomain).toBe('naive');
+                expect(dimension).not.toHaveProperty('skipTimezoneConversion');
+            });
+        });
+
+        it('does not leak the base column convert_timezone onto an annotated additional dimension', () => {
+            const result = convertTable(
+                SupportedDbtAdapter.POSTGRES,
+                buildAdditionalDimensionModel({
+                    baseConvertTimezone: false,
+                    wallClockTimezone: 'Europe/Lisbon',
+                }),
+                DEFAULT_SPOTLIGHT_CONFIG,
+            );
+
+            expect(result.warnings).toBeUndefined();
+            [
+                result.dimensions.alt_lisbon,
+                result.dimensions.alt_lisbon_day,
+            ].forEach((dimension) => {
+                expect(dimension.sourceTimezone).toBe('Europe/Lisbon');
+                expect(dimension.wallClockTimezone).toBe('Europe/Lisbon');
+                expect(dimension.timestampDomain).toBe('naive');
+                expect(dimension).not.toHaveProperty('skipTimezoneConversion');
+            });
+        });
+
+        it('leaves an unannotated additional dimension and its child untouched on Snowflake', () => {
+            const result = convertTable(
+                SupportedDbtAdapter.SNOWFLAKE,
+                buildAdditionalDimensionModel({}),
+                DEFAULT_SPOTLIGHT_CONFIG,
+            );
+
+            expect(result.dimensions.alt_lisbon.sql).toBe(
+                "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.alt))",
+            );
+            expect(result.dimensions.alt_lisbon_day.sql).toBe(
+                "DATE_TRUNC('DAY', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.alt)))))",
+            );
+            expect(result.dimensions.alt_lisbon.sourceTimezone).toBeUndefined();
+            expect(
+                result.dimensions.alt_lisbon_day.sourceTimezone,
+            ).toBeUndefined();
+        });
+
+        it('does not leak the base column convert_timezone onto an unannotated additional dimension child', () => {
+            const result = convertTable(
+                SupportedDbtAdapter.SNOWFLAKE,
+                buildAdditionalDimensionModel({ baseConvertTimezone: false }),
+                DEFAULT_SPOTLIGHT_CONFIG,
+            );
+
+            // Same SQL as without the base column annotation: convert_timezone
+            // never governed the compile-time wrap.
+            expect(result.dimensions.alt_lisbon.sql).toBe(
+                "TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.alt))",
+            );
+            expect(result.dimensions.alt_lisbon_day.sql).toBe(
+                "DATE_TRUNC('DAY', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${TABLE}.alt)))))",
+            );
+            expect(result.dimensions.alt_lisbon).not.toHaveProperty(
+                'skipTimezoneConversion',
+            );
+            expect(result.dimensions.alt_lisbon_day).not.toHaveProperty(
+                'skipTimezoneConversion',
+            );
+        });
+
+        it('carries an additional dimension own convert_timezone to its children', () => {
+            const withOwnConvertTimezone: DbtModelNode & {
+                relation_name: string;
+            } = {
+                ...model,
+                columns: {
+                    created_at: {
+                        name: 'created_at',
+                        data_type: DimensionType.TIMESTAMP,
+                        meta: {
+                            dimension: { type: DimensionType.TIMESTAMP },
+                            additional_dimensions: {
+                                alt_raw: {
+                                    type: DimensionType.TIMESTAMP,
+                                    sql: '${TABLE}.alt',
+                                    convert_timezone: false,
+                                    time_intervals: [TimeFrames.DAY],
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            const result = convertTable(
+                SupportedDbtAdapter.SNOWFLAKE,
+                withOwnConvertTimezone,
+                DEFAULT_SPOTLIGHT_CONFIG,
+            );
+
+            expect(result.dimensions.alt_raw.skipTimezoneConversion).toBe(true);
+            expect(result.dimensions.alt_raw_day.skipTimezoneConversion).toBe(
+                true,
+            );
+        });
+    });
+
+    it('warns but still reads an aware column as a naive wall clock', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            buildModel({ timestampDomain: 'aware' }),
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+
+        expect(result.warnings).toHaveLength(1);
+        expect(result.warnings?.[0].message).toContain(
+            'its "aware" timestamp domain is ignored',
+        );
+        expect(result.dimensions.created_at.timestampDomain).toBe('naive');
+        expect(result.dimensions.created_at.sourceTimezone).toBe(ZONE);
+        expect(result.dimensions.created_at_day.timestampDomain).toBe('naive');
+    });
+});
+
 describe('project default additional_time_intervals', () => {
     const TIMESTAMP_MODEL: DbtModelNode & { relation_name: string } = {
         ...model,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -64,6 +64,7 @@ import {
     type WarehouseTableSchema,
 } from '../types/warehouse';
 import assertUnreachable from '../utils/assertUnreachable';
+import { isValidTimezone } from '../utils/scheduler';
 import {
     getDefaultTimeFrames,
     getTimeFramesWithProjectDefaults,
@@ -88,6 +89,7 @@ const convertTimezone = (
     default_source_tz: string,
     target_tz: string,
     adapterType: SupportedDbtAdapter,
+    declared_source_tz?: string,
 ) => {
     // todo: implement default_source_tz
     // todo: implement target_tz
@@ -101,7 +103,11 @@ const convertTimezone = (
             // TIMESTAMP_NTZ: no tz. assume default_source_tz. convert from default_source_tz to target_tz
             // TIMESTAMP_LTZ: stored in utc. returns in session tz. convert from session tz to target_tz
             // TIMESTAMP_TZ: stored with tz. returns with tz. convert from value tz to target_tz
-            return `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${timestampSql}))`;
+            // A declared source zone reads the NTZ wall clock in that zone
+            // instead of the session zone, and returns NTZ in target_tz.
+            return declared_source_tz
+                ? `CONVERT_TIMEZONE('${declared_source_tz}', 'UTC', ${timestampSql})`
+                : `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', ${timestampSql}))`;
         case SupportedDbtAdapter.REDSHIFT:
             // TIMESTAMP WITH TIME ZONE: stored in utc. returns utc. convert from utc to target_tz
             // TIMESTAMP WITHOUT TIME ZONE: no tz. assume utc. convert from utc to target_tz
@@ -210,6 +216,99 @@ const convertFilterAutocomplete = (
     };
 };
 
+/** Warehouses whose compiled TIMESTAMP SQL converts a declared wall clock to
+ *  UTC in place, so query time sees a UTC column. */
+const convertsWallClockAtCompileTime = (
+    adapterType: SupportedDbtAdapter,
+): boolean => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return true;
+        case SupportedDbtAdapter.BIGQUERY:
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.DUCKDB:
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.CLICKHOUSE:
+        case SupportedDbtAdapter.ATHENA:
+        case SupportedDbtAdapter.SPARK:
+            return false;
+        default:
+            return assertUnreachable(
+                adapterType,
+                new ParseError(`Cannot recognise warehouse ${adapterType}`),
+            );
+    }
+};
+
+const resolveWallClockTimezone = ({
+    declaration,
+    type,
+    skipTimezoneConversion,
+    timestampDomain,
+    modelName,
+    dimensionName,
+}: {
+    declaration: string;
+    type: DimensionType;
+    skipTimezoneConversion: boolean;
+    timestampDomain: TimestampDomain | undefined;
+    modelName: string;
+    dimensionName: string;
+}): { timezone: string | undefined; warnings: InlineError[] } => {
+    const context = `dimension "${dimensionName}" in dbt model "${modelName}"`;
+    if (type !== DimensionType.TIMESTAMP) {
+        return {
+            timezone: undefined,
+            warnings: [
+                {
+                    type: InlineErrorType.FIELD_ERROR,
+                    message: `"wall_clock_timezone" only applies to timestamp dimensions, so it is ignored on ${context}.`,
+                },
+            ],
+        };
+    }
+    if (skipTimezoneConversion) {
+        return {
+            timezone: undefined,
+            warnings: [
+                {
+                    type: InlineErrorType.FIELD_ERROR,
+                    message: `"wall_clock_timezone" cannot be combined with "convert_timezone: false" on ${context}. "wall_clock_timezone" is ignored.`,
+                },
+            ],
+        };
+    }
+    // Offset strings pass isValidTimezone but Snowflake's CONVERT_TIMEZONE
+    // only takes named zones.
+    const isOffsetStyle =
+        declaration.startsWith('+') || declaration.startsWith('-');
+    if (isOffsetStyle || !isValidTimezone(declaration)) {
+        return {
+            timezone: undefined,
+            warnings: [
+                {
+                    type: InlineErrorType.FIELD_ERROR,
+                    message: `"wall_clock_timezone: ${declaration}" on ${context} is not a valid timezone, so it is ignored.`,
+                },
+            ],
+        };
+    }
+    return {
+        timezone: declaration,
+        warnings:
+            timestampDomain === 'aware'
+                ? [
+                      {
+                          type: InlineErrorType.FIELD_ERROR,
+                          message: `"wall_clock_timezone" declares ${context} as a wall clock, so its "aware" timestamp domain is ignored and the dimension is read as naive.`,
+                      },
+                  ]
+                : [],
+    };
+};
+
 const convertDimension = (
     index: number,
     targetWarehouse: SupportedDbtAdapter,
@@ -240,9 +339,6 @@ const convertDimension = (
     let name = meta.dimension?.name || column.name;
     let sql = meta.dimension?.sql || defaultSql(column.name);
     let label = meta.dimension?.label || friendlyName(name);
-    if (type === DimensionType.TIMESTAMP && !disableTimestampConversion) {
-        sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
-    }
     // YAML declaration wins over the warehouse catalog. The catalog describes
     // the physical column, so its domain is dropped when custom SQL replaces
     // the column — the expression may change the domain — and for additional
@@ -254,11 +350,50 @@ const convertDimension = (
         (meta.dimension?.sql || isAdditionalDimension
             ? undefined
             : column.timestamp_domain);
-    const timestampDomain: TimestampDomain | undefined =
+    const declaredTimestampDomain: TimestampDomain | undefined =
         type === DimensionType.TIMESTAMP &&
         isTimestampDomain(rawTimestampDomain)
             ? rawTimestampDomain
             : undefined;
+
+    const resolvedWallClock =
+        meta.dimension?.wall_clock_timezone !== undefined
+            ? resolveWallClockTimezone({
+                  declaration: meta.dimension.wall_clock_timezone,
+                  type,
+                  skipTimezoneConversion:
+                      meta.dimension.convert_timezone === false,
+                  timestampDomain: declaredTimestampDomain,
+                  modelName: model.name,
+                  dimensionName: name,
+              })
+            : undefined;
+    if (resolvedWallClock) {
+        warnings?.push(...resolvedWallClock.warnings);
+    }
+    const wallClockTimezone = resolvedWallClock?.timezone;
+    // A declared wall clock asserts the column is naive, whatever the catalog says.
+    const timestampDomain: TimestampDomain | undefined = wallClockTimezone
+        ? 'naive'
+        : declaredTimestampDomain;
+    const sourceTimezone =
+        wallClockTimezone && convertsWallClockAtCompileTime(targetWarehouse)
+            ? 'UTC'
+            : wallClockTimezone;
+
+    if (type === DimensionType.TIMESTAMP) {
+        if (wallClockTimezone) {
+            sql = convertTimezone(
+                sql,
+                'UTC',
+                'UTC',
+                targetWarehouse,
+                wallClockTimezone,
+            );
+        } else if (!disableTimestampConversion) {
+            sql = convertTimezone(sql, 'UTC', 'UTC', targetWarehouse);
+        }
+    }
     const isIntervalBase =
         timeInterval === undefined && isInterval(type, meta.dimension);
 
@@ -351,6 +486,8 @@ const convertDimension = (
             ? { skipTimezoneConversion: true }
             : {}),
         ...(timestampDomain ? { timestampDomain } : {}),
+        ...(sourceTimezone ? { sourceTimezone } : {}),
+        ...(wallClockTimezone ? { wallClockTimezone } : {}),
         groups,
         isIntervalBase,
         ...(meta.dimension && meta.dimension.tags
@@ -752,6 +889,15 @@ export const convertTable = (
                         (v) => !isTimeInterval(v.toUpperCase()),
                     );
 
+                    const isAdditional =
+                        'isAdditionalDimension' in dim &&
+                        !!dim.isAdditionalDimension;
+                    // An annotated additional dimension's SQL is already
+                    // converted, so its children carry the parent's resolved
+                    // state instead of re-resolving the annotation, which
+                    // would wrap the SQL a second time.
+                    const carriesParentWallClock =
+                        isAdditional && dim.wallClockTimezone !== undefined;
                     const dimensionMeta = {
                         ...columnMeta.dimension,
                         type: dim.type,
@@ -761,56 +907,77 @@ export const convertTable = (
                         description: dim.description,
                         hidden: dim.hidden,
                         // Additional-dim children must inherit the additional
-                        // dimension's own resolved domain, not the parent
-                        // column's annotation riding in the meta spread.
+                        // dimension's own resolved state, not the parent
+                        // column's annotations riding in the meta spread.
                         timestamp_domain: dim.timestampDomain,
+                        wall_clock_timezone: undefined,
+                        convert_timezone: dim.skipTimezoneConversion
+                            ? false
+                            : undefined,
                     };
 
                     // Generate standard interval dimensions
                     const standardDims = intervals.reduce<
                         Record<string, Dimension>
-                    >(
-                        (acc, interval) => ({
+                    >((acc, interval) => {
+                        const child = convertDimension(
+                            index,
+                            adapterType,
+                            model,
+                            tableLabel,
+                            {
+                                ...column,
+                                ...(isAdditional
+                                    ? {
+                                          name: dim.name,
+                                          meta: {
+                                              dimension: dimensionMeta,
+                                          },
+                                          // In dbt 1.10+, config.meta takes precedence over meta
+                                          // so we must set config.meta.dimension to prevent
+                                          // the base dimension's properties from overwriting
+                                          config: {
+                                              meta: {
+                                                  dimension: dimensionMeta,
+                                              },
+                                          },
+                                      }
+                                    : {}),
+                            },
+                            undefined,
+                            interval,
+                            startOfWeek,
+                            isAdditional,
+                            carriesParentWallClock
+                                ? true
+                                : disableTimestampConversion,
+                            undefined,
+                            granularityLabels,
+                        );
+                        return {
                             ...acc,
                             [`${dim.name}_${interval.toLowerCase()}`]:
-                                convertDimension(
-                                    index,
-                                    adapterType,
-                                    model,
-                                    tableLabel,
-                                    {
-                                        ...column,
-                                        ...('isAdditionalDimension' in dim &&
-                                        dim.isAdditionalDimension
-                                            ? {
-                                                  name: dim.name,
-                                                  meta: {
-                                                      dimension: dimensionMeta,
-                                                  },
-                                                  // In dbt 1.10+, config.meta takes precedence over meta
-                                                  // so we must set config.meta.dimension to prevent
-                                                  // the base dimension's properties from overwriting
-                                                  config: {
-                                                      meta: {
-                                                          dimension:
-                                                              dimensionMeta,
-                                                      },
-                                                  },
-                                              }
-                                            : {}),
-                                    },
-                                    undefined,
-                                    interval,
-                                    startOfWeek,
-                                    'isAdditionalDimension' in dim &&
-                                        dim.isAdditionalDimension,
-                                    disableTimestampConversion,
-                                    undefined,
-                                    granularityLabels,
-                                ),
-                        }),
-                        {},
-                    );
+                                carriesParentWallClock
+                                    ? {
+                                          ...child,
+                                          ...(dim.sourceTimezone
+                                              ? {
+                                                    sourceTimezone:
+                                                        dim.sourceTimezone,
+                                                }
+                                              : {}),
+                                          wallClockTimezone:
+                                              dim.wallClockTimezone,
+                                          ...(dim.timestampDomain
+                                              ? {
+                                                    timestampDomain:
+                                                        dim.timestampDomain,
+                                                }
+                                              : {}),
+                                      }
+                                    : child,
+                        };
+                    }, {});
 
                     // Generate custom granularity dimensions
                     const customDims = customIntervalNames.reduce<
@@ -867,6 +1034,15 @@ export const convertTable = (
                                     dim.isAdditionalDimension,
                                 ...(dim.skipTimezoneConversion
                                     ? { skipTimezoneConversion: true }
+                                    : {}),
+                                ...(dim.sourceTimezone
+                                    ? { sourceTimezone: dim.sourceTimezone }
+                                    : {}),
+                                ...(dim.wallClockTimezone
+                                    ? {
+                                          wallClockTimezone:
+                                              dim.wallClockTimezone,
+                                      }
                                     : {}),
                                 // Custom granularity SQL may change the base
                                 // column's domain, so keep its output unknown.

--- a/packages/common/src/dbt/schemas/lightdashMetadata.json
+++ b/packages/common/src/dbt/schemas/lightdashMetadata.json
@@ -250,6 +250,10 @@
                     "enum": ["aware", "naive"],
                     "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
                 },
+                "wall_clock_timezone": {
+                    "type": "string",
+                    "description": "Declares the IANA timezone of this column's stored wall clock (e.g. 'Africa/Johannesburg'), for a column that has no zone of its own. Implies the column is naive. Only valid on timestamp dimensions, and cannot be combined with convert_timezone: false."
+                },
                 "hidden": {
                     "type": "boolean"
                 },
@@ -315,6 +319,10 @@
                     "type": "string",
                     "enum": ["aware", "naive"],
                     "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
+                },
+                "wall_clock_timezone": {
+                    "type": "string",
+                    "description": "Declares the IANA timezone of this column's stored wall clock (e.g. 'Africa/Johannesburg'), for a column that has no zone of its own. Implies the column is naive. Only valid on timestamp dimensions, and cannot be combined with convert_timezone: false."
                 },
                 "hidden": {
                     "type": "boolean"

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1531,6 +1531,10 @@
                             "enum": ["aware", "naive"],
                             "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
                         },
+                        "wall_clock_timezone": {
+                            "type": "string",
+                            "description": "Declares the IANA timezone of this column's stored wall clock (e.g. 'Africa/Johannesburg'), for a column that has no zone of its own. Implies the column is naive. Only valid on timestamp dimensions, and cannot be combined with convert_timezone: false."
+                        },
                         "hidden": {
                             "type": "boolean"
                         },
@@ -1865,6 +1869,10 @@
                                     "type": "string",
                                     "enum": ["aware", "naive"],
                                     "description": "Declares whether this timestamp column stores an instant ('aware') or a bare wall clock ('naive'); overrides the warehouse catalog."
+                                },
+                                "wall_clock_timezone": {
+                                    "type": "string",
+                                    "description": "Declares the IANA timezone of this column's stored wall clock (e.g. 'Africa/Johannesburg'), for a column that has no zone of its own. Implies the column is naive. Only valid on timestamp dimensions, and cannot be combined with convert_timezone: false."
                                 },
                                 "hidden": {
                                     "type": "boolean"

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -300,6 +300,9 @@ export type DbtColumnLightdashDimension = {
     /** Declares whether the column stores an instant ('aware') or a bare wall
      *  clock ('naive'); overrides the warehouse catalog. */
     timestamp_domain?: TimestampDomain;
+    /** IANA zone the column's stored wall clock is in, when it differs from
+     *  the connection default. Implies the column is naive. */
+    wall_clock_timezone?: string;
     hidden?: boolean;
     // @deprecated Use format expression instead
     round?: number;

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -811,6 +811,14 @@ export interface Dimension extends Field {
     isAdditionalDimension?: boolean;
     skipTimezoneConversion?: boolean;
     timestampDomain?: TimestampDomain;
+    /** Zone the compiled SQL's naive timestamp values are in, when it differs
+     *  from the connection default. Set from `wall_clock_timezone`. On Snowflake
+     *  the compiler converts the column to UTC in place, so this reads 'UTC'. */
+    sourceTimezone?: string;
+    /** Zone declared by `wall_clock_timezone`, before any compile-time
+     *  conversion. Consumers that read the raw column (MIN/MAX metrics on
+     *  Snowflake) need it; everything else reads `sourceTimezone`. */
+    wallClockTimezone?: string;
     colors?: Record<string, string>;
     isIntervalBase?: boolean;
     aiHint?: string | string[];


### PR DESCRIPTION
Relates: GLITCH-463

### Description

`dataTimezone` is one zone per warehouse connection. A model with a UTC naive column next to a naive column stored in another zone (both `timestamp` / `DATETIME` / `TIMESTAMP_NTZ`) cannot be read correctly: one of the two is always shifted. This adds a `wall_clock_timezone` dimension annotation so a `timestamp` dimension can declare the zone its stored wall clock is in.

```yaml
columns:
  - name: created_at_local
    meta:
      dimension:
        type: timestamp
        wall_clock_timezone: Europe/Berlin
```

What this PR does:

- Both dbt YAML schemas and the dimension meta type accept `wall_clock_timezone` (IANA zone string).
- The compiler stamps two fields on the compiled dimension: `wallClockTimezone` (the declaration) and `sourceTimezone` (the zone the compiled SQL's values are in). The annotation implies `timestampDomain: 'naive'`; YAML wins over the catalog with a compile warning, the same rule as `timestamp_domain`.
- On Snowflake the session-based wrap `TO_TIMESTAMP_NTZ(CONVERT_TIMEZONE('UTC', col))` is swapped for the explicit `CONVERT_TIMEZONE('<zone>', 'UTC', col)` on annotated columns, so the column is UTC regardless of the session. Output type is unchanged (`TIMESTAMP_NTZ`).
- On every other warehouse the SQL is untouched; the next PR in the stack consumes `sourceTimezone` at query time.
- Rejected annotations (invalid zone, offset strings, non-timestamp dimension, combined with `convert_timezone: false`) warn and are ignored; nothing throws.
- Interval children and additional-dimension children inherit the resolved state.

Unannotated dimensions compile byte-identically to before.

Merge order: this PR is inert on its own for every warehouse except Snowflake with `disableTimestampConversion` and a data timezone set, where the query builder would treat the converted column as being in the data timezone until the next PR lands. Merge the stack together, before the docs PR that introduces the annotation publicly.

### Tests

- `pnpm -F common test src/compiler/translator.test.ts`: new `wall_clock_timezone dimension annotation` block pinning exact compiled SQL and flags on Snowflake and Postgres, interval and additional-dimension children, custom `sql`, and every warning path.
- `pnpm -F common lint`, `pnpm -F common typecheck`, `pnpm check:mcp-tools-snapshot`.
