### PR TITLE
fix(frontend): only diagnose transport failures on warehouse connection requests

### DIFF
--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -245,7 +245,32 @@ describe('network error messages', () => {
             method: 'PATCH',
             url: '/projects/abc',
             body: JSON.stringify({}),
+            diagnoseTransportFailures: true,
         });
+
+    it('keeps the generic message and never probes unless the request opts in', async () => {
+        globalThis.fetch = vi
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(healthOk());
+
+        await expect(
+            lightdashApi({
+                method: 'GET',
+                url: '/user',
+                body: undefined,
+            }),
+        ).rejects.toMatchObject({
+            error: {
+                name: 'NetworkError',
+                statusCode: 500,
+                message:
+                    'We are currently unable to reach the Lightdash server. Please try again in a few moments.',
+                data: {},
+            },
+        });
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
 
     it('says the request was blocked when fetch rejects but the server answers a probe', async () => {
         globalThis.fetch = vi
@@ -437,6 +462,7 @@ describe('network error messages', () => {
                 method: 'POST',
                 url: '/stream',
                 body: JSON.stringify({}),
+                diagnoseTransportFailures: true,
             }),
         ).rejects.toThrow('with HTTP 403 instead of Lightdash');
     });

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -131,6 +131,9 @@ type FailedRequest = {
     // Rendered inside a host application (SDK or embed): the viewer gets the
     // generic message and no diagnostics, which would name the Lightdash host.
     hosted: boolean;
+    // Only flows where a proxy or VPN is a likely culprit (warehouse
+    // connection setup) opt in; everything else keeps the generic message.
+    diagnose: boolean;
 };
 
 const handleError = async (
@@ -150,6 +153,17 @@ const handleError = async (
     // Surface the real transport error (abort, CORS, DNS, connection reset)
     // instead of silently masking it as the generic message below.
     console.error('Failed to reach the Lightdash server:', err);
+    if (request.hosted || !request.diagnose) {
+        return {
+            status: 'error',
+            error: {
+                name: 'NetworkError',
+                statusCode: 500,
+                message: GENERIC_NETWORK_FAILURE_MESSAGE,
+                data: {},
+            },
+        };
+    }
     const diagnostics = await diagnoseTransportFailure({
         ...request,
         error: err,
@@ -165,10 +179,8 @@ const handleError = async (
         error: {
             name: 'NetworkError',
             statusCode: 500,
-            message: request.hosted
-                ? GENERIC_NETWORK_FAILURE_MESSAGE
-                : networkFailureMessage(diagnostics),
-            data: request.hosted ? {} : diagnostics,
+            message: networkFailureMessage(diagnostics),
+            data: diagnostics,
         },
     };
 };
@@ -179,6 +191,9 @@ type LightdashApiPropsBase = {
     version?: 'v1' | 'v2';
     signal?: AbortSignal;
     sensitive?: boolean;
+    // Probe the server on a transport failure and tell the user what blocked
+    // the request. Opt in only where a proxy or VPN is a plausible cause.
+    diagnoseTransportFailures?: boolean;
 };
 
 type LightdashApiPropsGetOrDelete = LightdashApiPropsBase & {
@@ -205,6 +220,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     version = 'v1',
     signal,
     sensitive = false,
+    diagnoseTransportFailures = false,
 }: LightdashApiProps): Promise<T> => {
     const baseUrl = sessionStorage.getItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
@@ -286,6 +302,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
                 apiPrefix,
                 traceId: sentryTrace?.split('-')[0] ?? null,
                 hosted: baseUrl !== null || !!embed?.token,
+                diagnose: diagnoseTransportFailures,
             });
             networkHistory.push(
                 sensitive
@@ -321,6 +338,7 @@ export const lightdashApiStream = ({
     headers,
     version = 'v1',
     signal,
+    diagnoseTransportFailures = false,
 }: LightdashApiProps) => {
     const baseUrl = sessionStorage.getItem(
         LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY,
@@ -361,6 +379,7 @@ export const lightdashApiStream = ({
                 apiPrefix,
                 traceId: sentryTrace?.split('-')[0] ?? null,
                 hosted: baseUrl !== null || !!embed?.token,
+                diagnose: diagnoseTransportFailures,
             });
             throw new Error(apiError.error.message);
         }

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -39,6 +39,7 @@ const createProject = async (data: CreateProject) =>
         method: 'POST',
         body: JSON.stringify(data),
         sensitive: true,
+        diagnoseTransportFailures: true,
     });
 
 const createProjectWithoutCompile = async (data: CreateProject) =>
@@ -47,6 +48,7 @@ const createProjectWithoutCompile = async (data: CreateProject) =>
         method: 'POST',
         body: JSON.stringify(data),
         sensitive: true,
+        diagnoseTransportFailures: true,
     });
 
 const updateProject = async (uuid: string, data: UpdateProject) =>
@@ -55,6 +57,7 @@ const updateProject = async (uuid: string, data: UpdateProject) =>
         method: 'PATCH',
         body: JSON.stringify(data),
         sensitive: true,
+        diagnoseTransportFailures: true,
     });
 
 export const getProject = async (uuid: string) =>
@@ -233,6 +236,7 @@ const testWarehouseConnection = async (
         method: 'POST',
         body: JSON.stringify(body),
         sensitive: true,
+        diagnoseTransportFailures: true,
     });
 
 export const useTestWarehouseConnectionMutation = (uuid: string) => {


### PR DESCRIPTION
## Problem

#28875 made every failed request probe `/health` and, when the server answered, tell the user a corporate proxy, VPN or security software had blocked the request. That branch also fires for ordinary in-flight requests cancelled by a page navigation, most visibly the redirect to `/login` when a session expires. Users saw an alarming proxy warning for something that had nothing to do with their network.

## Change

Transport-failure diagnostics are now opt-in per request via `diagnoseTransportFailures` on `lightdashApi` and `lightdashApiStream`. Only the flows the original case was about ask for them:

- create project (`POST /org/projects/precompiled`, `POST /org/projects`)
- update project (`PATCH /projects/:uuid`)
- warehouse connection test (`POST /projects/:uuid/warehouse/test`)

Every other transport failure keeps the pre-#28875 generic message, carries no diagnostics and never probes the health endpoint. Embeds and the SDK were already on the generic path and stay there.

## Regression analysis

- The `NetworkError` name and 500 status are unchanged, so retry policies and `ApiErrorDisplay` keep working. The toast already rendered plain text when `error.data` was not a diagnostics object.
- The health probe no longer runs on navigation-cancelled requests, which removes a stray `GET /health` per aborted request.
- `Copy diagnostics` and the Sentry breadcrumb still appear on the four opted-in calls, which is where the Modivcare-style bastion case is diagnosed.

## Tests

- `src/api.test.ts`: new case asserting the default path returns the generic message with empty data and calls fetch exactly once. Existing diagnostics cases now opt in explicitly. 21/21 pass.
- Lint and oxfmt clean on the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCUP4nXF4SKDwnVAjCgXfF
