### PR TITLE
feat: link to saved chart page from in-dashboard chart editor

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -3,8 +3,19 @@ import {
     type DashboardCustomMetricAffectedChart,
     type SavedChart,
 } from '@lightdash/common';
-import { Anchor, Button, Group, Text } from '@mantine/core';
-import { IconAlertTriangle, IconChartBar } from '@tabler/icons-react';
+import {
+    ActionIcon,
+    Anchor,
+    Button,
+    Group,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconAlertTriangle,
+    IconChartBar,
+    IconExternalLink,
+} from '@tabler/icons-react';
 import {
     useCallback,
     useLayoutEffect,
@@ -28,6 +39,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
 import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
+import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import Page from '../common/Page/Page';
 import TruncatedText from '../common/TruncatedText';
@@ -315,9 +327,29 @@ const DashboardChartEditorModal: FC<Props> = ({
                         </>
                     )}
                     {editChart ? (
-                        <TruncatedText fw={600} fz="md" maxWidth="100%" miw={0}>
-                            {`Edit ${editChart.name}`}
-                        </TruncatedText>
+                        <>
+                            <TruncatedText
+                                fw={600}
+                                fz="md"
+                                maxWidth="100%"
+                                miw={0}
+                            >
+                                {`Edit ${editChart.name}`}
+                            </TruncatedText>
+                            {dashboard && (
+                                <Tooltip label="Open saved chart in new tab">
+                                    <ActionIcon
+                                        component="a"
+                                        href={`/projects/${editChart.projectUuid}/saved/${editChart.uuid}`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        aria-label="Open saved chart in new tab"
+                                    >
+                                        <MantineIcon icon={IconExternalLink} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                        </>
                     ) : (
                         <Text fw={600}>New chart</Text>
                     )}


### PR DESCRIPTION
## Summary

The in-dashboard chart editor modal doesn't expose chart-page actions (version history, name/description editing). Rather than porting each action into the modal (stacking modals on a modal), this adds an "Open saved chart in new tab" link in the editor header, next to the chart title.

- External-link icon with tooltip/aria-label "Open saved chart in new tab", opening `/projects/{projectUuid}/saved/{chartUuid}` in a new tab.
- Opening a new tab preserves the dashboard edit session and the editor's unsaved state — no discard prompt needed.
- Rendered only when editing an existing saved chart from a dashboard; the new-chart flow, AI-thread-hosted editor, and embed editor are unaffected.

Note: the link opens the *saved* chart, so edits made in the modal aren't visible there until saved (hence "saved chart" in the tooltip).

Closes: #29026
Closes: #29027