### PR TITLE
test(api-tests): cover a per-column wall clock timezone end to end

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/timezone_test.yml
@@ -109,6 +109,21 @@ models:
             count_ntz:
               type: count
               description: Total number of events (NTZ)
+          additional_dimensions:
+            event_timestamp_ntz_tokyo:
+              type: timestamp
+              label: Event timestamp NTZ (Tokyo wall clock)
+              sql: ${TABLE}.event_timestamp_ntz
+              wall_clock_timezone: Asia/Tokyo
+              time_intervals: [RAW, HOUR, DAY]
+              description: >
+                Same naive column as event_timestamp_ntz, but this dimension
+                declares its stored wall clock as Asia/Tokyo via
+                wall_clock_timezone, so it reads as Tokyo regardless of the
+                connection data timezone.
+
+                Interior-rows DAY counts for queryTimezone Asia/Tokyo
+                (Postgres): Jan 15 = 6, Jan 16 = 4.
       - name: category
         description: >
           Event classification. "early_utc" (rows 1-4, 7-8) shifts to previous

--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -408,6 +408,82 @@ describe('Data timezone — raw time frame on naive timestamps (Postgres)', () =
     });
 });
 
+/**
+ * Per-column wall clock timezone annotation. The additional
+ * dimension `event_timestamp_ntz_tokyo` reuses the same naive column as
+ * `event_timestamp_ntz`, but its `wall_clock_timezone: Asia/Tokyo` annotation
+ * declares the stored wall clock is Tokyo. It must read as Tokyo whether or
+ * not the connection's dataTimezone is set, unlike the plain column, which
+ * follows dataTimezone (or UTC when unset).
+ */
+const TOKYO_DIMENSION_KEY = 'timezone_test_event_timestamp_ntz_tokyo_day';
+const TOKYO_RAW_KEY = 'timezone_test_event_timestamp_ntz_tokyo_raw';
+
+describe('Data timezone — per-column wall clock (Postgres)', () => {
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        await updateDataTimezone(admin, undefined);
+    });
+
+    it('dataTz unset, queryTz=Asia/Tokyo: annotated dimension reads the stored wall clock as Tokyo', async () => {
+        await updateDataTimezone(admin, undefined);
+        const rows = await runTimezoneTestQuery(admin, {
+            dimensions: [TOKYO_DIMENSION_KEY],
+            metrics: [NTZ_METRIC_KEY],
+            timezone: 'Asia/Tokyo',
+        });
+        expect(
+            getRawBucketMap(rows, TOKYO_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-15': 6, '2024-01-16': 4 });
+    });
+
+    it('dataTz unset, queryTz=Asia/Tokyo: plain column is unaffected (control)', async () => {
+        await updateDataTimezone(admin, undefined);
+        const rows = await runNaiveDayQuery(admin, { timezone: 'Asia/Tokyo' });
+        expect(
+            getRawBucketMap(rows, NTZ_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-15': 5, '2024-01-16': 4, '2024-01-17': 1 });
+    });
+
+    it('dataTz=Pacific/Pago_Pago, queryTz=Asia/Tokyo: annotation overrides the connection data timezone', async () => {
+        await updateDataTimezone(admin, 'Pacific/Pago_Pago');
+        const rows = await runTimezoneTestQuery(admin, {
+            dimensions: [TOKYO_DIMENSION_KEY],
+            metrics: [NTZ_METRIC_KEY],
+            timezone: 'Asia/Tokyo',
+        });
+        expect(
+            getRawBucketMap(rows, TOKYO_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-15': 6, '2024-01-16': 4 });
+    });
+
+    it('dataTz unset, queryTz=Pacific/Pago_Pago: annotated dimension still reads as Tokyo', async () => {
+        await updateDataTimezone(admin, undefined);
+        const rows = await runTimezoneTestQuery(admin, {
+            dimensions: [TOKYO_DIMENSION_KEY],
+            metrics: [NTZ_METRIC_KEY],
+            timezone: 'Pacific/Pago_Pago',
+        });
+        expect(
+            getRawBucketMap(rows, TOKYO_DIMENSION_KEY, NTZ_METRIC_KEY),
+        ).toEqual({ '2024-01-14': 6, '2024-01-15': 4 });
+    });
+
+    it('raw frame, dataTz unset: event #1 reads the stored wall clock as Tokyo', async () => {
+        await updateDataTimezone(admin, undefined);
+        const [row] = await runTimezoneTestQuery(admin, {
+            dimensions: [TOKYO_RAW_KEY],
+            metrics: [],
+            eventIds: [1],
+            timezone: 'Asia/Tokyo',
+        });
+        expect(toInstant(row, TOKYO_RAW_KEY)).toBe('2024-01-14T17:00:00.000Z');
+    });
+});
+
 describe.skipIf(!hasBigqueryCredentials())(
     'Data timezone — naive timestamps (BigQuery)',
     () => {


### PR DESCRIPTION
Closes: GLITCH-463

### Description

Last PR of the `wall_clock_timezone` stack. Adds an additional dimension to the demo `timezone_test` model that reuses the naive `event_timestamp_ntz` column but declares its wall clock as `Asia/Tokyo`, and Postgres API tests showing:

| data timezone | query timezone | annotated dimension | plain column |
|---|---|---|---|
| unset | Asia/Tokyo | Jan 15 = 6, Jan 16 = 4 | Jan 15 = 5, Jan 16 = 4, Jan 17 = 1 |
| Pacific/Pago_Pago | Asia/Tokyo | Jan 15 = 6, Jan 16 = 4 | |
| unset | Pacific/Pago_Pago | Jan 14 = 6, Jan 15 = 4 | |

The annotated results equal what the plain column already produces in the existing tests when the connection data timezone is Asia/Tokyo, which is the point: the declaration replaces the connection default for that column only. A raw-frame test pins event #1 to the instant `2024-01-14T17:00:00.000Z`.

test-timezone

### Tests

Runs in CI (Backend API Tests). Locally: `pnpm -F api-tests typecheck`, `pnpm -F api-tests lint`.
