### PR TITLE
feat(backend): resolve the naive timestamp source timezone per dimension

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -8267,6 +8267,334 @@ describe('Naive timestamp domain — explicit, session-independent conversion', 
     });
 });
 
+describe('Per-dimension declared wall clock timezone', () => {
+    const LOS_ANGELES = 'America/Los_Angeles';
+    // Every test runs on a connection whose column timezone differs from the
+    // dimension's declared zone, so a per-dimension read cannot pass by accident.
+    const CONNECTION_TIMEZONE = 'Asia/Tokyo';
+    const PROJECT_TIMEZONE = 'Europe/Paris';
+
+    const buildWallClockExplore = ({
+        adapter,
+        sourceTimezone,
+        wallClockTimezone,
+        baseCompiledSql,
+        annotateIntervalChildren,
+    }: {
+        adapter: SupportedDbtAdapter;
+        sourceTimezone: string;
+        wallClockTimezone?: string;
+        baseCompiledSql: string;
+        annotateIntervalChildren: boolean;
+    }): Explore => {
+        const declaration = wallClockTimezone ? { wallClockTimezone } : {};
+        const childAnnotation = annotateIntervalChildren
+            ? { sourceTimezone, ...declaration }
+            : {};
+        return {
+            targetDatabase: adapter,
+            name: 'events',
+            label: 'events',
+            baseTable: 'events',
+            tags: [],
+            joinedTables: [],
+            tables: {
+                events: {
+                    name: 'events',
+                    label: 'events',
+                    database: 'db',
+                    schema: 's',
+                    sqlTable: '"events"',
+                    primaryKey: ['id'],
+                    dimensions: {
+                        occurred_at: {
+                            type: DimensionType.TIMESTAMP,
+                            name: 'occurred_at',
+                            label: 'occurred_at',
+                            table: 'events',
+                            tableLabel: 'events',
+                            fieldType: FieldType.DIMENSION,
+                            sql: '${TABLE}.occurred_at',
+                            compiledSql: baseCompiledSql,
+                            tablesReferences: ['events'],
+                            hidden: false,
+                            timestampDomain: 'naive',
+                            sourceTimezone,
+                            ...declaration,
+                        },
+                        occurred_at_raw: {
+                            type: DimensionType.TIMESTAMP,
+                            name: 'occurred_at_raw',
+                            label: 'occurred_at_raw',
+                            table: 'events',
+                            tableLabel: 'events',
+                            fieldType: FieldType.DIMENSION,
+                            sql: '${TABLE}.occurred_at',
+                            compiledSql: baseCompiledSql,
+                            tablesReferences: ['events'],
+                            hidden: false,
+                            timeInterval: TimeFrames.RAW,
+                            timeIntervalBaseDimensionName: 'occurred_at',
+                            timeIntervalBaseDimensionType:
+                                DimensionType.TIMESTAMP,
+                            ...childAnnotation,
+                        },
+                        occurred_at_day: {
+                            type: DimensionType.DATE,
+                            name: 'occurred_at_day',
+                            label: 'occurred_at_day',
+                            table: 'events',
+                            tableLabel: 'events',
+                            fieldType: FieldType.DIMENSION,
+                            sql: `DATE_TRUNC('DAY', \${TABLE}.occurred_at)`,
+                            compiledSql: `DATE_TRUNC('DAY', ${baseCompiledSql})`,
+                            tablesReferences: ['events'],
+                            hidden: false,
+                            timeInterval: TimeFrames.DAY,
+                            timeIntervalBaseDimensionName: 'occurred_at',
+                            timeIntervalBaseDimensionType:
+                                DimensionType.TIMESTAMP,
+                            ...childAnnotation,
+                        },
+                    },
+                    metrics: {
+                        event_count: {
+                            type: MetricType.COUNT,
+                            fieldType: FieldType.METRIC,
+                            table: 'events',
+                            tableLabel: 'events',
+                            name: 'event_count',
+                            label: 'event_count',
+                            sql: '${TABLE}.id',
+                            compiledSql: 'COUNT("events".id)',
+                            tablesReferences: ['events'],
+                            hidden: false,
+                        },
+                    },
+                    lineageGraph: {},
+                },
+            },
+        };
+    };
+
+    const postgresExplore = (annotateIntervalChildren: boolean = true) =>
+        buildWallClockExplore({
+            adapter: SupportedDbtAdapter.POSTGRES,
+            sourceTimezone: LOS_ANGELES,
+            baseCompiledSql: '"events".occurred_at',
+            annotateIntervalChildren,
+        });
+
+    const wallClockQuery = (dimensions: string[]): CompiledMetricQuery => ({
+        exploreName: 'events',
+        dimensions,
+        metrics: ['events_event_count'],
+        filters: {},
+        sorts: [],
+        limit: 100,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    });
+
+    const buildPostgresQuery = (
+        compiledMetricQuery: CompiledMetricQuery,
+        annotateIntervalChildren: boolean = true,
+    ) =>
+        buildQuery({
+            explore: postgresExplore(annotateIntervalChildren),
+            compiledMetricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: PROJECT_TIMEZONE,
+            useTimezoneAwareDateTrunc: true,
+            columnTimezone: CONNECTION_TIMEZONE,
+        }).query;
+
+    test('truncated SELECT rebases from the declared zone, not the connection default', () => {
+        const query = buildPostgresQuery(
+            wallClockQuery(['events_occurred_at_day']),
+        );
+        expect(query).toContain(
+            `CAST(DATE_TRUNC('DAY', (("events".occurred_at) AT TIME ZONE '${LOS_ANGELES}') AT TIME ZONE '${PROJECT_TIMEZONE}') AS DATE) AS "events_occurred_at_day"`,
+        );
+        expect(query).not.toContain(CONNECTION_TIMEZONE);
+    });
+
+    test('RAW SELECT casts from the declared zone', () => {
+        const query = buildPostgresQuery(
+            wallClockQuery(['events_occurred_at_raw']),
+        );
+        expect(query).toContain(
+            `(("events".occurred_at) AT TIME ZONE '${LOS_ANGELES}') AS "events_occurred_at_raw"`,
+        );
+        expect(query).not.toContain(CONNECTION_TIMEZONE);
+    });
+
+    test('filter literal renders in the declared wall clock with a bare LHS', () => {
+        const query = buildPostgresQuery({
+            ...wallClockQuery(['events_occurred_at_raw']),
+            filters: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'f1',
+                            target: { fieldId: 'events_occurred_at_raw' },
+                            operator: FilterOperator.EQUALS,
+                            values: ['2024-01-14T17:00:00Z'],
+                        },
+                    ],
+                },
+            },
+        });
+        const whereClause = query.slice(query.indexOf('WHERE'));
+        // 17:00Z is 09:00 on the Los Angeles wall clock (UTC-8 in January).
+        expect(whereClause).toContain(
+            `("events".occurred_at) = ('2024-01-14 09:00:00'::timestamp)`,
+        );
+        expect(whereClause).not.toContain('2024-01-15 02:00:00');
+    });
+
+    const maxWallClockQuery: CompiledMetricQuery = {
+        ...wallClockQuery([]),
+        metrics: ['events_max_ts'],
+        additionalMetrics: [
+            {
+                table: 'events',
+                name: 'max_ts',
+                label: 'Max of occurred at',
+                type: MetricType.MAX,
+                sql: '${TABLE}.occurred_at',
+                baseDimensionName: 'occurred_at',
+            },
+        ],
+        compiledAdditionalMetrics: [
+            {
+                type: MetricType.MAX,
+                fieldType: FieldType.METRIC,
+                table: 'events',
+                tableLabel: 'events',
+                name: 'max_ts',
+                label: 'Max of occurred at',
+                sql: '${TABLE}.occurred_at',
+                compiledSql: `MAX("events".occurred_at)`,
+                tablesReferences: ['events'],
+                hidden: false,
+                baseDimensionType: DimensionType.TIMESTAMP,
+            },
+        ],
+    };
+
+    test('MIN/MAX rebases the aggregate operand from the declared zone', () => {
+        const query = buildPostgresQuery(maxWallClockQuery);
+        expect(query).toContain(
+            `MAX((("events".occurred_at) AT TIME ZONE '${LOS_ANGELES}')) AS "events_max_ts"`,
+        );
+        expect(query).not.toContain(CONNECTION_TIMEZONE);
+    });
+
+    test('an interval child without its own declaration resolves the base dimension zone', () => {
+        const query = buildPostgresQuery(
+            wallClockQuery([
+                'events_occurred_at_day',
+                'events_occurred_at_raw',
+            ]),
+            false,
+        );
+        expect(query).toContain(
+            `CAST(DATE_TRUNC('DAY', (("events".occurred_at) AT TIME ZONE '${LOS_ANGELES}') AT TIME ZONE '${PROJECT_TIMEZONE}') AS DATE) AS "events_occurred_at_day"`,
+        );
+        expect(query).toContain(
+            `(("events".occurred_at) AT TIME ZONE '${LOS_ANGELES}') AS "events_occurred_at_raw"`,
+        );
+        expect(query).not.toContain(CONNECTION_TIMEZONE);
+    });
+
+    describe('Snowflake, compile-time converted to UTC', () => {
+        const JOHANNESBURG = 'Africa/Johannesburg';
+        // What the compiler emits for a declared wall clock on Snowflake: the
+        // column is already UTC, so the dimension carries sourceTimezone 'UTC'
+        // even though the connection has timestamp conversion disabled.
+        const convertedSql = `CONVERT_TIMEZONE('${JOHANNESBURG}', 'UTC', "events".occurred_at)`;
+        const snowflakeClient = {
+            ...warehouseClientMock,
+            getAdapterType: () => SupportedDbtAdapter.SNOWFLAKE,
+        };
+        const buildSnowflakeQuery = (
+            compiledMetricQuery: CompiledMetricQuery,
+        ) =>
+            buildQuery({
+                explore: buildWallClockExplore({
+                    adapter: SupportedDbtAdapter.SNOWFLAKE,
+                    sourceTimezone: 'UTC',
+                    baseCompiledSql: convertedSql,
+                    annotateIntervalChildren: true,
+                }),
+                compiledMetricQuery,
+                warehouseSqlBuilder: snowflakeClient,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: PROJECT_TIMEZONE,
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: JOHANNESBURG,
+                dataTimezone: JOHANNESBURG,
+            }).query;
+
+        test('truncated SELECT converts from UTC only', () => {
+            const query = buildSnowflakeQuery(
+                wallClockQuery(['events_occurred_at_day']),
+            );
+            expect(query).toContain(
+                `CONVERT_TIMEZONE('UTC', '${PROJECT_TIMEZONE}', ${convertedSql})`,
+            );
+            expect(query).not.toContain(
+                `CONVERT_TIMEZONE('${JOHANNESBURG}', '${PROJECT_TIMEZONE}'`,
+            );
+        });
+
+        test('MIN/MAX over the converted column takes the UTC path', () => {
+            const query = buildSnowflakeQuery({
+                ...maxWallClockQuery,
+                compiledAdditionalMetrics:
+                    maxWallClockQuery.compiledAdditionalMetrics?.map(
+                        (metric) => ({
+                            ...metric,
+                            compiledSql: `MAX(${convertedSql})`,
+                        }),
+                    ),
+            });
+            expect(query).toContain(`MAX(${convertedSql}) AS "events_max_ts"`);
+            expect(query).not.toContain(
+                `CONVERT_TIMEZONE('${JOHANNESBURG}', 'UTC', MAX(`,
+            );
+        });
+
+        test('MIN/MAX over the raw column rebases from the declared zone, not the connection', () => {
+            const { query } = buildQuery({
+                explore: buildWallClockExplore({
+                    adapter: SupportedDbtAdapter.SNOWFLAKE,
+                    sourceTimezone: 'UTC',
+                    wallClockTimezone: JOHANNESBURG,
+                    baseCompiledSql: convertedSql,
+                    annotateIntervalChildren: true,
+                }),
+                compiledMetricQuery: maxWallClockQuery,
+                warehouseSqlBuilder: snowflakeClient,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: PROJECT_TIMEZONE,
+                useTimezoneAwareDateTrunc: true,
+                columnTimezone: CONNECTION_TIMEZONE,
+                dataTimezone: CONNECTION_TIMEZONE,
+            });
+            expect(query).toContain(
+                `MAX(CONVERT_TIMEZONE('${JOHANNESBURG}', 'UTC', "events".occurred_at)) AS "events_max_ts"`,
+            );
+            expect(query).not.toContain(CONNECTION_TIMEZONE);
+        });
+    });
+});
+
 describe('Metric filters: absolute timestamp predicates re-render at query time (GLITCH-627)', () => {
     const BAKED_PREDICATE = `("events".occurred_at) = ('2024-01-14 17:00:00+00:00')`;
     const FRESH_PREDICATE = `("events".occurred_at) = ('2024-01-15 02:00:00'::timestamp)`;

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -792,6 +792,31 @@ export class MetricQueryBuilder {
     }
 
     /**
+     * Zone the dimension's compiled naive values are in: its own declared wall
+     * clock, then its interval base's (resolved like `skipTimezoneConversion`
+     * and `timestampDomain`), then the connection default.
+     */
+    private resolveSourceTimezone(
+        dimension: CompiledDimension | undefined,
+    ): string {
+        if (!dimension) {
+            return this.columnTimezone;
+        }
+        const baseDimensionId = dimension.timeIntervalBaseDimensionName
+            ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
+            : undefined;
+        const baseDimension = baseDimensionId
+            ? (this.originalExploreDimensions[baseDimensionId] ??
+              this.exploreDimensions[baseDimensionId])
+            : undefined;
+        return (
+            dimension.sourceTimezone ??
+            baseDimension?.sourceTimezone ??
+            this.columnTimezone
+        );
+    }
+
+    /**
      * Rewrites `compiledSql` with the project-TZ wrap for truncatable and
      * extractable intervals.
      *
@@ -843,13 +868,14 @@ export class MetricQueryBuilder {
         // base dimension (mirrors skipTimezoneConversion resolution).
         const timestampDomain =
             dimension.timestampDomain ?? baseDimension.timestampDomain;
+        const sourceTimezone = this.resolveSourceTimezone(dimension);
 
         // RAW passes the base column through untouched, so a naive column is
         // misparsed as UTC downstream — rebase it to a true instant via the
         // session timezone (identity in value for aware columns), or via the
         // explicit data-timezone rebase when the column is known-naive.
         if (isRaw) {
-            if (this.columnTimezone === 'UTC') {
+            if (sourceTimezone === 'UTC') {
                 return { sql: dimension.compiledSql, lhsMode: 'legacy' };
             }
             // Filter LHS keeps the bare column — the literal side carries the
@@ -863,7 +889,7 @@ export class MetricQueryBuilder {
                 return {
                     sql: castNaiveToInstant(
                         baseDimension.compiledSql,
-                        this.columnTimezone,
+                        sourceTimezone,
                     ),
                     lhsMode: 'instant',
                 };
@@ -892,7 +918,7 @@ export class MetricQueryBuilder {
                     baseDimension.type,
                     startOfWeek,
                     timezone,
-                    this.columnTimezone,
+                    sourceTimezone,
                     timestampDomain,
                     // GLITCH-452: reached only when useTimezoneAwareDateTrunc is on,
                     // so day-or-coarser grains emit a real DATE (matches metadata).
@@ -901,7 +927,7 @@ export class MetricQueryBuilder {
                 lhsMode: isTimezoneRoundTripNoOp(
                     adapterType,
                     timezone,
-                    this.columnTimezone,
+                    sourceTimezone,
                     timestampDomain,
                 )
                     ? 'legacy'
@@ -917,7 +943,7 @@ export class MetricQueryBuilder {
                 baseDimension.type,
                 startOfWeek,
                 timezone,
-                this.columnTimezone,
+                sourceTimezone,
                 timestampDomain,
             ),
             lhsMode: 'legacy',
@@ -997,7 +1023,7 @@ export class MetricQueryBuilder {
             timestampFilterContext: resolveTimestampFilterContext({
                 adapterType,
                 useTimezoneAwareDateTrunc: this.args.useTimezoneAwareDateTrunc,
-                sourceTimezone: this.columnTimezone,
+                sourceTimezone: this.resolveSourceTimezone(dimension),
                 timestampDomain: this.resolveFilterTimestampDomain(dimension),
                 timeInterval: dimension.timeInterval,
                 lhsMode,
@@ -1192,13 +1218,15 @@ export class MetricQueryBuilder {
                 baseSql,
             );
             // The operand form decides which timezone the aggregate reads: the
-            // dimension's compiled SQL is in columnTimezone, a raw column in
-            // dataTimezone. When the compiler wrapped the dimension, a metric
-            // that inherited its SQL already aggregates the UTC expression.
+            // dimension's compiled SQL is in its own source timezone, a raw
+            // column in its declared wall clock zone, else dataTimezone. When
+            // the compiler wrapped the dimension, a metric that inherited its
+            // SQL already aggregates the UTC expression.
+            const dimensionTimezone = this.resolveSourceTimezone(baseDimension);
             const operandTimezone =
                 operand !== undefined && operand === baseDimension?.compiledSql
-                    ? this.columnTimezone
-                    : this.dataTimezone;
+                    ? dimensionTimezone
+                    : (baseDimension?.wallClockTimezone ?? this.dataTimezone);
             const explicitNaive =
                 baseDimension?.timestampDomain === 'naive' &&
                 castNaiveAggregateToInstant !== null &&
@@ -1206,11 +1234,11 @@ export class MetricQueryBuilder {
             const explicitAware =
                 baseDimension?.timestampDomain === 'aware' &&
                 castAwareToInstant !== null &&
-                this.columnTimezone !== 'UTC';
+                dimensionTimezone !== 'UTC';
             if (
                 !explicitNaive &&
                 !explicitAware &&
-                this.columnTimezone === 'UTC'
+                dimensionTimezone === 'UTC'
             ) {
                 return baseSql;
             }

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -147,7 +147,8 @@ export const getDimensionFromId = ({
                         baseField.type,
                         startOfWeek,
                         effectiveTimezone,
-                        columnTimezone,
+                        // A declared wall clock wins over the connection default.
+                        baseField.sourceTimezone ?? columnTimezone,
                         baseField.timestampDomain,
                     ),
                     timeInterval: newTimeFrame,


### PR DESCRIPTION
Relates: GLITCH-463

### Description

Second PR of the `wall_clock_timezone` stack. The query builder read the source zone of naive timestamp columns from the connection (`columnTimezone`), one value per query. A dimension compiled with `sourceTimezone` now wins over that default, resolved like `skipTimezoneConversion`: the dimension's own value, then its interval base's, then the connection default.

Sites converted:

- truncation and extract wraps (`getSqlForTruncatedDate`, `timeFrameConfigs[...].getSql`, `isTimezoneRoundTripNoOp`)
- the RAW-frame instant cast
- filter literal rendering (`resolveTimestampFilterContext`), so the `naiveWall` literal is rendered in the dimension's zone and the column stays bare on the LHS (partition pruning preserved)
- the MIN/MAX rebase, including the raw-column operand on Snowflake which reads the declared `wallClockTimezone`
- `getDimensionFromId`, which covers the period-over-period and totals paths

Unannotated dimensions produce byte-identical SQL; the existing snapshot tests are the guard and none changed.

test-timezone

### Tests

- `pnpm -F backend test src/utils/QueryBuilder/MetricQueryBuilder.test.ts`: new `Per-dimension declared wall clock timezone` block. Each test uses a connection zone different from the dimension's zone so it cannot pass by accident; with the source files restored to `main` all of them fail.
- `pnpm -F backend test src/utils/QueryBuilder` (whole directory, includes snapshots), `pnpm -F backend lint`, `pnpm -F backend typecheck`.
