### PR TITLE
fix: expose Sentry CLI in release Docker build

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -328,6 +328,7 @@ ARG SENTRY_ENVIRONMENT=""
 
 RUN if [ -n "${SENTRY_AUTH_TOKEN}" ] && [ -n "${SENTRY_ORG}" ] && [ -n "${SENTRY_RELEASE_VERSION}" ] && [ -n "${SENTRY_FRONTEND_PROJECT}" ] && [ -n "${SENTRY_BACKEND_PROJECT}" ] && [ -n "${SENTRY_ENVIRONMENT}" ]; then \
     npm install -g @sentry/cli; \
+    export PATH="$(npm prefix -g)/bin:${PATH}"; \
     echo "Creating Sentry releases and processing sourcemaps"; \
     # Create releases for both projects \
     sentry-cli releases new "${SENTRY_RELEASE_VERSION}" --project "${SENTRY_FRONTEND_PROJECT}"; \


### PR DESCRIPTION
## Problem

After pnpm-managed Node was added through `devEngines.runtime`, `npm install -g @sentry/cli` installs the binary under that runtime prefix. The Docker build only had the workspace and system bin directories on `PATH`, so every subsequent `sentry-cli` command failed with exit code 127.

The Sentry install lifecycle script is not new and is already reviewed in `allowBuilds`; the npm install-script warning also appeared in the last successful release image build. It is not the cause of this failure.

## Fix

Add npm’s active global bin directory to `PATH` before invoking Sentry CLI. The change is scoped to the conditional Sentry release layer.

## Validation

- Reproduced in the production-like linux/amd64 pnpm 12.3.4 image with the workspace installed: `npm prefix -g` points inside `node_modules/.pnpm`, followed by `sentry-cli: not found` (exit 127)
- Re-ran the same install with the patched `PATH`; `command -v sentry-cli` resolves the managed-runtime binary and `sentry-cli --version` reports 3.7.0
- `git diff --check`

## Risk

Low. No dependency or lifecycle-script policy changes; only command lookup during the Sentry release layer changes.

Relates: PROD-11185