### PR TITLE
feat(chart-registry): scheme-aware gallery thumbnails via optional thumbnailDark

### DIFF
--- a/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
@@ -31,6 +31,7 @@ const entry = {
     minLightdashVersion: null,
     vizSchema: { fields: [], configOptions: [], colorPalette: null },
     thumbnail: 'charts/sankey/1.2.0/thumb.png',
+    thumbnailDark: null,
     screenshots: ['charts/sankey/1.2.0/screenshot-1.png'],
     artifacts: {
         source: {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.registryInstall.test.ts
@@ -67,6 +67,7 @@ function makeEntry(
         icon: null,
         vizSchema: VIZ_SCHEMA,
         thumbnail: null,
+        thumbnailDark: null,
         screenshots: [],
         artifacts: {
             source: { path: 'sankey/1.3.0/source.tar', sha256: 'a'.repeat(64) },

--- a/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/testFixtures/buildChartRegistryFixture.ts
@@ -189,6 +189,7 @@ export async function buildChartRegistryFixture({
         icon: null,
         vizSchema: FIXTURE_VIZ_SCHEMA,
         thumbnail: `${relPrefix}/thumb.png`,
+        thumbnailDark: null,
         screenshots: [`${relPrefix}/screenshot-1.png`],
         artifacts: {
             source: {

--- a/packages/common/src/ee/apps/registry.test.ts
+++ b/packages/common/src/ee/apps/registry.test.ts
@@ -16,6 +16,7 @@ const validEntry = {
     minLightdashVersion: null,
     vizSchema: { fields: [], configOptions: [], colorPalette: null },
     thumbnail: 'charts/sankey/1.2.0/thumb.png',
+    thumbnailDark: null,
     screenshots: ['charts/sankey/1.2.0/screenshot-1.png'],
     artifacts: {
         source: {

--- a/packages/common/src/ee/apps/registry.ts
+++ b/packages/common/src/ee/apps/registry.ts
@@ -66,6 +66,8 @@ export type ChartRegistryEntry = {
     channel?: 'stable' | 'beta';
     vizSchema: DataAppVizSchema;
     thumbnail: string | null;
+    /** Dark-scheme thumbnail variant; null = reuse `thumbnail` in both schemes */
+    thumbnailDark: string | null;
     screenshots: string[];
     // Curated Tabler icon name; copied onto the app on install and upgrade.
     icon: ChartTypeIcon | null;
@@ -87,6 +89,7 @@ const registryEntrySchema = z.object({
     channel: z.enum(['stable', 'beta']).optional(),
     vizSchema: dataAppVizSchema,
     thumbnail: z.string().nullable().default(null),
+    thumbnailDark: z.string().nullable().default(null),
     screenshots: z.array(z.string()).default([]),
     icon: chartTypeIconSchema.nullable().default(null),
     artifacts: z.object({

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -7,7 +7,11 @@ import { IconPhoto } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
-import { registryAssetUrl } from '../utils/registryAssetUrl';
+import { useAppColorScheme } from '../../../providers/ColorSchemeContext';
+import {
+    registryAssetUrl,
+    registryThumbnailPath,
+} from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryCard.module.css';
 import OfficialChartTypeBadge from './OfficialChartTypeBadge';
@@ -47,51 +51,60 @@ type Props = {
     onClick: () => void;
 };
 
-const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => (
-    <PolymorphicPaperButton
-        component="button"
-        type="button"
-        withBorder
-        radius="md"
-        shadow="subtle"
-        className={classes.card}
-        onClick={onClick}
-    >
-        <Box className={classes.preview}>
-            {item.thumbnail ? (
-                <img
-                    src={registryAssetUrl(item.thumbnail)}
-                    alt={item.name}
-                    className={classes.previewImage}
-                />
-            ) : (
-                <Paper variant="dotted" h="100%" radius={0}>
-                    <Stack align="center" justify="center" gap="xs" h="100%">
-                        <MantineIcon
-                            icon={IconPhoto}
-                            size="xl"
-                            color="ldGray.5"
-                        />
-                    </Stack>
-                </Paper>
-            )}
-        </Box>
-        <Stack gap="xs" p="sm">
-            <Group gap="xs" wrap="nowrap" justify="space-between">
-                <Text fz={13} fw={600} truncate="end">
-                    {item.name}
-                </Text>
-                <Group gap={4} wrap="nowrap" className="ld-shrink-0">
-                    {item.channel === 'beta' && <ChartTypeBetaBadge />}
-                    <OfficialChartTypeBadge />
+const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => {
+    const { colorScheme } = useAppColorScheme();
+    const thumbnail = registryThumbnailPath(item, colorScheme);
+    return (
+        <PolymorphicPaperButton
+            component="button"
+            type="button"
+            withBorder
+            radius="md"
+            shadow="subtle"
+            className={classes.card}
+            onClick={onClick}
+        >
+            <Box className={classes.preview}>
+                {thumbnail ? (
+                    <img
+                        src={registryAssetUrl(thumbnail)}
+                        alt={item.name}
+                        className={classes.previewImage}
+                    />
+                ) : (
+                    <Paper variant="dotted" h="100%" radius={0}>
+                        <Stack
+                            align="center"
+                            justify="center"
+                            gap="xs"
+                            h="100%"
+                        >
+                            <MantineIcon
+                                icon={IconPhoto}
+                                size="xl"
+                                color="ldGray.5"
+                            />
+                        </Stack>
+                    </Paper>
+                )}
+            </Box>
+            <Stack gap="xs" p="sm">
+                <Group gap="xs" wrap="nowrap" justify="space-between">
+                    <Text fz={13} fw={600} truncate="end">
+                        {item.name}
+                    </Text>
+                    <Group gap={4} wrap="nowrap" className="ld-shrink-0">
+                        {item.channel === 'beta' && <ChartTypeBetaBadge />}
+                        <OfficialChartTypeBadge />
+                    </Group>
                 </Group>
-            </Group>
-            <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
-                {item.description || 'No description'}
-            </Text>
-            <StateBadge item={item} />
-        </Stack>
-    </PolymorphicPaperButton>
-);
+                <Text fz="xs" c="dimmed" lh={1.35} lineClamp={2}>
+                    {item.description || 'No description'}
+                </Text>
+                <StateBadge item={item} />
+            </Stack>
+        </PolymorphicPaperButton>
+    );
+};
 
 export default ChartTypeLibraryCard;

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -20,10 +20,14 @@ import MantineModal from '../../../components/common/MantineModal';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
+import { useAppColorScheme } from '../../../providers/ColorSchemeContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
-import { registryAssetUrl } from '../utils/registryAssetUrl';
+import {
+    registryAssetUrl,
+    registryThumbnailPath,
+} from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryDetailModal.module.css';
 import DataAppVizFieldsList from './DataAppVizFieldsList';
@@ -43,6 +47,8 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
     const publishedAgo = useTimeAgo(item.publishedAt);
     const installMutation = useInstallRegistryChartType();
     const { track } = useTracking();
+    const { colorScheme } = useAppColorScheme();
+    const thumbnail = registryThumbnailPath(item, colorScheme);
 
     const handleInstall = () => {
         track({
@@ -147,10 +153,10 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
                             ))}
                         </Group>
                     </ScrollArea>
-                ) : item.thumbnail ? (
+                ) : thumbnail ? (
                     <Box className={classes.preview}>
                         <img
-                            src={registryAssetUrl(item.thumbnail)}
+                            src={registryAssetUrl(thumbnail)}
                             alt={item.name}
                             className={classes.previewImage}
                         />

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -68,6 +68,7 @@ const makeItem = (
         colorPalette: null,
     },
     thumbnail: null,
+    thumbnailDark: null,
     screenshots: [],
     artifacts: {
         source: { path: 'source.zip', sha256: 'a'.repeat(64) },

--- a/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.test.ts
+++ b/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { registryThumbnailPath } from './registryAssetUrl';
+
+describe('registryThumbnailPath', () => {
+    const item = {
+        thumbnail: 'charts/sankey/1.2.0/thumb.png',
+        thumbnailDark: 'charts/sankey/1.2.0/thumb-dark.png',
+    };
+
+    it('returns the light thumbnail for the light scheme', () => {
+        expect(registryThumbnailPath(item, 'light')).toBe(item.thumbnail);
+    });
+
+    it('returns the dark variant for the dark scheme', () => {
+        expect(registryThumbnailPath(item, 'dark')).toBe(item.thumbnailDark);
+    });
+
+    it('falls back to the light thumbnail when no dark variant exists', () => {
+        expect(
+            registryThumbnailPath({ ...item, thumbnailDark: null }, 'dark'),
+        ).toBe(item.thumbnail);
+    });
+
+    it('propagates a missing thumbnail as null', () => {
+        expect(
+            registryThumbnailPath(
+                { thumbnail: null, thumbnailDark: null },
+                'dark',
+            ),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.ts
+++ b/packages/frontend/src/features/chartTypes/utils/registryAssetUrl.ts
@@ -1,5 +1,17 @@
+import { type ChartRegistryEntry } from '@lightdash/common';
+import { type ColorScheme } from '../../../theme/colors';
+
 // Same-origin authenticated asset route (thumbnails, screenshots) served
 // straight from the chart registry — a plain `<img src>` is enough, no
 // query hook needed.
 export const registryAssetUrl = (path: string): string =>
     `/api/v1/ee/chart-registry/assets?path=${encodeURIComponent(path)}`;
+
+/** Thumbnail path for the active scheme; dark falls back to the light one. */
+export const registryThumbnailPath = (
+    item: Pick<ChartRegistryEntry, 'thumbnail' | 'thumbnailDark'>,
+    colorScheme: ColorScheme,
+): string | null =>
+    colorScheme === 'dark'
+        ? (item.thumbnailDark ?? item.thumbnail)
+        : item.thumbnail;


### PR DESCRIPTION
## What

Makes the in-product chart type library light/dark aware: registry entries can now carry an optional `thumbnailDark`, and the library card + detail modal show it when the app color scheme is dark, falling back to the light `thumbnail` when absent.

## How

- **Contract** (`packages/common/src/ee/apps/registry.ts`): `thumbnailDark: string | null` added to `ChartRegistryEntry` and `registryEntrySchema` (`.nullable().default(null)`). The zod schema is the single parse point for the registry index, so existing published indexes (no field) parse to `null` unchanged — no ordering hazard with the gallery: an older Lightdash simply strips the field a newer registry publishes.
- **Backend**: no changes needed — `listRegistryChartTypes` spreads registry entries into the response, and the asset proxy's structural path validation already admits any published PNG under `charts/<slug>/<version>/`.
- **Frontend**: new `registryThumbnailPath(item, colorScheme)` helper next to `registryAssetUrl`; `ChartTypeLibraryCard` and `ChartTypeLibraryDetailModal` select via `useAppColorScheme()` (the persisted app scheme). Detail-modal screenshot strips are unchanged — scope is the thumbnail.

## Verification

- `common`/`backend`/`frontend` typecheck clean
- Touched tests green: common registry (8), backend ChartRegistryClient (28) + registryInstall (22), frontend chartTypes section (14) + new `registryThumbnailPath` unit tests (4)
- `pnpm generate-api` validates; MCP tool snapshot unchanged

## Follow-up

The publisher half (gallery repo): `registry.yml` gains an optional dark thumbnail file, `build-registry` copies it and stamps `thumbnailDark` on the entry. Lands separately in lightdash/lightdash-gallery; safe in either order thanks to the zod default.

Relates: GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN