### PR TITLE
docs: standardize feature flag implementation and rollout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,17 @@ pnpm -F backend migrate
 pnpm -F backend rollback-last
 ```
 
+## Feature flags
+
+Before adding or changing a feature flag, read [docs/feature-flags.md](docs/feature-flags.md).
+Use `FeatureFlagModel.get` / `FeatureFlagService.get` in backend services and
+`useServerFeatureFlag` in the frontend. Do not create an ENV-only or `NODE_ENV`
+rollout gate: the shared resolver supports Console database overrides and
+self-hosted ENV configuration. Keep resource authorization separate.
+Verify Console-only enablement with ENV enable unset and preview defaults off,
+including the backend action, not just UI visibility. Document scope, precedence,
+refresh/restart behavior, and remove temporary ENV overrides after rollout.
+
 ## Development Workflow
 
 1. **Package Management**: Use `pnpm` (pinned via `packageManager` in the root `package.json`, which pnpm reads directly). Install pnpm directly; do not use Corepack, npm, or yarn for workspace commands.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,184 @@
+# Adding and operating feature flags
+
+Internal implementation and rollout guide for engineers and reviewers. Use one
+resolver for Console-managed Cloud rollouts and self-hosted ENV configuration.
+Flag enablement does not replace authorization or supply infrastructure/credentials.
+
+## Required implementation pattern
+
+1. Register a stable ID in `FeatureFlags` or `CommercialFeatureFlags` in
+   [featureFlags.ts](../packages/common/src/types/featureFlags.ts). Describe its
+   purpose and decide whether rollout is per user, organization, or deployment.
+2. In backend services, call the injected `FeatureFlagModel.get` or
+   `FeatureFlagService.get`. Do not implement a rollout gate by reading
+   `process.env`, `enabledFeatureFlags.has(...)`, or `NODE_ENV` directly.
+3. In the frontend, use `useServerFeatureFlag`, which reads the resolved backend
+   value. Do not independently resolve ENV or read PostHog flags for this feature.
+4. Gate every backend entry point that needs the feature: direct API calls,
+   background work, provisioning, queries, and access to existing cached results
+   where applicable. Hiding UI is not backend enforcement.
+5. Preserve normal permissions and tenant isolation. A flag grants availability,
+   not organization-admin privileges or access to another organization's data.
+6. Review preview defaults and infrastructure prerequisites; see
+   [preview feature flags](preview-feature-flags.md). Preview success alone does
+   not prove Console-only production enablement works.
+
+Backend example inside an authenticated service (after validating the target
+organization and the caller's normal permissions):
+
+```ts
+const { enabled } = await this.featureFlagModel.get({
+  user,
+  featureFlagId: FeatureFlags.MyFeature,
+});
+if (!enabled) {
+  throw new ForbiddenError('This feature is not enabled');
+}
+```
+
+Frontend example (replace the illustrative ID with the registered flag):
+
+```tsx
+const flag = useServerFeatureFlag(FeatureFlags.MyFeature);
+const enabled = flag.data?.enabled === true;
+```
+
+Use the same rollout scope across entry points. For a user-scoped flag, pass the
+actual authenticated user and organization. For an organization-scoped background
+or warehouse operation, resolve the resource's organization through the shared
+resolver; do not fabricate a user UUID or silently fall back to an instance-wide
+check because an actor is unavailable. Document whether personal overrides are
+supported. Never accept the target organization from an unvalidated request body.
+
+Do not add a per-feature ENV variable or special handler just to support
+self-hosting: the generic ENV lists already provide that. Operational configuration
+(storage endpoints, credentials, provider availability) can remain ENV-backed,
+but its validation is separate from the rollout decision. A custom resolver
+handler is an exception that needs an explicit reason, documentation of whether
+Console overrides apply, and matching UI/backend tests.
+
+## Resolution and precedence
+
+The source of truth is
+[FeatureFlagModel.resolve](../packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts),
+not the caller. For ordinary production resolution:
+
+1. `LIGHTDASH_ENABLE_FEATURE_FLAGS` forces the flag on.
+2. Otherwise, `LIGHTDASH_DISABLE_FEATURE_FLAGS` forces it off.
+3. Otherwise, a registered per-flag handler decides, if present. Some handlers
+   consult the database; others short-circuit it. Inspect the specific handler.
+4. Otherwise, the database resolves user override → organization override →
+   instance default; an absent value resolves off.
+
+**Enable wins if both ENV lists contain the same ID.** Do not rely on ambiguous
+configuration. To force a flag off, remove it from the enable list and put it in
+the disable list. A Console override cannot defeat an ENV force-on in production.
+Legacy per-flag ENV settings mapped by `LEGACY_ENABLE_ENV_VARS` and
+`LEGACY_DISABLE_ENV_VARS` also participate; check them when diagnosing a conflict.
+The current generic resolver does not fall back to PostHog.
+
+Preview exception: when a flag is forced on by ENV or curated preview defaults,
+the resolver consults stored user/org overrides first so QA can turn it off.
+An ENV-disable without an ENV-enable still takes precedence. Keep tests with
+`previewFeatureFlags.enabled = false` for production behavior.
+
+## Console: Cloud organization rollouts
+
+Lightdash staff manage database flags at [Console](https://console.lightdash.com).
+Console writes `feature_flags` and `feature_flag_overrides` in the target
+deployment's application database; it does not set pod environment variables.
+
+1. Deploy the code that registers and consumes the flag.
+2. Find the flag in Console and select the intended deployment/organization.
+3. Prefer an organization override for a targeted organization rollout. Use a
+   user override only when the feature explicitly supports user-scoped rollout.
+   An instance default affects other organizations sharing that database.
+4. Confirm no ENV enable/disable or custom handler overrides the Console choice.
+5. Enable, refetch the UI flag, and exercise the actual backend action. Then
+   disable and verify the backend rejects the action as intended.
+
+Deleting an override means “fall back,” not “off.” Use an explicit off override
+when that is the intended state, subject to the precedence above. Manage flags
+through Console's audited workflow rather than ad-hoc SQL.
+
+## Self-hosting: ENV configuration
+
+Self-hosters do not need access to the internal Console. They can set the generic
+comma-separated lists in their deployment configuration:
+
+```ini
+LIGHTDASH_ENABLE_FEATURE_FLAGS=my-feature,another-feature
+LIGHTDASH_DISABLE_FEATURE_FLAGS=third-feature
+```
+
+These example IDs are placeholders: use exact registered IDs supported by the
+installed version. Preserve existing entries. ENV enablement is deployment-wide,
+not an organization isolation boundary. Apply it consistently to API and worker
+processes that evaluate the feature, then redeploy/restart those processes.
+Enabling a flag does not configure missing storage, credentials, or other required
+services. Do not enable preview flag-management endpoints on production merely
+to expose a self-hosted toggle UI.
+
+For a temporary Cloud ENV workaround, record its removal: once the normal
+Console-controlled path is deployed, remove the forced ENV setting and restart
+so Console can turn the feature off again.
+
+## Refresh, caching, and restart expectations
+
+- The standard backend `FeatureFlagModel.get` does not cache database flag
+  values; a subsequent database-backed resolution sees a committed Console change.
+  Do not capture the resolved boolean at service construction or add a separate
+  feature cache without a documented invalidation strategy.
+- ENV sets are parsed at startup; changing a deployment configuration requires
+  a process rollout. Mixed old/new pods can briefly disagree during rollout.
+- `useServerFeatureFlag` uses React Query with `refetchOnMount: false`.
+  A page can keep an older value until refetched. For in-app context changes,
+  use the existing `refetchFeatureFlags(queryClient)` helper; an external Console
+  change may require a page reload/refetch. Do not promise immediate UI refresh.
+- Disabling a flag does not undo completed writes, cancel every in-flight job,
+  erase downloaded data, or revoke already issued signed URLs. Define the
+  cancellation/recheck boundary where that matters.
+
+If the UI appears but the API says “not enabled,” compare the resolver, target
+scope, ENV precedence, deployed version, and actual backend response before
+attributing it to caching or advising a restart.
+
+## Required tests and review checklist
+
+For a default-off flag with no special handler, test production-mode resolution:
+
+| Configuration                          | Expected                                   |
+| -------------------------------------- | ------------------------------------------ |
+| No ENV or DB enable                    | Off; existing non-feature paths still work |
+| Console organization on, no ENV        | UI and backend action enabled for that org |
+| Different organization, no enable      | Off; no cross-org data access              |
+| Console organization off, no ENV       | UI/action disabled after refetch/recheck   |
+| ENV enable, no DB row                  | On; self-hosting does not require Console  |
+| ENV disable, Console on, no ENV enable | Off                                        |
+| Both ENV enable and disable            | On, matching standard resolver precedence  |
+
+Also verify:
+
+- Enable → disable → enable on the same running service/client, without restart.
+- Non-admin/unauthorized and cross-org requests stay denied while the flag is on.
+- Existing projects, cached results, workers, and direct API calls follow the same
+  intended gate; preview behavior is covered separately.
+- Test the actual resolver with DB fixtures (or a narrowly mocked DB), not only
+  a stubbed `enabled: true` result or a mocked authorization helper.
+- At least one API/UI smoke test uses Console-style DB enablement **with ENV
+  enable unset and preview defaults disabled**. Check the action, not only the menu.
+- Document untested live paths and temporary ENV workarounds in the PR.
+
+## Code references
+
+- [Flag registration](../packages/common/src/types/featureFlags.ts)
+- [Resolver and database lookup](../packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts)
+- [Service wrapper](../packages/backend/src/services/FeatureFlag/FeatureFlagService.ts)
+- [ENV parsing](../packages/backend/src/config/parseConfig.ts)
+- [Frontend hook and refetch helper](../packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts)
+- [Resolver tests](../packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts)
+
+The internal analytics incident is the counterexample: the UI used the standard
+resolver while its backend checked only ENV. Enabling Console made the menu
+visible but could never enable the API. An ENV workaround can restore availability;
+the proper fix is to use the standard resolver across entry points.

--- a/docs/preview-feature-flags.md
+++ b/docs/preview-feature-flags.md
@@ -1,5 +1,8 @@
 # Feature flags in preview environments
 
+For implementation standards, Console rollouts, and self-hosted ENV configuration,
+start with [Adding and operating feature flags](feature-flags.md).
+
 Preview environments (`LIGHTDASH_MODE=pr`) enable most feature flags by default
 and expose an API for toggling them, so QA can validate recent features without
 a redeploy.
@@ -69,13 +72,15 @@ Unknown flag ids are rejected, so a typo can't silently create a dead override.
 
 `FeatureFlagModel.get()` resolves in this order:
 
-1. `LIGHTDASH_ENABLE_FEATURE_FLAGS` and `LIGHTDASH_DISABLE_FEATURE_FLAGS`. Enable
-   wins when a flag is in both; disable is absolute — no override overrides it.
+1. `LIGHTDASH_ENABLE_FEATURE_FLAGS` and `LIGHTDASH_DISABLE_FEATURE_FLAGS`. When
+   only disable contains the flag, it is off regardless of stored overrides.
+   When enable contains it (including when both lists do), proceed to the
+   preview override check below before returning on.
 2. In preview environments, a stored override for the user or organization,
    consulted only for flags the environment forces on.
 3. `PREVIEW_ENABLED_FEATURE_FLAGS`, in preview environments.
 4. Per-flag config handlers (for example `EDIT_YAML_IN_UI_ENABLED`).
 5. Database: user override, then organization override, then flag default.
 
-Consulting overrides costs a couple of extra indexed lookups per flag check, in
-preview environments only.
+The preview override check adds indexed lookups to the forced-on path. Ordinary
+database-backed resolution also queries overrides outside preview environments.

--- a/docs/usage-analytics/architecture.md
+++ b/docs/usage-analytics/architecture.md
@@ -16,7 +16,7 @@ queries. It does not require dbt or a MotherDuck account.
 | ---------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | Project                | Internal `PREVIEW` project with `provisioning_source=analytics`; both Query Events and AI Usage | Final metadata-project lifecycle and role design                            |
 | Entry point            | Session-authenticated, org-admin-only create-or-get endpoint                                    | Admin navigation/button; no connector setup UI                              |
-| Enablement             | Explicit deployment `analytics-project` flag in all environments; disable takes precedence      | Controlled live verification before customer rollout                        |
+| Enablement             | Standard `analytics-project` resolver: Console organization flags or deployment ENV flags       | Controlled live verification before customer rollout                        |
 | Source org             | Persisted, authorized project org; legacy local overrides ignored                               | Live shared-instance isolation verification                                 |
 | Storage authentication | Existing writer credentials retained in backend; signed GET URLs passed to DuckDB               | Verify effective IAM; read-only hardening is deferred (PROD-11103)          |
 | Models                 | Backend-owned `query_events` and `ai_usage` explores                                            | Reevaluate other streams, metadata enrichment and additional event coverage |
@@ -183,7 +183,7 @@ cryptographic revocation of previously issued capabilities or returned data.
 [`analyticsProjectClient`](../../packages/backend/src/services/ProjectService/analyticsProject/analyticsProjectClient.ts)
 reads files for the persisted project's org after service authorization checks.
 Legacy local org/source-org overrides are ignored in all environments. Production
-execution requires the explicit deployment feature flag; disable takes precedence.
+execution uses the standard feature-flag resolver for the target organization.
 See [live testing](live-testing.md) for rollout and remaining trust boundaries.
 
 The prefix filter is a backend authorization boundary, not bucket IAM. Storage

--- a/docs/usage-analytics/live-testing.md
+++ b/docs/usage-analytics/live-testing.md
@@ -10,11 +10,15 @@ change is required. Read-only credential hardening is deferred in PROD-11103.
 1. Verify the existing usage-events endpoint, bucket and credentials are correct
    for the deployment and that its org has compacted Parquet data. Confirm effective
    IAM does not grant the identity access to other deployments' buckets.
-2. Add `analytics-project` to `LIGHTDASH_ENABLE_FEATURE_FLAGS`, preserving other
-   flags. Ensure it is not in `LIGHTDASH_DISABLE_FEATURE_FLAGS`; disable wins.
-   This is an explicit deployment-wide backend gate, not a per-org rollout flag.
+2. Enable `analytics-project` for the intended organization in Console, or add it
+   to `LIGHTDASH_ENABLE_FEATURE_FLAGS` for deployment-wide enablement. Backend
+   checks use the standard flag resolver with the target organization, including
+   on file reads. Console organization overrides are read without an analytics
+   flag cache; no restart is needed. ENV changes require a deployment/restart.
+   Standard precedence applies: ENV enable wins, then ENV disable, then database
+   organization override/default (preview overrides follow preview rules).
    Do not change `NODE_ENV` or enable unrelated deployments.
-3. Use normal deployment/restart handling, then sign in as an organization admin.
+3. After deploying this code, sign in as an organization admin.
    In Organization settings → Lightdash analytics, create the project, open its
    dashboards and Explore, and exercise Sync content.
 4. Verify both AI usage and query events, non-admin and cross-org denial, then
@@ -29,8 +33,9 @@ development. Local demos with mismatched source and project orgs must use matchi
 fixtures; they can no longer read another org through an override.
 
 No flags are enabled or infrastructure applied by this code change. Live production
-verification remains pending deployment. Roll back by explicitly disabling the
-feature and leaving projects/content intact. Issued signed URLs remain valid until
+verification remains pending deployment. Roll back by disabling the organization
+flag in Console when no ENV enable forces it on, or remove the ENV enable and
+explicitly disable it. Leave projects/content intact. Issued signed URLs remain valid until
 expiry (up to 15 minutes); flag-off does not revoke data already returned.
 
 ## Accepted boundary

--- a/docs/usage-analytics/local-testing.md
+++ b/docs/usage-analytics/local-testing.md
@@ -122,7 +122,8 @@ slice does not issue export URLs that outlive these checks.
 
 Actual GCS reads and isolated MinIO tests verify the signed-URL path; AWS S3 and
 production multi-tenant rollout remain unverified.
-Production execution requires explicit deployment feature enablement.
+Production execution supports Console organization flags or ENV enablement through
+the standard feature-flag resolver; see [live testing](live-testing.md).
 
 ## Incremental PR stack
 


### PR DESCRIPTION
## Summary

- Add an internal feature-flag implementation and operations guide covering the shared backend resolver, frontend hook, Console database overrides, and self-hosted ENV configuration.
- Make the guide discoverable from root CLAUDE.md, with an explicit rule against accidental ENV-only or NODE_ENV rollout gates.
- Clarify ENV-enable precedence, preview override behavior, restart/refetch expectations, target scope, authorization boundaries, and temporary ENV workaround removal.
- Require Console-only regression coverage with ENV enable unset and preview defaults disabled, including actual backend action validation rather than just menu visibility.
- Correct ambiguous precedence/database-lookup wording in the existing preview guide.

## Validation

- Cross-checked examples and precedence against FeatureFlagModel, the frontend hook, parseConfig, and the internal Console implementation.
- Formatting, diff sanity, and relative-link checks pass.
- Documentation only: no runtime changes, migrations, infrastructure changes, production flag mutations, or app/database startup. Runtime tests are not applicable.

Relates: PROD-11059
Related implementation fix: https://github.com/lightdash/lightdash/pull/29042
## Analytics-specific documentation

Includes the architecture, local-testing, and live-testing updates moved out of #29042. These describe the corrected Console/ENV behavior and should accompany that fix's release; they do not change runtime behavior.

