### PR TITLE
fix(ai): validate Deep Research configuration limits

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -40,6 +40,65 @@ beforeEach(() => {
     };
 });
 
+describe('query history retention', () => {
+    it('warns when cleanup can expire charts before their Deep Research reports', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.QUERY_HISTORY_RETENTION_DAYS = '29';
+
+        try {
+            expect(
+                parseConfig().scheduler.queryHistory.cleanup.retentionDays,
+            ).toBe(29);
+            expect(warn).toHaveBeenCalledWith(
+                'WARNING: QUERY_HISTORY_RETENTION_DAYS is below the 30-day Deep Research report retention. Report charts may become unavailable before their reports expire.',
+            );
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it.each([undefined, '30', '32', '60'])(
+        'does not warn for a sufficient retention window: %s',
+        (retentionDays) => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            if (retentionDays !== undefined) {
+                process.env.QUERY_HISTORY_RETENTION_DAYS = retentionDays;
+            }
+
+            try {
+                expect(
+                    parseConfig().scheduler.queryHistory.cleanup.retentionDays,
+                ).toBe(
+                    retentionDays === undefined ? 32 : Number(retentionDays),
+                );
+                expect(warn).not.toHaveBeenCalledWith(
+                    expect.stringContaining('QUERY_HISTORY_RETENTION_DAYS'),
+                );
+            } finally {
+                warn.mockRestore();
+            }
+        },
+    );
+
+    it('does not warn when query history cleanup is disabled', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.QUERY_HISTORY_RETENTION_DAYS = '1';
+        process.env.QUERY_HISTORY_CLEANUP_ENABLED = 'false';
+
+        try {
+            expect(parseConfig().scheduler.queryHistory.cleanup).toMatchObject({
+                enabled: false,
+                retentionDays: 1,
+            });
+            expect(warn).not.toHaveBeenCalledWith(
+                expect.stringContaining('QUERY_HISTORY_RETENTION_DAYS'),
+            );
+        } finally {
+            warn.mockRestore();
+        }
+    });
+});
+
 describe('usage events storage endpoint', () => {
     it('inherits the base endpoint when no override is configured', () => {
         expect(parseUsageEventsS3Config()?.endpoint).toBe('mock_endpoint');

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1,5 +1,6 @@
 import {
     AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
+    AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS,
     AI_DEFAULT_MAX_QUERY_LIMIT,
     ALL_TASK_NAMES,
     AllowedEmailDomainsRole,
@@ -2950,6 +2951,20 @@ export const parseConfig = (): LightdashConfig => {
         );
     }
 
+    const queryHistoryCleanupEnabled =
+        process.env.QUERY_HISTORY_CLEANUP_ENABLED !== 'false';
+    const queryHistoryRetentionDays =
+        getIntegerFromEnvironmentVariable('QUERY_HISTORY_RETENTION_DAYS') ||
+        AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS;
+    if (
+        queryHistoryCleanupEnabled &&
+        queryHistoryRetentionDays < AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS
+    ) {
+        console.warn(
+            `WARNING: QUERY_HISTORY_RETENTION_DAYS is below the ${AI_DEEP_RESEARCH_REPORT_RETENTION_DAYS}-day Deep Research report retention. Report charts may become unavailable before their reports expire.`,
+        );
+    }
+
     return {
         mode,
         mobile: {
@@ -3467,12 +3482,8 @@ export const parseConfig = (): LightdashConfig => {
             },
             queryHistory: {
                 cleanup: {
-                    enabled:
-                        process.env.QUERY_HISTORY_CLEANUP_ENABLED !== 'false', // true by default
-                    retentionDays:
-                        getIntegerFromEnvironmentVariable(
-                            'QUERY_HISTORY_RETENTION_DAYS',
-                        ) || AI_DEEP_RESEARCH_QUERY_HISTORY_RETENTION_DAYS,
+                    enabled: queryHistoryCleanupEnabled,
+                    retentionDays: queryHistoryRetentionDays,
                     batchSize:
                         getIntegerFromEnvironmentVariable(
                             'QUERY_HISTORY_CLEANUP_BATCH_SIZE',

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.test.ts
@@ -40,6 +40,23 @@ describe('validateDeepResearchLimits', () => {
         ).not.toThrow();
     });
 
+    it('allows positive integer values in unrecognized fields', () => {
+        const limits = { ...AI_DEEP_RESEARCH_DEFAULT_LIMITS, extraLimit: 1 };
+
+        expect(() => validateDeepResearchLimits(limits)).not.toThrow();
+    });
+
+    it.each([0, -1, 1.5, 'invalid'])(
+        'rejects invalid values in unrecognized fields: %s',
+        (extraLimit) => {
+            const limits = { ...AI_DEEP_RESEARCH_DEFAULT_LIMITS, extraLimit };
+
+            expect(() => validateDeepResearchLimits(limits)).toThrow(
+                'extraLimit must be a positive integer',
+            );
+        },
+    );
+
     it.each([
         ['maxTokens', 0],
         ['maxToolCalls', -1],
@@ -411,6 +428,61 @@ describe('upsertSettings model validation', () => {
         ).rejects.toThrow('maxToolCalls must be a positive integer');
         expect(upsert).not.toHaveBeenCalled();
     });
+
+    it.each([
+        ['maxToolCalls', 1],
+        ['maxToolCalls', 2],
+        ['deadlineMs', 1],
+        ['deadlineMs', 999],
+        ['maxTokens', 10_000_001],
+        ['maxSteps', 1_001],
+        ['maxToolCalls', 1_001],
+        ['maxWarehouseQueries', 1_001],
+        ['deadlineMs', 3_600_001],
+    ] as const)(
+        'rejects out-of-range %s=%s before writing',
+        async (key, value) => {
+            const { service, upsert } = buildService();
+
+            await expect(
+                service.upsertSettings(user, {
+                    deepResearchLimits: {
+                        ...AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+                        [key]: value,
+                    },
+                }),
+            ).rejects.toThrow(ParameterError);
+            expect(upsert).not.toHaveBeenCalled();
+        },
+    );
+
+    it.each([
+        {
+            maxTokens: 1,
+            maxSteps: 1,
+            maxToolCalls: 3,
+            maxWarehouseQueries: 1,
+            deadlineMs: 1_000,
+        },
+        {
+            maxTokens: 10_000_000,
+            maxSteps: 1_000,
+            maxToolCalls: 1_000,
+            maxWarehouseQueries: 1_000,
+            deadlineMs: 3_600_000,
+        },
+    ])(
+        'persists inclusive limit boundaries: %j',
+        async (deepResearchLimits) => {
+            const { service, upsert } = buildService();
+
+            await service.upsertSettings(user, { deepResearchLimits });
+
+            expect(upsert).toHaveBeenCalledWith('org-uuid', {
+                deepResearchLimits,
+            });
+        },
+    );
 
     it('forwards valid Deep Research limits to the model', async () => {
         const { service, upsert } = buildService();

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     AI_DEEP_RESEARCH_DEFAULT_LIMITS,
+    AI_DEEP_RESEARCH_MAX_WORKERS,
     AiOrganizationRuntimeSettings,
     AiOrganizationSettings,
     BYO_AI_PROVIDERS,
@@ -109,6 +110,17 @@ export const findUnconfiguredProviderKeyWrites = (
             !configuredProviders[provider],
     );
 
+const DEEP_RESEARCH_LIMIT_BOUNDS: Record<
+    keyof AiDeepResearchLimits,
+    { min: number; max: number }
+> = {
+    maxTokens: { min: 1, max: 10_000_000 },
+    maxSteps: { min: 1, max: 1_000 },
+    maxToolCalls: { min: AI_DEEP_RESEARCH_MAX_WORKERS + 1, max: 1_000 },
+    maxWarehouseQueries: { min: 1, max: 1_000 },
+    deadlineMs: { min: 1_000, max: 3_600_000 },
+};
+
 export const validateDeepResearchLimits = (
     limits: AiDeepResearchLimits,
 ): void => {
@@ -117,6 +129,12 @@ export const validateDeepResearchLimits = (
     ).forEach(([key, value]) => {
         if (!Number.isInteger(value) || value <= 0) {
             throw new ParameterError(`${key} must be a positive integer`);
+        }
+        const bounds = DEEP_RESEARCH_LIMIT_BOUNDS[key];
+        if (bounds && (value < bounds.min || value > bounds.max)) {
+            throw new ParameterError(
+                `${key} must be between ${bounds.min} and ${bounds.max}`,
+            );
         }
     });
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-10098

## Summary

Reject Deep Research settings that would prevent runs from starting or exceed the agreed limits. Warn operators when query-history cleanup can remove chart data before the 30-day reports expire.

## Root cause

Settings writes checked only for positive integers, while run creation rejects tool-call budgets of two or fewer. Query-history retention overrides had no warning about the report lifetime.

## Fix

Validate settings before persistence with inclusive ranges:

- Tokens: 1–10,000,000 (the existing default remains valid).
- Steps and warehouse queries: 1–1,000.
- Tool calls: 3–1,000, with the minimum derived from the worker limit.
- Deadline: 1 second–60 minutes.

Preserve existing validation for extra fields. Warn when query-history cleanup is enabled and its effective retention is below 30 days; preserve the operator's setting and the 32-day default. Existing stored budgets are not rewritten.

```text
Before: save tool-call limit 2 → 200, persisted → create run → 400
After:  save tool-call limit 2 → 400 with allowed range → settings unchanged
```

## Test plan

- [x] Regression tests: 10 failed before the fix; both targeted suites now pass all 298 tests, including extra-field compatibility cases.
- [x] Local API after restart: 15 invalid writes rejected without persistence; minimums, maximums, defaults, and a valid extra field accepted. Original settings restored.
- [x] Configuration parser: warning below 30 days; no warning at/above 30 days or with cleanup disabled; configured values preserved.
- [x] Backend typecheck, lint, formatting, and diff whitespace checks.
- [x] Five-lens review and focused re-review after fixes.

### Risk assessment

- [ ] This is a high-risk change

Low risk: validation changes are limited to settings writes, and retention behavior is unchanged. Saving settings outside the new ranges now returns an actionable 400 response.
