### PR TITLE
fix: prevent custom chart loading flash in dark mode

### DIFF
--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -380,7 +380,8 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                     border: 'none',
                     colorScheme,
                     // Keep the host surface visible until the app applies its theme.
-                    visibility: loadedSrc === effectiveSrc ? 'visible' : 'hidden',
+                    visibility:
+                        loadedSrc === effectiveSrc ? 'visible' : 'hidden',
                 }}
                 title="App preview"
                 sandbox="allow-scripts allow-modals allow-downloads allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -247,6 +247,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 iframeNavigation.src,
             ],
         );
+        const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
         // Memoized so the bridge's message listener doesn't re-attach on every
         // parent render — AppGenerate re-renders on every keystroke (editor's
         // `onUpdate` → `setIsPromptEmpty`) and we don't want to thrash listeners.
@@ -357,6 +358,7 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
         // re-fire if `inspectorEnabled` was already true, so re-sync on load.
         const handleLoad = () => {
             handleIframeLoad();
+            setLoadedSrc(effectiveSrc);
             if (inspectorEnabled) enableInspector();
             if (lineageEnabled) enableLineage();
             highlightLineage(lineageHighlightQueryUuid ?? null);
@@ -372,7 +374,14 @@ const AppIframePreview = forwardRef<AppIframePreviewHandle, Props>(
                 data-tour-docs="data-apps.mdx#choosing-a-template:li1"
                 ref={iframeRef}
                 src={effectiveSrc}
-                style={{ width: '100%', height: '100%', border: 'none' }}
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    border: 'none',
+                    colorScheme,
+                    // Keep the host surface visible until the app applies its theme.
+                    visibility: loadedSrc === effectiveSrc ? 'visible' : 'hidden',
+                }}
                 title="App preview"
                 sandbox="allow-scripts allow-modals allow-downloads allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
                 allow=""


### PR DESCRIPTION
### Description:

Custom chart types can briefly paint a white iframe while loading in dark mode, before the app JavaScript applies the theme. Keep the preview iframe hidden until its current URL finishes loading, preserving its dimensions so the surrounding surface remains visible, and set its CSS color scheme from the resolved host/forced theme.

The fix lives in the shared app preview component, so it also applies to data app previews. Theme toggles and preview-token renewal retain the existing URL and do not hide or reload an already loaded preview.

### Validation:

- `git diff --check` passed.
- Attempted `pnpm -F frontend test src/features/apps/AppIframePreview.test.tsx`; blocked because dependencies are not installed (`vitest: command not found`).
- Browser verification remains pending.

### Risk assessment:

- [ ] This is a high-risk change

Small, reversible frontend change. Preview visibility now waits for the iframe load event; slow-loading resources can delay its appearance.
