### PR TITLE
fix(charts): keep outside legend labels inside the reserved legend area

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -9,7 +9,15 @@ import {
     type EChartsReactProps,
     type Opts,
 } from 'echarts-for-react/lib/types';
-import { memo, useCallback, useEffect, useMemo, useRef, type FC } from 'react';
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import useEchartsCartesianConfig from '../../hooks/echarts/useEchartsCartesianConfig';
 import {
     getDisabledLegendEntries,
@@ -232,9 +240,12 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                 cartesianChartConfig?.dirtyEchartsConfig?.legend?.selected,
                 persistLegendSelection,
             );
+        // Measured canvas width so outside legends can size their labels
+        const [chartWidth, setChartWidth] = useState<number | null>(null);
         const eChartsOptions = useEchartsCartesianConfig(
             selectedLegends,
             props.isInDashboard,
+            chartWidth,
         );
 
         const hasSignaledScreenshotReady = useRef(false);
@@ -294,7 +305,11 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             };
 
             // Observe container size changes (e.g., collapsible card expand/collapse)
-            const observer = new ResizeObserver(resizeChart);
+            const observer = new ResizeObserver((entries) => {
+                const width = entries[0]?.contentRect.width;
+                if (width !== undefined) setChartWidth(Math.round(width));
+                resizeChart();
+            });
             observer.observe(dom);
 
             // Also listen for window resize events

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -3,9 +3,10 @@ import {
     CartesianSeriesType,
     createConditionalFormattingConfigWithSingleColor,
     DimensionType,
-    REFERENCE_LINE_Z,
     FieldType,
     FilterOperator,
+    getLegendStyle,
+    REFERENCE_LINE_Z,
     TimeFrames,
     transformToPercentageStacking,
     type CartesianChart,
@@ -16,7 +17,6 @@ import {
     type ResultRow,
     type Series,
 } from '@lightdash/common';
-import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/styles/legendStyles';
 import dayjs from 'dayjs';
 import timezonePlugin from 'dayjs/plugin/timezone';
 import utcPlugin from 'dayjs/plugin/utc';

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.test.ts
@@ -16,6 +16,7 @@ import {
     type ResultRow,
     type Series,
 } from '@lightdash/common';
+import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/styles/legendStyles';
 import dayjs from 'dayjs';
 import timezonePlugin from 'dayjs/plugin/timezone';
 import utcPlugin from 'dayjs/plugin/utc';
@@ -36,6 +37,8 @@ import {
     getPinnedDayTickFormatter,
     getStackTotalSeries,
     getTimeAxisPinnedTickValues,
+    composeLegendConfig,
+    getOutsideLegendLabelWidth,
     mergeLegendSettings,
     padDatasetForContinuousAxis,
     relocateMarkLinesToVisibleSeries,
@@ -43,6 +46,10 @@ import {
     selectContinuousDateRange,
     transformStack100ByValueAxis,
 } from './useEchartsCartesianConfig';
+import {
+    LEGEND_INTERACTION_HINT,
+    type LegendDoubleClickTooltip,
+} from './useLegendDoubleClickTooltip';
 
 dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
@@ -2552,6 +2559,16 @@ describe('mergeLegendSettings', () => {
         expect(result.bottom).toBeUndefined();
     });
 
+    test('uses the provided outside label width', () => {
+        const result = mergeLegendSettings(
+            { placement: 'outsideRight' },
+            selected,
+            series,
+            220,
+        );
+        expect(result.textStyle).toEqual({ overflow: 'truncate', width: 220 });
+    });
+
     test("placement 'custom' is treated as no override", () => {
         const result = mergeLegendSettings(
             { placement: 'custom', orient: 'vertical', right: '5' },
@@ -2564,6 +2581,116 @@ describe('mergeLegendSettings', () => {
             selected,
         });
         expect(result).not.toHaveProperty('placement');
+    });
+});
+
+describe('getOutsideLegendLabelWidth', () => {
+    const squareStyle = getLegendStyle('square');
+
+    test('falls back to a fixed width when the chart width is unknown', () => {
+        expect(getOutsideLegendLabelWidth(null, '25%', squareStyle)).toBe(150);
+        expect(getOutsideLegendLabelWidth(0, '25%', squareStyle)).toBe(150);
+    });
+
+    test('derives the width from a percentage legend area', () => {
+        // 250px area - 20px margin - 10px box padding - 12px icon - 5px gap - 2px text padding
+        expect(getOutsideLegendLabelWidth(1000, '25%', squareStyle)).toBe(201);
+    });
+
+    test('accepts pixel legend areas with or without a unit', () => {
+        expect(getOutsideLegendLabelWidth(1000, '300px', squareStyle)).toBe(
+            251,
+        );
+        expect(getOutsideLegendLabelWidth(1000, '300', squareStyle)).toBe(251);
+    });
+
+    test('accounts for the wider line icon', () => {
+        expect(
+            getOutsideLegendLabelWidth(1000, '25%', getLegendStyle('line')),
+        ).toBe(195);
+    });
+
+    test('never drops below the minimum on narrow charts', () => {
+        expect(getOutsideLegendLabelWidth(200, '25%', squareStyle)).toBe(40);
+    });
+
+    test('falls back when the legend area cannot be parsed', () => {
+        expect(getOutsideLegendLabelWidth(1000, 'auto', squareStyle)).toBe(150);
+    });
+});
+
+describe('composeLegendConfig', () => {
+    const series = [{ name: 'A' }, { name: 'B' }] as any;
+    const selected = { A: true, B: true };
+    const legendStyle = getLegendStyle('square');
+    const doubleClickTooltip: LegendDoubleClickTooltip = {
+        show: true,
+        backgroundColor: '#fff',
+        borderColor: '#ddd',
+        borderWidth: 0,
+        borderRadius: 4,
+        textStyle: { color: '#333', fontSize: 12, fontWeight: 400 },
+        padding: [4, 8],
+        extraCssText: '',
+        formatter: () => LEGEND_INTERACTION_HINT,
+    };
+
+    test('keeps outside-legend truncation alongside the shared typography', () => {
+        const merged = mergeLegendSettings(
+            { placement: 'outsideRight' },
+            selected,
+            series,
+            200,
+        );
+        const result = composeLegendConfig(
+            merged,
+            legendStyle,
+            doubleClickTooltip,
+        );
+        expect(result.textStyle).toEqual({
+            ...legendStyle.textStyle,
+            overflow: 'truncate',
+            width: 200,
+        });
+        expect(result).toMatchObject({
+            type: 'scroll',
+            orient: 'vertical',
+            right: '2%',
+            icon: 'roundRect',
+            itemWidth: 12,
+        });
+    });
+
+    test('shows the full label above the hint when labels can be truncated', () => {
+        const merged = mergeLegendSettings(
+            { placement: 'outsideLeft' },
+            selected,
+            series,
+        );
+        const { tooltip } = composeLegendConfig(
+            merged,
+            legendStyle,
+            doubleClickTooltip,
+        );
+        expect(tooltip).toMatchObject({ show: true, borderRadius: 4 });
+        const html = tooltip.formatter({ name: '<Long> & wordy label' });
+        expect(html).toContain('&lt;Long&gt; &amp; wordy label');
+        expect(html).toContain(LEGEND_INTERACTION_HINT);
+    });
+
+    test('leaves in-chart legends with the plain hint tooltip and typography', () => {
+        const merged = mergeLegendSettings(
+            { orient: 'horizontal', top: '0' },
+            selected,
+            series,
+        );
+        const result = composeLegendConfig(
+            merged,
+            legendStyle,
+            doubleClickTooltip,
+        );
+        expect(result.tooltip).toBe(doubleClickTooltip);
+        expect(result.textStyle).toEqual(legendStyle.textStyle);
     });
 });
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -86,6 +86,7 @@ import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/sty
 import { useMantineTheme } from '@mantine/core';
 import dayjs from 'dayjs';
 import {
+    format as echartsFormat,
     type DefaultLabelFormatterCallbackParams,
     type TooltipComponentFormatterCallback,
     type TooltipComponentOption,
@@ -117,7 +118,11 @@ import {
     resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
 } from './timezoneShift';
-import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
+import {
+    LEGEND_INTERACTION_HINT,
+    useLegendDoubleClickTooltip,
+    type LegendDoubleClickTooltip,
+} from './useLegendDoubleClickTooltip';
 
 // NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
 type TooltipFormatterParams = DefaultLabelFormatterCallbackParams & {
@@ -422,13 +427,30 @@ const removeEmptyProperties = <
     );
 };
 
+/** Label width used when the chart width is unknown, e.g. chart export. */
+const OUTSIDE_LEGEND_FALLBACK_LABEL_WIDTH = 150;
+const OUTSIDE_LEGEND_MIN_LABEL_WIDTH = 40;
+const OUTSIDE_LEGEND_MARGIN_PERCENT = 2;
+/** Gap ECharts leaves between a legend icon and its label. */
+const ECHARTS_LEGEND_ICON_LABEL_GAP = 5;
+/** ECharts' default legend padding, 5px on each side. */
+const ECHARTS_LEGEND_BOX_PADDING = 10;
+
+type OutsideLegendTextStyle = { overflow: 'truncate'; width: number };
+
+export type MergedLegendSettings = Record<string, unknown> & {
+    textStyle?: OutsideLegendTextStyle;
+    tooltip?: { show: boolean };
+};
+
 export const mergeLegendSettings = <
     T extends Record<string, any> = Record<any, any>,
 >(
     legendConfig: T | undefined,
     legendsSelected: LegendValues,
     series: EChartsSeries[],
-): Record<string, unknown> => {
+    outsideLabelWidth: number = OUTSIDE_LEGEND_FALLBACK_LABEL_WIDTH,
+): MergedLegendSettings => {
     const normalizedConfig = removeEmptyProperties(legendConfig);
     if (!normalizedConfig || Object.keys(normalizedConfig).length === 0) {
         return {
@@ -447,8 +469,8 @@ export const mergeLegendSettings = <
     // the full label via the legend's built-in tooltip.
     const outsideLegendOverflow = {
         textStyle: {
-            overflow: 'truncate',
-            width: 150,
+            overflow: 'truncate' as const,
+            width: outsideLabelWidth,
         },
         tooltip: { show: true },
     };
@@ -465,7 +487,7 @@ export const mergeLegendSettings = <
             // pagination still works for legends with many series.
             top: 'middle',
             height: '80%',
-            right: '2%',
+            right: `${OUTSIDE_LEGEND_MARGIN_PERCENT}%`,
             left: undefined,
             bottom: undefined,
             ...outsideLegendOverflow,
@@ -480,7 +502,7 @@ export const mergeLegendSettings = <
             orient: 'vertical',
             top: 'middle',
             height: '80%',
-            left: '2%',
+            left: `${OUTSIDE_LEGEND_MARGIN_PERCENT}%`,
             right: undefined,
             bottom: undefined,
             ...outsideLegendOverflow,
@@ -496,6 +518,83 @@ export const mergeLegendSettings = <
         top: 'bottom' in rest ? undefined : 0,
         ...rest,
         selected: legendsSelected,
+    };
+};
+
+/** Resolves a legend area width ('25%', '300px' or '300') to pixels. */
+const parseLegendAreaWidth = (
+    value: string,
+    chartWidth: number,
+): number | null => {
+    const match = value.trim().match(/^(\d+(?:\.\d+)?)(%|px)?$/);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    return match[2] === '%' ? (chartWidth * amount) / 100 : amount;
+};
+
+type LegendStyle = ReturnType<typeof getLegendStyle>;
+
+/**
+ * Widest label that still fits inside the reserved outside-legend area once
+ * the legend margin, box padding, icon and icon gap are taken out.
+ */
+export const getOutsideLegendLabelWidth = (
+    chartWidth: number | null,
+    legendAreaWidth: string,
+    legendStyle: Pick<LegendStyle, 'itemWidth' | 'textStyle'>,
+): number => {
+    if (chartWidth === null || chartWidth <= 0) {
+        return OUTSIDE_LEGEND_FALLBACK_LABEL_WIDTH;
+    }
+    const areaWidth = parseLegendAreaWidth(legendAreaWidth, chartWidth);
+    if (areaWidth === null) return OUTSIDE_LEGEND_FALLBACK_LABEL_WIDTH;
+
+    const margin = (chartWidth * OUTSIDE_LEGEND_MARGIN_PERCENT) / 100;
+    const [, paddingRight = 0, , paddingLeft = 0] =
+        legendStyle.textStyle.padding;
+    const available =
+        areaWidth -
+        margin -
+        ECHARTS_LEGEND_BOX_PADDING -
+        legendStyle.itemWidth -
+        ECHARTS_LEGEND_ICON_LABEL_GAP -
+        paddingLeft -
+        paddingRight;
+    return Math.max(OUTSIDE_LEGEND_MIN_LABEL_WIDTH, Math.floor(available));
+};
+
+const getLegendItemName = (params: unknown): string =>
+    typeof params === 'object' &&
+    params !== null &&
+    'name' in params &&
+    typeof params.name === 'string'
+        ? params.name
+        : '';
+
+/**
+ * Layers the shared legend typography over the merged legend settings without
+ * dropping the outside-placement truncation, and shows the full label in the
+ * hover tooltip whenever labels can be truncated.
+ */
+export const composeLegendConfig = (
+    mergedLegend: MergedLegendSettings,
+    legendStyle: LegendStyle,
+    doubleClickTooltip: LegendDoubleClickTooltip,
+) => {
+    const isTruncated = mergedLegend.textStyle?.overflow === 'truncate';
+    return {
+        ...mergedLegend,
+        ...legendStyle,
+        textStyle: { ...legendStyle.textStyle, ...mergedLegend.textStyle },
+        tooltip: isTruncated
+            ? {
+                  ...doubleClickTooltip,
+                  formatter: (params: unknown) =>
+                      `<div style="font-weight: 500">${echartsFormat.encodeHTML(
+                          getLegendItemName(params),
+                      )}</div>${LEGEND_INTERACTION_HINT}`,
+              }
+            : doubleClickTooltip,
     };
 };
 
@@ -3254,6 +3353,7 @@ export const relocateMarkLinesToVisibleSeries = (
 const useEchartsCartesianConfig = (
     validCartesianConfigLegend?: LegendValues,
     isInDashboard?: boolean,
+    chartWidth: number | null = null,
 ) => {
     const {
         visualizationConfig,
@@ -4341,12 +4441,6 @@ const useEchartsCartesianConfig = (
     const { tooltip: legendDoubleClickTooltip } = useLegendDoubleClickTooltip();
 
     const legendConfigWithInstructionsTooltip = useMemo(() => {
-        const mergedLegendConfig = mergeLegendSettings(
-            validCartesianConfig?.eChartsConfig.legend,
-            validCartesianConfigLegend,
-            series,
-        );
-
         // Use line icon only for line/area charts, otherwise use square with border radius
         const hasOnlyLineCharts = series.every(
             (s) =>
@@ -4358,12 +4452,33 @@ const useEchartsCartesianConfig = (
             hasOnlyLineCharts ? 'line' : 'square',
         );
 
-        return {
-            ...mergedLegendConfig,
-            ...legendStyle,
-            tooltip: legendDoubleClickTooltip,
-        };
+        const legendAreaWidth =
+            validCartesianConfig?.eChartsConfig.legend?.placement ===
+            'outsideLeft'
+                ? currentGrid.left
+                : currentGrid.right;
+        const outsideLabelWidth = getOutsideLegendLabelWidth(
+            chartWidth,
+            legendAreaWidth,
+            legendStyle,
+        );
+
+        const mergedLegendConfig = mergeLegendSettings(
+            validCartesianConfig?.eChartsConfig.legend,
+            validCartesianConfigLegend,
+            series,
+            outsideLabelWidth,
+        );
+
+        return composeLegendConfig(
+            mergedLegendConfig,
+            legendStyle,
+            legendDoubleClickTooltip,
+        );
     }, [
+        chartWidth,
+        currentGrid.left,
+        currentGrid.right,
         legendDoubleClickTooltip,
         validCartesianConfig?.eChartsConfig.legend,
         validCartesianConfigLegend,

--- a/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
+++ b/packages/frontend/src/hooks/echarts/useLegendDoubleClickTooltip.ts
@@ -1,5 +1,8 @@
 import { px, useMantineTheme } from '@mantine/core';
 
+export const LEGEND_INTERACTION_HINT =
+    'Click to toggle visibility. Double click to isolate';
+
 export const useLegendDoubleClickTooltip = () => {
     const theme = useMantineTheme();
 
@@ -17,9 +20,11 @@ export const useLegendDoubleClickTooltip = () => {
             },
             padding: [4, Number(px(theme.spacing.xs))],
             extraCssText: `box-shadow: ${theme.shadows.subtle};`,
-            formatter: () => {
-                return `Click to toggle visibility. Double click to isolate`;
-            },
+            formatter: () => LEGEND_INTERACTION_HINT,
         },
     };
 };
+
+export type LegendDoubleClickTooltip = ReturnType<
+    typeof useLegendDoubleClickTooltip
+>['tooltip'];


### PR DESCRIPTION
## Summary

Outside-left and outside-right legends were meant to truncate long series labels so the legend stays inside its reserved column, but the truncation never reached ECharts. In the memo that builds the final legend options, the shared legend typography from `getLegendStyle()` is spread after the merged legend settings, and its own `textStyle` object replaced the one carrying `overflow: 'truncate'` and `width`. The final `tooltip:` assignment replaced the overflow tooltip the same way. Long labels therefore grew leftwards into the plot, and widening the legend area only helped once it fit the longest label.

This PR:

- Composes the two layers explicitly (`composeLegendConfig`): the shared typography and the outside-placement truncation now coexist in one `textStyle`.
- Derives the label width from the measured chart width and the configured legend area (percent or px) instead of a fixed 150px, minus the legend margin, box padding, icon and icon gap, with a 40px floor. `SimpleChart` feeds the width from the resize observer it already runs; callers without a canvas (chart download, debug copy) keep the 150px fallback.
- Shows the full label above the existing "Click to toggle visibility. Double click to isolate" hint when hovering a truncated label, HTML-encoded via ECharts' encoder.

## Before / after

Same chart, 108 series with 55 to 70 character labels, legend placement Outside right, legend area 25%.

Half-width dashboard tile (1100px viewport):

| Before | After |
| --- | --- |
| ![before tile](https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-11174-legend-truncation/before_1100.png) | ![after tile](https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-11174-legend-truncation/after_1100.png) |

Full width (1600px viewport):

| Before | After |
| --- | --- |
| ![before wide](https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-11174-legend-truncation/before_1600.png) | ![after wide](https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-11174-legend-truncation/after_1600.png) |

Hovering a truncated label:

![hover tooltip](https://raw.githubusercontent.com/lightdash/lightdash/assets/prod-11174-legend-truncation/after_hover.png)

## Regression analysis

- **Default in-chart placement is byte-for-byte unchanged.** `composeLegendConfig` returns the same `textStyle` object contents as before and the very same tooltip object when the merged settings carry no truncation. Covered by a test.
- **Pie and funnel charts** use `useLegendDoubleClickTooltip` directly and are untouched; the hook only gained an exported constant and a type.
- **The existing `mergeLegendSettings` test asserted truncation at the helper level and passed while the bug shipped.** New tests cover the composition layer where the bug lived, plus the width derivation (percent, px, unitless, line icon, narrow-chart floor, unparsable input, unknown width).
- **Hook signature**: `useEchartsCartesianConfig` takes an optional third `chartWidth` (defaults to `null`). The two other callers are unchanged and get the fallback width.
- **Resize behaviour**: the width is stored as a rounded integer, so the observer only triggers a re-render when the canvas width actually changes; the observer callback still calls `resize()` exactly as before.
- **Legend area input** accepts `%` and `px`; both are parsed. Anything else falls back to 150px rather than breaking the legend.

## Verification

- `pnpm -F frontend test src/hooks/echarts/useEchartsCartesianConfig.test.ts`: 174 passed.
- `pnpm -F frontend typecheck`, oxlint and oxfmt clean on the changed files.
- Verified in the browser at 1100px and 1600px with the chart above, plus the hover tooltip.
- Reviewed twelve saved variants side by side against the unpatched frontend: outside right at 15%, 25%, 40% and 300px, outside left, vertical bars, a five-series line chart, a stacked area chart, short labels, and both in-chart placements (unchanged), at 700px, 1100px and 1600px, in dark mode, and on a dashboard with full, half, third and quarter-width tiles.

Closes: #29008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017H8p9PaMaSyYtmsoXsymMS
