### PR TITLE
feat(audit): record direct access grant provenance

### DIFF
--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -91,6 +91,220 @@ describe('CaslAuditWrapper', () => {
         vi.clearAllMocks();
     });
 
+    describe('direct grant provenance', () => {
+        const grant = {
+            userUuid: mockUser.userUuid,
+            role: 'editor',
+            grantedVia: 'dashboard',
+            grantSourceUuid: 'grant-dashboard',
+        };
+        const provenance = [
+            {
+                grantedVia: 'dashboard',
+                grantSourceUuid: 'grant-dashboard',
+            },
+        ];
+        const createGrantWrapper = (auditEnabled = true) => {
+            const logger = createMockLogger();
+            const ability = defineAbility((can, cannot) => {
+                can(['view', 'update'], 'Dashboard', {
+                    access: {
+                        $elemMatch: {
+                            userUuid: mockUser.userUuid,
+                            role: 'editor',
+                        },
+                    },
+                });
+                can('view', 'Dashboard', {
+                    access: {
+                        $elemMatch: {
+                            userUuid: mockUser.userUuid,
+                            role: 'viewer',
+                        },
+                    },
+                });
+                can(['view', 'update'], 'Dashboard', { isAdmin: true });
+                cannot('update', 'Dashboard', { locked: true });
+            });
+            return {
+                logger,
+                wrapper: new CaslAuditWrapper(ability, mockUser, {
+                    auditLogger: logger,
+                    auditEnabled,
+                }),
+            };
+        };
+
+        it.each(['view', 'update'])(
+            'records the source of a grant-dependent %s',
+            (action) => {
+                const { logger, wrapper } = createGrantWrapper();
+                expect(
+                    wrapper.can(
+                        action,
+                        createDashboard('content', { access: [grant] }),
+                    ),
+                ).toBe(true);
+                expect(logger.mock.calls[0][0].resource.metadata).toEqual({
+                    dashboardUuid: 'content',
+                    directGrants: provenance,
+                });
+            },
+        );
+
+        it('records an editor grant when inherited access only permits viewing', () => {
+            const { logger, wrapper } = createGrantWrapper();
+            const dashboard = createDashboard('content', {
+                access: [
+                    { userUuid: mockUser.userUuid, role: 'viewer' },
+                    grant,
+                ],
+            });
+            expect(wrapper.can('view', dashboard)).toBe(true);
+            expect(logger.mock.calls[0][0].resource.metadata).toEqual({
+                dashboardUuid: 'content',
+            });
+            expect(wrapper.cannot('update', dashboard)).toBe(false);
+            expect(logger.mock.calls[1][0].resource.metadata).toEqual({
+                dashboardUuid: 'content',
+                directGrants: provenance,
+            });
+        });
+
+        it.each([
+            {
+                name: 'administrator',
+                attributes: { isAdmin: true, access: [grant] },
+                allowed: true,
+            },
+            {
+                name: 'inherited editor',
+                attributes: {
+                    access: [
+                        { userUuid: mockUser.userUuid, role: 'editor' },
+                        grant,
+                    ],
+                },
+                allowed: true,
+            },
+            {
+                name: 'denied action',
+                attributes: { locked: true, access: [grant] },
+                allowed: false,
+            },
+            {
+                name: 'another user',
+                attributes: { access: [{ ...grant, userUuid: 'other-user' }] },
+                allowed: false,
+            },
+            {
+                name: 'insufficient role',
+                attributes: { access: [{ ...grant, role: 'viewer' }] },
+                allowed: false,
+            },
+            {
+                name: 'legacy grant without source',
+                attributes: {
+                    access: [{ ...grant, grantSourceUuid: undefined }],
+                },
+                allowed: true,
+            },
+        ])(
+            'does not attribute $name to a direct grant',
+            ({ attributes, allowed }) => {
+                const { logger, wrapper } = createGrantWrapper();
+                expect(
+                    wrapper.can(
+                        'update',
+                        createDashboard('content', attributes),
+                    ),
+                ).toBe(allowed);
+                expect(logger.mock.calls[0][0].resource.metadata).toEqual({
+                    dashboardUuid: 'content',
+                });
+            },
+        );
+
+        it('deduplicates user and group grants and excludes insufficient grants', () => {
+            const { logger, wrapper } = createGrantWrapper();
+            expect(
+                wrapper.can(
+                    'update',
+                    createDashboard('content', {
+                        access: [
+                            grant,
+                            { ...grant },
+                            {
+                                ...grant,
+                                role: 'viewer',
+                                grantSourceUuid: 'unrelated',
+                            },
+                            {
+                                ...grant,
+                                userUuid: 'other-user',
+                                grantSourceUuid: 'other-user-grant',
+                            },
+                        ],
+                    }),
+                ),
+            ).toBe(true);
+            expect(logger.mock.calls[0][0].resource.metadata).toEqual({
+                dashboardUuid: 'content',
+                directGrants: provenance,
+            });
+        });
+
+        it('keeps grant provenance on each resource in a bulk event', () => {
+            const { logger, wrapper } = createGrantWrapper();
+            expect(
+                wrapper.canBulk('update', [
+                    createDashboard('one', { access: [grant] }),
+                    createDashboard('two', {
+                        access: [
+                            { ...grant, grantSourceUuid: 'second-dashboard' },
+                        ],
+                    }),
+                    createDashboard('three', {
+                        access: [
+                            { userUuid: mockUser.userUuid, role: 'editor' },
+                        ],
+                    }),
+                ]),
+            ).toEqual([true, true, true]);
+            expect(logger.mock.calls[0][0].resource.metadata).toEqual({
+                resources: [
+                    { dashboardUuid: 'one', directGrants: provenance },
+                    {
+                        dashboardUuid: 'two',
+                        directGrants: [
+                            {
+                                grantedVia: 'dashboard',
+                                grantSourceUuid: 'second-dashboard',
+                            },
+                        ],
+                    },
+                    { dashboardUuid: 'three' },
+                ],
+            });
+        });
+
+        it('preserves decisions with auditing disabled', () => {
+            const { logger, wrapper } = createGrantWrapper(false);
+            expect(
+                wrapper.can(
+                    'update',
+                    createDashboard('content', { access: [grant] }),
+                ),
+            ).toBe(true);
+            expect(
+                wrapper.canBulk('update', [
+                    createDashboard('content', { access: [grant] }),
+                ]),
+            ).toEqual([true]);
+            expect(logger).not.toHaveBeenCalled();
+        });
+    });
+
     describe('can method', () => {
         it('should return the same result as the original ability', () => {
             const mockLogger = createMockLogger();

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -9,6 +9,7 @@ import {
     type ServiceAcctAccount,
     type SessionUser,
 } from '@lightdash/common';
+import { z } from 'zod';
 import {
     createAuditLogEvent,
     type AuditActor,
@@ -38,10 +39,16 @@ export type AuditableUser = Pick<
     | 'serviceAccount'
 >;
 
+const GrantProvenanceSchema = z.object({
+    grantedVia: z.string(),
+    grantSourceUuid: z.string(),
+});
+
 type AuditableCaslSubjectObject = ForcedSubject<CaslSubjectNames> & {
     organizationUuid: string;
     projectUuid?: string;
     metadata?: Record<string, unknown>;
+    access?: unknown[];
 };
 
 type AuditableCaslSubject = AuditableCaslSubjectObject | CaslSubjectNames;
@@ -54,6 +61,7 @@ type AuditHelperArgs = {
     actor: AuditActor;
     action: string;
     subject: AuditableCaslSubject;
+    resource?: AuditResource;
     ip?: string;
     userAgent?: string;
     requestId?: string;
@@ -278,7 +286,8 @@ export class CaslAuditWrapper<T extends Ability> {
         if (!this.auditEnabled) return;
 
         try {
-            const resource = createResourceFromSubject(args.subject);
+            const resource =
+                args.resource ?? createResourceFromSubject(args.subject);
             const context = createContextFromArgs(args);
 
             const event = createAuditLogEvent(
@@ -310,6 +319,60 @@ export class CaslAuditWrapper<T extends Ability> {
         return { allowed: Boolean(rule && !rule.inverted), rule };
     }
 
+    private createAuditedResource(
+        action: string,
+        subject: AuditableCaslSubject,
+        allowed: boolean,
+    ): AuditResource {
+        const resource = createResourceFromSubject(subject);
+        if (!allowed || typeof subject === 'string' || !subject.access) {
+            return resource;
+        }
+        const grants = subject.access.flatMap((row) => {
+            const provenance = GrantProvenanceSchema.safeParse(row);
+            return provenance.success
+                ? [{ row, provenance: provenance.data }]
+                : [];
+        });
+        if (grants.length === 0) {
+            return resource;
+        }
+        const baseline = {
+            ...subject,
+            __caslSubjectType__: subject.__caslSubjectType__,
+            access: subject.access.filter(
+                (row) => !grants.some((grant) => grant.row === row),
+            ),
+        };
+        if (this.evaluate(action, baseline).allowed) {
+            return resource;
+        }
+        const directGrants = grants
+            .flatMap(({ row, provenance }) =>
+                this.evaluate(action, {
+                    ...baseline,
+                    access: [...baseline.access, row],
+                }).allowed
+                    ? [provenance]
+                    : [],
+            )
+            .filter(
+                (grant, index, all) =>
+                    all.findIndex(
+                        (other) =>
+                            other.grantedVia === grant.grantedVia &&
+                            other.grantSourceUuid === grant.grantSourceUuid,
+                    ) === index,
+            );
+        if (directGrants.length === 0) {
+            return resource;
+        }
+        return {
+            ...resource,
+            metadata: { ...resource.metadata, directGrants },
+        };
+    }
+
     can(action: string, subject: AuditableCaslSubject): boolean {
         const { allowed, rule } = this.evaluate(action, subject);
         if (!this.auditEnabled) return allowed;
@@ -319,6 +382,7 @@ export class CaslAuditWrapper<T extends Ability> {
                 actor: this.actor,
                 action,
                 subject,
+                resource: this.createAuditedResource(action, subject, allowed),
                 ip: this.ip,
                 userAgent: this.userAgent,
                 requestId: this.requestId,
@@ -344,7 +408,11 @@ export class CaslAuditWrapper<T extends Ability> {
             const { allowed, rule } = this.evaluate(action, subject);
 
             if (this.auditEnabled) {
-                const resource = createResourceFromSubject(subject);
+                const resource = this.createAuditedResource(
+                    action,
+                    subject,
+                    allowed,
+                );
                 const scopeKey = `${resource.type}\0${resource.organizationUuid}`;
                 const ruleGroups = groups.get(rule);
                 const group = ruleGroups?.get(scopeKey);

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -1989,6 +1989,7 @@ describe('resolveAccess', () => {
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
                     grantedVia: 'dashboard',
+                    grantSourceUuid: 'dashboard-uuid',
                 },
                 {
                     userUuid: 'user-uuid',
@@ -1998,6 +1999,7 @@ describe('resolveAccess', () => {
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
                     grantedVia: 'dashboard',
+                    grantSourceUuid: 'dashboard-uuid',
                 },
             ],
             directOnly: true,
@@ -2133,11 +2135,13 @@ describe('resolveAccess', () => {
                     userUuid: 'user-uuid',
                     role: SpaceMemberRole.VIEWER,
                     grantedVia: 'app',
+                    grantSourceUuid: 'app-uuid',
                 },
                 {
                     userUuid: 'user-uuid',
                     role: SpaceMemberRole.EDITOR,
                     grantedVia: 'app',
+                    grantSourceUuid: 'app-uuid',
                 },
             ],
         });
@@ -2714,6 +2718,7 @@ describe('resolveAccess space-saved chart target', () => {
                 userUuid: 'user-uuid',
                 role: SpaceMemberRole.EDITOR,
                 grantedVia: 'saved_chart',
+                grantSourceUuid: 'chart-uuid',
             }),
         ]);
         expect(result.directOnly).toBe(true);
@@ -2815,6 +2820,7 @@ describe('resolveAccess saved SQL chart target', () => {
                 userUuid: 'user-uuid',
                 role: SpaceMemberRole.VIEWER,
                 grantedVia: 'sql_chart',
+                grantSourceUuid: 'saved-sql-uuid',
             }),
         ]);
         expect(result.directOnly).toBe(true);
@@ -2918,7 +2924,10 @@ describe('resolveAccess chart ownership routing', () => {
         });
 
         expect(result.access).toEqual([
-            expect.objectContaining({ grantedVia: 'dashboard' }),
+            expect.objectContaining({
+                grantedVia: 'dashboard',
+                grantSourceUuid: 'dashboard-uuid',
+            }),
         ]);
         expect(dashboardAccessModel.getUserAccess).toHaveBeenCalledWith(
             ['dashboard-uuid'],

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -563,7 +563,7 @@ export class SpacePermissionService extends BaseService {
                     baselineContext,
                     userUuid,
                     grantRoles,
-                    grantTarget.source,
+                    grantTarget,
                 ),
             );
         });
@@ -573,7 +573,7 @@ export class SpacePermissionService extends BaseService {
         spaceContext: SpaceAccessContextForCasl,
         userUuid: string,
         grantRoles: SpaceMemberRole[],
-        grantedVia: GrantSource,
+        grantTarget: DirectGrantTarget,
     ): AccessContextForCasl {
         const hasSpacePath =
             spaceContext.access.some(
@@ -591,7 +591,8 @@ export class SpacePermissionService extends BaseService {
                     projectRole: undefined,
                     inheritedRole: undefined,
                     inheritedFrom: undefined,
-                    grantedVia,
+                    grantedVia: grantTarget.source,
+                    grantSourceUuid: grantTarget.resourceUuid,
                 })),
             ],
             directOnly: !hasSpacePath,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -176,6 +176,7 @@ export type SpaceAccess = {
     // Present only on rows synthesized from a direct content grant; absent on
     // space-derived rows. CASL rules never match on it.
     grantedVia?: GrantSource;
+    grantSourceUuid?: string;
 };
 
 // Full space share with user metadata, used for frontend display


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-1461

## Description

Audit logs now identify the resource whose direct grant authorizes a read or write, including dashboards, saved charts, SQL charts, and data apps. Grant source UUIDs flow through the existing permission resolver into `resource.metadata.directGrants`; bulk checks retain provenance per resource.

```text
Allowed with grants
  ├─ Still allowed without grants → ordinary audit event
  └─ Requires a grant             → granting resource type + UUID
```

Authorization decisions stay unchanged. Dashboard-owned charts identify their dashboard, duplicate user/group grants collapse to one source, and denied checks or independently authorized admin/space access receive no grant attribution.

## Test plan

- 105 tests pass across the audit wrapper and permission service; five new assertions fail before the implementation.
- Common build, backend typecheck, both package lints, and API/schema generation pass.
- Local API and JSON audit logs verify restricted-dashboard read/update with an Editor grant, denial before sharing and after revocation, and no false attribution for admin access. Temporary fixtures were cleaned up.
