### PR TITLE
fix(feature-flags): fail closed on the ai-copilot flag for anonymous callers

### DIFF
--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.test.ts
@@ -6,15 +6,78 @@ import { CommercialFeatureFlagModel } from './CommercialFeatureFlagModel';
 
 const database = knex({ client: MockClient, dialect: 'pg' });
 
-const createModel = () =>
+const createModel = (config: Partial<typeof lightdashConfigMock> = {}) =>
     new CommercialFeatureFlagModel({
         database,
         lightdashConfig: {
             ...lightdashConfigMock,
             enabledFeatureFlags: new Set<string>(),
             disabledFeatureFlags: new Set<string>(),
+            ...config,
         },
     });
+
+const createGatedCopilotModel = () =>
+    createModel({
+        ai: {
+            ...lightdashConfigMock.ai,
+            copilot: {
+                ...lightdashConfigMock.ai.copilot,
+                enabled: true,
+                requiresFeatureFlag: true,
+            },
+        },
+    });
+
+describe('CommercialFeatureFlagModel ai copilot', () => {
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    it('fails closed without a user and issues no flag queries', async () => {
+        await expect(
+            createGatedCopilotModel().get({
+                featureFlagId: CommercialFeatureFlags.AiCopilot,
+            }),
+        ).resolves.toEqual({
+            id: CommercialFeatureFlags.AiCopilot,
+            enabled: false,
+        });
+        expect(tracker.history.select).toHaveLength(0);
+    });
+
+    it('resolves through the database when a user is present', async () => {
+        tracker.on.select('feature_flags').responseOnce({
+            flag_id: CommercialFeatureFlags.AiCopilot,
+            default_enabled: null,
+        });
+        tracker.on.select('feature_flag_overrides').responseOnce({
+            flag_id: CommercialFeatureFlags.AiCopilot,
+            organization_uuid: 'organization-uuid',
+            user_uuid: null,
+            enabled: true,
+        });
+
+        await expect(
+            createGatedCopilotModel().get({
+                featureFlagId: CommercialFeatureFlags.AiCopilot,
+                user: {
+                    userUuid: 'user-uuid',
+                    organizationUuid: 'organization-uuid',
+                },
+            }),
+        ).resolves.toEqual({
+            id: CommercialFeatureFlags.AiCopilot,
+            enabled: true,
+        });
+    });
+});
 
 describe('CommercialFeatureFlagModel direct access', () => {
     let tracker: Tracker;

--- a/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
+++ b/packages/backend/src/ee/models/CommercialFeatureFlagModel.ts
@@ -58,10 +58,10 @@ export class CommercialFeatureFlagModel extends FeatureFlagModel {
             return { id: featureFlagId, enabled: copilotConfigEnabled };
         }
 
+        // The endpoint allows anonymous callers, so fail closed like the
+        // other commercial flags instead of erroring.
         if (!user) {
-            throw new Error(
-                'User is required to check if AI copilot is enabled',
-            );
+            return { id: featureFlagId, enabled: false };
         }
 
         const dbResult = await this.tryGetFromDatabase({ user, featureFlagId });

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useAiAgentsButtonVisibility.ts
@@ -37,8 +37,10 @@ export const useAiAgentButtonVisibility = () => {
         projectUuid,
     });
 
+    // The flag is always off without a registered user, so skip the request.
     const aiCopilotFlagQuery = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
+        { enabled: !!appQuery.user.data },
     );
 
     if (
@@ -46,7 +48,7 @@ export const useAiAgentButtonVisibility = () => {
         aiOrganizationSettingsQuery.isLoading ||
         appQuery.user.isLoading ||
         appQuery.health.isLoading ||
-        aiCopilotFlagQuery.isLoading
+        aiCopilotFlagQuery.isInitialLoading
     ) {
         return false;
     }

--- a/packages/frontend/src/ee/features/aiCopilot/hooks/useIsCopilotEnabled.ts
+++ b/packages/frontend/src/ee/features/aiCopilot/hooks/useIsCopilotEnabled.ts
@@ -1,15 +1,20 @@
 import { CommercialFeatureFlags } from '@lightdash/common';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../../providers/App/useApp';
 import { useAiOrganizationSettings } from './useAiOrganizationSettings';
 
 // Raw "copilot available" signal: the AI copilot flag or an active trial.
 // Unlike useAiAgentButtonVisibility this does not require agents to already
 // exist, so a copilot-enabled org with no agents still counts as enabled.
 export const useIsCopilotEnabled = () => {
-    const flagQuery = useServerFeatureFlag(CommercialFeatureFlags.AiCopilot);
+    const { user } = useApp();
+    // The flag is always off without a registered user, so skip the request.
+    const flagQuery = useServerFeatureFlag(CommercialFeatureFlags.AiCopilot, {
+        enabled: !!user.data,
+    });
     const orgSettingsQuery = useAiOrganizationSettings();
 
-    const isLoading = flagQuery.isLoading || orgSettingsQuery.isLoading;
+    const isLoading = flagQuery.isInitialLoading || orgSettingsQuery.isLoading;
     const isCopilotEnabled =
         !!flagQuery.data?.enabled || !!orgSettingsQuery.data?.isTrial;
 

--- a/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
+++ b/packages/frontend/src/ee/features/ambientAi/hooks/useAmbientAiEnabled.ts
@@ -1,6 +1,7 @@
 import { CommercialFeatureFlags } from '@lightdash/common';
 import useHealth from '../../../../hooks/health/useHealth';
 import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
+import useApp from '../../../../providers/App/useApp';
 
 /**
  * Checks if the ambient ai is enabled.
@@ -8,8 +9,11 @@ import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeature
  */
 export const useAmbientAiEnabled = () => {
     const { data: health } = useHealth();
+    const { user } = useApp();
+    // The flag is always off without a registered user, so skip the request.
     const { data: aiCopilotFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
+        { enabled: !!user.data },
     );
     return health?.ai.isAmbientAiEnabled || aiCopilotFlag?.enabled;
 };

--- a/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
+++ b/packages/frontend/src/hooks/useServerOrClientFeatureFlag.ts
@@ -24,7 +24,7 @@ export const refetchFeatureFlags = (queryClient: QueryClient) =>
  */
 export const useServerFeatureFlag = (
     featureFlagId: string,
-    options?: { retry?: number | boolean },
+    options?: { retry?: number | boolean; enabled?: boolean },
 ) => {
     return useQuery<FeatureFlag, ApiError>(
         [FEATURE_FLAG_QUERY_KEY, featureFlagId],
@@ -38,6 +38,7 @@ export const useServerFeatureFlag = (
         },
         {
             retry: options?.retry ?? false,
+            enabled: options?.enabled ?? true,
             refetchOnMount: false,
         },
     );


### PR DESCRIPTION
## Problem

Sentry issue [LIGHTDASH-BACKEND-8ER](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-8ER) (`User is required to check if AI copilot is enabled`) has 31k events across 1.1k users since June 2025.

`GET /api/v2/feature-flag/{id}` deliberately allows anonymous callers (`allowApiKeyAuthenticationIfPresent`, no `isAuthenticated`), and the controller passes `user: undefined` for both anonymous and JWT accounts. The ai-copilot handler threw a plain `Error` in that case, which is classified as an unexpected server error, so every anonymous call became a 500 and an unhandled Sentry event. The sibling commercial flag handlers (direct access, homepage builder) already return `enabled: false` in the same situation.

The frontend requests this flag from globally mounted components (AI launcher, navbar button, Home, Omnibar), so the requests fire on logged-out and expired-session pages and inside headless renders for Slack unfurls and exports.

## Changes

- **Backend**: the ai-copilot handler returns `enabled: false` without a user instead of throwing. Unit tests cover the no-user path (no database queries issued) and the resolved-through-database path with a user.
- **Frontend**: `useServerFeatureFlag` accepts an `enabled` option. The three copilot hooks (`useIsCopilotEnabled`, `useAmbientAiEnabled`, `useAiAgentButtonVisibility`) skip the request when there is no registered user, since the answer is always `false`. Loading checks use `isInitialLoading` so a disabled query is not reported as loading.

## Regression analysis

- Registered users: unchanged. The handler path with a user is identical, and the hooks still request the flag once the user query resolves.
- Anonymous and embed callers: previously a 500, now `{ enabled: false }`, matching the other commercial flags and what the copilot hooks already assumed.
- Dedicated instances (`requiresFeatureFlag=false`): unchanged, the config short-circuit runs before the user check.
- `useIsCopilotEnabled` / `useAiAgentButtonVisibility` loading state: with react-query v4 a disabled query reports `isLoading: true`, so these now use `isInitialLoading`. While the user query is loading the flag query is disabled and `isInitialLoading` is false, so the hooks resolve to "not enabled" during that window, which is the same value they resolved to before once the flag came back for a logged-out user.
- The flag query key is unchanged, so `refetchFeatureFlags` after org/project creation still refreshes it.

No ticket exists for this; opened against the Sentry issue only.

Fixes LIGHTDASH-BACKEND-8ER

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFgZo1qWmagCbxL8vCFMVK