### PR TITLE
fix(data-apps): scope SDK upgrade offers to the bundle kind

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -40,6 +40,8 @@ import {
     getCustomSqlFieldKey,
     getEffectiveFieldAiHints,
     getErrorMessage,
+    getSdkFeaturesForTarget,
+    getSdkFeatureTargetForTemplate,
     getVisibleDataAppClaudeModels,
     isChartTypeIcon,
     isDashboardChartTileType,
@@ -120,9 +122,11 @@ import {
     type RegistryChartTypeListItem,
     type RegistryChartTypeState,
     type SavedChart,
+    type SdkFeatureTarget,
     type SessionUser,
     type TogglePinnedItemInfo,
     type UpgradeAppRequestBody,
+    type UpgradeCandidateFeature,
 } from '@lightdash/common';
 import { generateObject } from 'ai';
 import { Knex } from 'knex';
@@ -6765,8 +6769,32 @@ export class AppGenerateService extends BaseService {
      * this composed instruction is what the pipeline actually sends —
      * mirrors the theme-change prompt pattern.
      */
-    private static buildUpgradePrompt(body: UpgradeAppRequestBody): string {
-        const candidates = (body.candidateFeatures ?? []).slice(0, 20);
+    /**
+     * The client computes candidates from its own registry, but the registry
+     * is the same for every bundle kind, so re-check applicability here: a
+     * chart type never gets query/Sheets/delivery features, an app never
+     * gets viz-context ones. Keys the registry does not know are dropped too.
+     */
+    private static applicableCandidateFeatures(
+        body: UpgradeAppRequestBody,
+        target: SdkFeatureTarget,
+    ): UpgradeCandidateFeature[] {
+        const applicableKeys = new Set(
+            getSdkFeaturesForTarget(target).map((f) => f.key),
+        );
+        return (body.candidateFeatures ?? [])
+            .filter((f) => applicableKeys.has(f.key))
+            .slice(0, 20);
+    }
+
+    private static buildUpgradePrompt(
+        body: UpgradeAppRequestBody,
+        target: SdkFeatureTarget,
+    ): string {
+        const candidates = AppGenerateService.applicableCandidateFeatures(
+            body,
+            target,
+        );
         const featureStep =
             candidates.length > 0
                 ? [
@@ -6809,7 +6837,10 @@ export class AppGenerateService extends BaseService {
     private static buildDataAppVizUpgradeStatusMessage(
         body: UpgradeAppRequestBody,
     ): string {
-        const candidates = (body.candidateFeatures ?? []).slice(0, 20);
+        const candidates = AppGenerateService.applicableCandidateFeatures(
+            body,
+            'chart_type',
+        );
         if (body.reportedFeatures === undefined) {
             return [
                 'Upgraded to the latest chart SDK.',
@@ -6937,6 +6968,7 @@ export class AppGenerateService extends BaseService {
         });
 
         const claudeEffort = resolveClaudeEffort(newVersion, app.template);
+        const sdkFeatureTarget = getSdkFeatureTargetForTemplate(app.template);
 
         await this.schedulerClient.appGeneratePipeline({
             appUuid,
@@ -6944,7 +6976,10 @@ export class AppGenerateService extends BaseService {
             projectUuid,
             organizationUuid: user.organizationUuid!,
             userUuid: user.userUuid,
-            prompt: AppGenerateService.buildUpgradePrompt(body),
+            prompt: AppGenerateService.buildUpgradePrompt(
+                body,
+                sdkFeatureTarget,
+            ),
             isIteration: true,
             isUpgrade: true,
             ...(app.template === DATA_APP_VIZ_TEMPLATE

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.upgrade.test.ts
@@ -228,7 +228,43 @@ describe('upgradeApp', () => {
         );
     });
 
-    it('preserves a chart type schema and queues a durable capability summary', async () => {
+    it('drops chart-type-only candidates from a data app upgrade', async () => {
+        const { service, schedulerClient } = buildService();
+
+        await service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {
+            reportedSdkVersion: '0.3400.0',
+            reportedFeatures: ['query'],
+            candidateFeatures: [
+                {
+                    key: 'viz-config-options',
+                    label: 'Visualization config options',
+                    description: 'Adjust the viz from the config panel.',
+                    wiring: 'Read options[name] from useVizContext().',
+                },
+                {
+                    key: 'gsheet-export',
+                    label: 'Google Sheets export',
+                    description: 'Export tabular results to Google Sheets.',
+                },
+                {
+                    key: 'not-a-registry-key',
+                    label: 'Made up',
+                    description: 'Not in the SDK registry.',
+                },
+            ],
+        });
+
+        const payload = schedulerClient.appGeneratePipeline.mock.calls[0][0];
+        expect(payload.prompt).toContain(
+            'gsheet-export: Google Sheets export — Export tabular results to Google Sheets.',
+        );
+        expect(payload.prompt).not.toContain('viz-config-options');
+        expect(payload.prompt).not.toContain('useVizContext');
+        expect(payload.prompt).not.toContain('not-a-registry-key');
+        expect(payload.upgradeStatusMessage).toBeUndefined();
+    });
+
+    it('preserves a chart type schema and queues a capability summary limited to chart-type features', async () => {
         const { service, appModel, schedulerClient } = buildService({
             template: 'data_app_viz',
         });
@@ -244,9 +280,20 @@ describe('upgradeApp', () => {
                     wiring: 'Pass metric filters to the query builder.',
                 },
                 {
+                    key: 'gsheet-export',
+                    label: 'Google Sheets export',
+                    description: 'Export tabular results to Google Sheets.',
+                },
+                {
                     key: 'screenshot',
                     label: 'In-app screenshots',
                     description: 'Capture this chart for deliveries.',
+                },
+                {
+                    key: 'viz-underlying-data',
+                    label: 'View underlying data',
+                    description: 'Open the rows behind a clicked data point.',
+                    wiring: 'Show the action menu when underlyingData.enabled.',
                 },
             ],
         });
@@ -260,11 +307,41 @@ describe('upgradeApp', () => {
             undefined,
             VIZ_SCHEMA,
         );
+        const payload = schedulerClient.appGeneratePipeline.mock.calls[0][0];
+        // Query and Sheets features never apply to a chart type: neither the
+        // durable summary nor the agent prompt may mention them.
+        expect(payload.upgradeStatusMessage).toBe(
+            'Upgraded to the latest chart SDK.\n\nNow active:\n\n- **In-app screenshots** — Capture this chart for deliveries.\n\nNewly available — ask me to add this in the prompt bar:\n\n- **View underlying data** — Open the rows behind a clicked data point.',
+        );
+        expect(payload.prompt).toContain('viz-underlying-data');
+        expect(payload.prompt).toContain('screenshot');
+        expect(payload.prompt).not.toContain('metric-filters');
+        expect(payload.prompt).not.toContain('gsheet-export');
+    });
+
+    it('treats a chart type whose only candidates are data-app features as already complete', async () => {
+        const { service, schedulerClient } = buildService({
+            template: 'data_app_viz',
+        });
+
+        await service.upgradeApp(makeUser(), PROJECT_UUID, APP_UUID, {
+            reportedSdkVersion: '1.68.0',
+            reportedFeatures: ['query'],
+            candidateFeatures: [
+                {
+                    key: 'metric-filters',
+                    label: 'Metric filters',
+                    description: 'Filter grouped results by metric values.',
+                    wiring: 'Pass metric filters to the query builder.',
+                },
+            ],
+        });
+
         expect(
             schedulerClient.appGeneratePipeline.mock.calls[0][0]
                 .upgradeStatusMessage,
         ).toBe(
-            'Upgraded to the latest chart SDK.\n\nNow active:\n\n- **In-app screenshots** — Capture this chart for deliveries.\n\nNewly available — ask me to add this in the prompt bar:\n\n- **Metric filters** — Filter grouped results by metric values.',
+            'Upgraded to the latest chart SDK. This chart already had all currently reported capabilities.',
         );
     });
 

--- a/packages/common/src/ee/apps/sdkFeatures.ts
+++ b/packages/common/src/ee/apps/sdkFeatures.ts
@@ -8,10 +8,27 @@
  * the dual dbt-YAML schemas.
  */
 
+import { DATA_APP_VIZ_TEMPLATE, type DataAppTemplate } from './types';
+
+/**
+ * Which kind of bundle a capability is meaningful for. Every bundle on a
+ * given SDK version reports the whole registry, so the host uses this to
+ * offer only what the app kind can use: a chart type never runs queries or
+ * exports to Sheets, an app never receives a viz context.
+ */
+export type SdkFeatureTarget = 'data_app' | 'chart_type';
+
+export const SDK_FEATURE_TARGETS: SdkFeatureTarget[] = [
+    'data_app',
+    'chart_type',
+];
+
 export type SdkFeature = {
     key: string;
     label: string;
     description: string;
+    /** Non-empty; features used by both kinds list both targets. */
+    appliesTo: SdkFeatureTarget[];
     /** Agent-facing note on the app-code wiring the feature needs before the
      *  host can use it (absent = zero wiring; it activates automatically once
      *  the bundle runs on a current SDK). Never rendered in user-facing UI. */
@@ -21,12 +38,14 @@ export type SdkFeature = {
 export const SDK_FEATURES: SdkFeature[] = [
     {
         key: 'query',
+        appliesTo: ['data_app'],
         label: 'Semantic layer queries',
         description:
             'Run metric and dimension queries against the Lightdash semantic layer.',
     },
     {
         key: 'metric-filters',
+        appliesTo: ['data_app'],
         label: 'Metric filters',
         description:
             'Filter grouped query results by metric values, including metrics used only as filters.',
@@ -34,24 +53,28 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'saved-chart',
+        appliesTo: ['data_app'],
         label: 'Saved chart queries',
         description:
             'Fetch results from existing saved charts instead of ad-hoc queries.',
     },
     {
         key: 'drill-down',
+        appliesTo: ['data_app'],
         label: 'Drill-down helper',
         description:
             'Derive drill-down queries from a clicked result row to build explore-style interactions.',
     },
     {
         key: 'inspect',
+        appliesTo: ['data_app'],
         label: 'Element inspection',
         description:
             'Lets the Lightdash editor highlight and select app elements to reference them in prompts.',
     },
     {
         key: 'lineage',
+        appliesTo: ['data_app'],
         label: 'Inspect data',
         description:
             'Click any chart to trace it back to the query and fields behind it, from the Inspect data button in the editor.',
@@ -59,36 +82,42 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'screenshot',
+        appliesTo: ['data_app', 'chart_type'],
         label: 'In-app screenshots',
         description:
             'Lets the host rasterize the app to an image for thumbnails and scheduled deliveries.',
     },
     {
         key: 'external-fetch',
+        appliesTo: ['data_app'],
         label: 'External data fetch',
         description:
             'Fetch approved external HTTP data sources through the Lightdash proxy.',
     },
     {
         key: 'gsheet-export',
+        appliesTo: ['data_app'],
         label: 'Google Sheets export',
         description:
             'Export tabular results from the app straight to Google Sheets.',
     },
     {
         key: 'url-state',
+        appliesTo: ['data_app'],
         label: 'Shareable URL state',
         description:
             'Sync in-app state to the page URL so app views can be shared and restored.',
     },
     {
         key: 'viz-context',
+        appliesTo: ['chart_type'],
         label: 'Dashboard visualization context',
         description:
             'Receive query context when app visualizations are embedded in dashboards.',
     },
     {
         key: 'viz-config-options',
+        appliesTo: ['chart_type'],
         label: 'Visualization config options',
         description:
             "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
@@ -96,6 +125,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-pivoted-results',
+        appliesTo: ['chart_type'],
         label: 'Pivoted results',
         description:
             'Render reusable charts and tables from backend-pivoted rows and their complete layout metadata.',
@@ -103,6 +133,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-resolved-colors',
+        appliesTo: ['chart_type'],
         label: 'Consistent visualization colors',
         description:
             'Honor model-defined colors and shared dashboard color assignments in reusable visualizations.',
@@ -110,6 +141,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'follow-host-theme',
+        appliesTo: ['data_app', 'chart_type'],
         label: 'Follow the host light/dark mode',
         description:
             "Match the light or dark mode of the viewer's Lightdash (or embed) instead of a fixed theme, and restyle live when they switch.",
@@ -117,6 +149,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'delivery-render',
+        appliesTo: ['data_app'],
         label: 'Full data in scheduled deliveries',
         description:
             "Scheduled deliveries and their preview render every tab or slide's data, not just the one currently visible.",
@@ -124,6 +157,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-underlying-data',
+        appliesTo: ['chart_type'],
         label: 'View underlying data',
         description:
             'Open the raw result rows behind a clicked data point in a reusable visualization, with CSV/XLSX download.',
@@ -131,6 +165,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-drill-down',
+        appliesTo: ['chart_type'],
         label: 'Drill into data points',
         description:
             'Drill into a clicked data point in a reusable visualization — pick a dimension in Lightdash and open the drilled view in explore.',
@@ -139,3 +174,20 @@ export const SDK_FEATURES: SdkFeature[] = [
 ];
 
 export const SDK_FEATURE_KEYS: string[] = SDK_FEATURES.map((f) => f.key);
+
+export const sdkFeatureAppliesTo = (
+    feature: Pick<SdkFeature, 'appliesTo'>,
+    target: SdkFeatureTarget,
+): boolean => feature.appliesTo.includes(target);
+
+/** The registry entries an upgrade may offer to a bundle of this kind. */
+export const getSdkFeaturesForTarget = (
+    target: SdkFeatureTarget,
+): SdkFeature[] => SDK_FEATURES.filter((f) => sdkFeatureAppliesTo(f, target));
+
+/** Custom chart types are the `data_app_viz` template; every other template
+ *  (including pre-template `null`) is a data app. */
+export const getSdkFeatureTargetForTemplate = (
+    template: DataAppTemplate | null | undefined,
+): SdkFeatureTarget =>
+    template === DATA_APP_VIZ_TEMPLATE ? 'chart_type' : 'data_app';

--- a/packages/frontend/src/features/apps/components/AppUpgradeModal.test.tsx
+++ b/packages/frontend/src/features/apps/components/AppUpgradeModal.test.tsx
@@ -9,24 +9,17 @@ vi.mock('../hooks/useUpgradeApp', () => ({
     useUpgradeApp: vi.fn(),
 }));
 
+const metricFilters = {
+    key: 'metric-filters',
+    label: 'Metric filters',
+    description: 'Filter grouped results by metric values.',
+    wiring: 'Pass metric filters to the query builder.',
+};
+
 const staleOffer: SdkUpgradeOffer = {
     status: 'stale',
-    newFeatures: [
-        {
-            key: 'metric-filters',
-            label: 'Metric filters',
-            description: 'Filter grouped results by metric values.',
-            wiring: 'Pass metric filters to the query builder.',
-        },
-    ],
-    candidateFeatures: [
-        {
-            key: 'metric-filters',
-            label: 'Metric filters',
-            description: 'Filter grouped results by metric values.',
-            wiring: 'Pass metric filters to the query builder.',
-        },
-    ],
+    newFeatures: [{ ...metricFilters, appliesTo: ['data_app'] }],
+    candidateFeatures: [{ ...metricFilters, appliesTo: ['data_app'] }],
     reportedSdkVersion: '1.68.0',
     reportedFeatures: ['query'],
 };
@@ -72,7 +65,8 @@ describe('AppUpgradeModal', () => {
                 body: {
                     reportedSdkVersion: '1.68.0',
                     reportedFeatures: ['query'],
-                    candidateFeatures: staleOffer.candidateFeatures,
+                    // Registry-only metadata (appliesTo) stays off the wire.
+                    candidateFeatures: [metricFilters],
                 },
             },
             expect.objectContaining({ onSuccess: expect.any(Function) }),

--- a/packages/frontend/src/features/apps/components/AppUpgradeModal.tsx
+++ b/packages/frontend/src/features/apps/components/AppUpgradeModal.tsx
@@ -47,7 +47,16 @@ const AppUpgradeModal: FC<Props> = ({
                         ? { reportedFeatures: offer.reportedFeatures }
                         : {}),
                     ...(offer.candidateFeatures.length > 0
-                        ? { candidateFeatures: offer.candidateFeatures }
+                        ? {
+                              candidateFeatures: offer.candidateFeatures.map(
+                                  ({ key, label, description, wiring }) => ({
+                                      key,
+                                      label,
+                                      description,
+                                      ...(wiring ? { wiring } : {}),
+                                  }),
+                              ),
+                          }
                         : {}),
                 },
             },

--- a/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.test.tsx
+++ b/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.test.tsx
@@ -1,10 +1,36 @@
-import { SDK_FEATURES } from '@lightdash/common';
+import {
+    getSdkFeaturesForTarget,
+    SDK_FEATURES,
+    type SdkFeatureTarget,
+} from '@lightdash/common';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useSdkUpgradeStatus } from './useSdkUpgradeStatus';
 
 const ALL_FEATURES = SDK_FEATURES.map(({ key }) => key);
 const MISSING_FIRST = SDK_FEATURES.slice(1).map(({ key }) => key);
+
+const APP_FEATURES = getSdkFeaturesForTarget('data_app');
+const CHART_TYPE_FEATURES = getSdkFeaturesForTarget('chart_type');
+const APP_ONLY_KEYS = APP_FEATURES.filter(
+    (f) => !f.appliesTo.includes('chart_type'),
+).map(({ key }) => key);
+const CHART_TYPE_ONLY_KEYS = CHART_TYPE_FEATURES.filter(
+    (f) => !f.appliesTo.includes('data_app'),
+).map(({ key }) => key);
+
+const renderStatus = (
+    target: SdkFeatureTarget,
+    bundleKey: string | null = 'app-1:1',
+) =>
+    renderHook(() =>
+        useSdkUpgradeStatus({
+            target,
+            bundleKey,
+            renderedKey: bundleKey,
+            isRendering: true,
+        }),
+    );
 
 describe('useSdkUpgradeStatus', () => {
     afterEach(() => {
@@ -15,6 +41,7 @@ describe('useSdkUpgradeStatus', () => {
         const { result, rerender } = renderHook(
             ({ bundleKey }) =>
                 useSdkUpgradeStatus({
+                    target: 'data_app',
                     bundleKey,
                     renderedKey: bundleKey,
                     isRendering: true,
@@ -45,26 +72,84 @@ describe('useSdkUpgradeStatus', () => {
         expect(result.current.offer.status).toBe('unknown');
     });
 
-    it('classifies a silent bundle as legacy', async () => {
+    it('classifies a silent bundle as legacy and offers only the applicable registry', async () => {
         vi.useFakeTimers();
-        const { result } = renderHook(() =>
-            useSdkUpgradeStatus({
-                bundleKey: 'app-1:1',
-                renderedKey: 'app-1:1',
-                isRendering: true,
-            }),
-        );
+        const { result } = renderStatus('chart_type');
 
         await act(async () => vi.advanceTimersByTime(5_000));
 
         expect(result.current.offer.status).toBe('legacy');
-        expect(result.current.offer.candidateFeatures).toEqual(SDK_FEATURES);
+        expect(result.current.offer.candidateFeatures).toEqual(
+            CHART_TYPE_FEATURES,
+        );
+    });
+
+    it('keeps a chart type current when it only lacks data-app features', () => {
+        expect(APP_ONLY_KEYS.length).toBeGreaterThan(0);
+        const { result } = renderStatus('chart_type');
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '1.0.0',
+                features: ALL_FEATURES.filter(
+                    (key) => !APP_ONLY_KEYS.includes(key),
+                ),
+            });
+        });
+
+        expect(result.current.offer.status).toBe('current');
+        expect(result.current.offer.newFeatures).toEqual([]);
+        expect(result.current.offer.candidateFeatures).toEqual([]);
+    });
+
+    it('keeps a data app current when it only lacks chart-type features', () => {
+        expect(CHART_TYPE_ONLY_KEYS.length).toBeGreaterThan(0);
+        const { result } = renderStatus('data_app');
+
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '1.0.0',
+                features: ALL_FEATURES.filter(
+                    (key) => !CHART_TYPE_ONLY_KEYS.includes(key),
+                ),
+            });
+        });
+
+        expect(result.current.offer.status).toBe('current');
+        expect(result.current.offer.newFeatures).toEqual([]);
+    });
+
+    it('offers a chart type only the missing features it can use', () => {
+        const { result } = renderStatus('chart_type');
+
+        // An old bundle predating every viz feature and Sheets export.
+        act(() => {
+            result.current.onSdkManifest({
+                sdkVersion: '1.0.0',
+                features: ALL_FEATURES.filter(
+                    (key) =>
+                        !CHART_TYPE_ONLY_KEYS.includes(key) &&
+                        key !== 'gsheet-export',
+                ),
+            });
+        });
+
+        expect(result.current.offer.status).toBe('stale');
+        const offeredKeys = result.current.offer.newFeatures.map(
+            ({ key }) => key,
+        );
+        expect(offeredKeys).toEqual(CHART_TYPE_ONLY_KEYS);
+        expect(offeredKeys).not.toContain('gsheet-export');
+        expect(result.current.offer.candidateFeatures).toEqual(
+            result.current.offer.newFeatures,
+        );
     });
 
     it('ignores manifests reported while another version is on screen', () => {
         const { result, rerender } = renderHook(
             ({ isRendering }) =>
                 useSdkUpgradeStatus({
+                    target: 'data_app',
                     bundleKey: 'app-1:3',
                     renderedKey: 'app-1:3',
                     isRendering,
@@ -101,6 +186,7 @@ describe('useSdkUpgradeStatus', () => {
         const { result, rerender } = renderHook(
             ({ renderedKey }) =>
                 useSdkUpgradeStatus({
+                    target: 'data_app',
                     bundleKey: 'app-1:3',
                     renderedKey,
                     isRendering: renderedKey === 'app-1:3',
@@ -127,6 +213,7 @@ describe('useSdkUpgradeStatus', () => {
         vi.useFakeTimers();
         const { result } = renderHook(() =>
             useSdkUpgradeStatus({
+                target: 'data_app',
                 bundleKey: 'app-1:3',
                 renderedKey: 'app-1:2',
                 isRendering: false,

--- a/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.ts
+++ b/packages/frontend/src/features/apps/hooks/useSdkUpgradeStatus.ts
@@ -1,4 +1,8 @@
-import { SDK_FEATURES, type SdkFeature } from '@lightdash/common';
+import {
+    getSdkFeaturesForTarget,
+    type SdkFeature,
+    type SdkFeatureTarget,
+} from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { type SdkManifest } from './useAppSdkBridge';
 
@@ -32,12 +36,19 @@ export type SdkUpgradeOffer = {
  * The offer always describes the version an upgrade would actually rebuild
  * from — `upgradeApp` restores the latest ready source regardless of what the
  * user is previewing — so manifests from any other version are ignored.
+ *
+ * Only registry entries that apply to `target` count: every bundle reports
+ * the whole SDK registry, so a chart type is not stale for lacking Sheets
+ * export, and an app is not stale for lacking viz-context features.
  */
 export const useSdkUpgradeStatus = ({
+    target,
     bundleKey,
     renderedKey,
     isRendering,
 }: {
+    /** Which kind of bundle is being classified. */
+    target: SdkFeatureTarget;
     /** Identity (app + version) of the bundle the offer describes: the latest
      *  ready version, never the one the user happens to be viewing. A change
      *  resets the manifest so the new bundle re-reports rather than inheriting
@@ -88,13 +99,12 @@ export const useSdkUpgradeStatus = ({
     }, []);
 
     const offer = useMemo<SdkUpgradeOffer>(() => {
+        const registry = getSdkFeaturesForTarget(target);
         if (manifest) {
             const reported = new Set(manifest.features);
             // Additions only: keys the bundle reports that the current
             // registry no longer has (removed features) are ignored.
-            const newFeatures = SDK_FEATURES.filter(
-                (f) => !reported.has(f.key),
-            );
+            const newFeatures = registry.filter((f) => !reported.has(f.key));
             return {
                 status: newFeatures.length > 0 ? 'stale' : 'current',
                 newFeatures,
@@ -106,11 +116,11 @@ export const useSdkUpgradeStatus = ({
         return {
             status: timedOut ? 'legacy' : 'unknown',
             newFeatures: [],
-            candidateFeatures: timedOut ? [...SDK_FEATURES] : [],
+            candidateFeatures: timedOut ? registry : [],
             reportedSdkVersion: null,
             reportedFeatures: null,
         };
-    }, [manifest, timedOut]);
+    }, [manifest, timedOut, target]);
 
     /** What the bundle on screen reports, whichever version that is. Answers
      *  "can the app I am looking at do X?" — a different question from the

--- a/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
+++ b/packages/frontend/src/features/chartTypes/builder/useChartTypeBuilderWorkspace.ts
@@ -231,6 +231,7 @@ export const useChartTypeBuilderWorkspace = ({
 
     const previewVersion = viewedVersion ?? history.latestReadyVersion;
     const { offer: sdkUpgradeOffer, onSdkManifest } = useSdkUpgradeStatus({
+        target: 'chart_type',
         bundleKey:
             dataAppVizUuid && history.latestReadyVersion !== null
                 ? `${dataAppVizUuid}:${history.latestReadyVersion}`

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3,6 +3,7 @@ import {
     ChartKind,
     DATA_APP_VIZ_TEMPLATE,
     FeatureFlags,
+    getSdkFeatureTargetForTemplate,
     isApiError,
     isAppVersionInProgress,
     MAX_APP_FILES_PER_VERSION,
@@ -1066,6 +1067,7 @@ const AppGenerate: FC = () => {
         renderedManifest: renderedSdkManifest,
         onSdkManifest: handleSdkManifest,
     } = useSdkUpgradeStatus({
+        target: getSdkFeatureTargetForTemplate(appPersistedTemplate),
         bundleKey:
             activeAppUuid && latestReadyVersion !== null
                 ? `${activeAppUuid}:${latestReadyVersion.version}`

--- a/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
+++ b/packages/frontend/src/pages/ChartTypeBuilder.test.tsx
@@ -3,6 +3,7 @@ import {
     FeatureFlags,
     type ApiAppVersionSummary,
     type ApiGetAppResponse,
+    type SdkFeature,
 } from '@lightdash/common';
 import { fireEvent, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
@@ -15,7 +16,10 @@ import { useCanCreateDataApp } from '../features/apps/hooks/useCanCreateDataApp'
 import { useCanEditDataApp } from '../features/apps/hooks/useCanEditDataApp';
 import { useClarificationRound } from '../features/apps/hooks/useClarificationRound';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
-import { useSdkUpgradeStatus } from '../features/apps/hooks/useSdkUpgradeStatus';
+import {
+    useSdkUpgradeStatus,
+    type SdkUpgradeOffer,
+} from '../features/apps/hooks/useSdkUpgradeStatus';
 import { useUpgradeApp } from '../features/apps/hooks/useUpgradeApp';
 import { appVersion } from '../features/apps/testing/appVersionHistory';
 import { useDataAppVisualization } from '../features/chartTypes/hooks/useDataAppVisualization';
@@ -250,26 +254,20 @@ const mockedClarificationRound = vi.mocked(
     useClarificationRound<VizBuildRequest>,
 );
 
-const staleUpgradeOffer = {
-    status: 'stale' as const,
-    newFeatures: [
-        {
-            key: 'metric-filters',
-            label: 'Metric filters',
-            description: 'Filter grouped results by metric values.',
-            wiring: 'Pass metric filters to the query builder.',
-        },
-    ],
-    candidateFeatures: [
-        {
-            key: 'metric-filters',
-            label: 'Metric filters',
-            description: 'Filter grouped results by metric values.',
-            wiring: 'Pass metric filters to the query builder.',
-        },
-    ],
+const underlyingDataFeature: SdkFeature = {
+    key: 'viz-underlying-data',
+    label: 'View underlying data',
+    description: 'Open the raw result rows behind a clicked data point.',
+    appliesTo: ['chart_type'],
+    wiring: 'Show the action menu when underlyingData.enabled.',
+};
+
+const staleUpgradeOffer: SdkUpgradeOffer = {
+    status: 'stale',
+    newFeatures: [underlyingDataFeature],
+    candidateFeatures: [underlyingDataFeature],
     reportedSdkVersion: '1.68.0',
-    reportedFeatures: ['query'],
+    reportedFeatures: ['viz-context'],
 };
 
 describe('ChartTypeBuilder', () => {
@@ -796,6 +794,7 @@ describe('ChartTypeBuilder', () => {
             vi.mocked(useSdkUpgradeStatus).mock.lastCall?.[0];
 
         expect(keyedToLatestReady()).toEqual({
+            target: 'chart_type',
             bundleKey: 'viz-1:2',
             renderedKey: 'viz-1:2',
             isRendering: true,
@@ -807,6 +806,7 @@ describe('ChartTypeBuilder', () => {
         // An upgrade always rebuilds from v2, so the offer keeps describing
         // it; the v1 bundle on screen must not be classified in its place.
         expect(keyedToLatestReady()).toEqual({
+            target: 'chart_type',
             bundleKey: 'viz-1:2',
             renderedKey: 'viz-1:1',
             isRendering: false,

--- a/packages/query-sdk/CLAUDE.md
+++ b/packages/query-sdk/CLAUDE.md
@@ -17,14 +17,20 @@ manifest automatically on creation.
 compared against the current SDK — an unregistered feature is invisible to
 upgrade detection and the "What's new" UI, so old apps will never be offered it.
 
-1. Add an entry `{ key, label, description }` to `SDK_FEATURES`. The `key` is a
-   stable kebab-case identifier (never rename it — deployed bundles report it
-   forever). `label`/`description` render verbatim in the host's What's-new UI
-   and guide the upgrade agent's offer, so write the description as "what it
-   enables + when to want it". The `label` must match what users see in the
-   host UI (e.g. the `lineage` key is labelled "Inspect data" — the button's
-   name), or upgrade-agent conversations can't connect the user's words to the
-   feature.
+1. Add an entry `{ key, label, description, appliesTo }` to `SDK_FEATURES`. The
+   `key` is a stable kebab-case identifier (never rename it — deployed bundles
+   report it forever). `label`/`description` render verbatim in the host's
+   What's-new UI and guide the upgrade agent's offer, so write the description
+   as "what it enables + when to want it". The `label` must match what users
+   see in the host UI (e.g. the `lineage` key is labelled "Inspect data" — the
+   button's name), or upgrade-agent conversations can't connect the user's
+   words to the feature. `appliesTo` says which bundle kinds can use the
+   feature — `'data_app'`, `'chart_type'`, or both. Every bundle reports the
+   whole registry, so this is what stops a chart type being offered Sheets
+   export, or an app being offered `useVizContext()` features. Chart types run
+   no queries and fetch nothing (see the `reusable-visualization` skill), so
+   anything on the query builder, `externalFetch`, URL state or deliveries is
+   `['data_app']`; anything read from `useVizContext()` is `['chart_type']`.
 2. If the feature needs app-code wiring before the host can use it (e.g.
    `lineage` needs `data-ld-query` stamps on chart roots), say exactly how in
    the optional `wiring` field. It is agent-facing only — never rendered in

--- a/packages/query-sdk/src/features.test.ts
+++ b/packages/query-sdk/src/features.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     SDK_FEATURE_KEYS,
+    SDK_FEATURE_TARGETS,
     SDK_FEATURES,
     SDK_MANIFEST_MESSAGE_TYPE,
 } from './features';
@@ -28,6 +29,21 @@ describe('SDK_FEATURES registry', () => {
             expect(feature.description.trim().length).toBeGreaterThan(0);
         }
         expect(SDK_FEATURE_KEYS).toEqual(keys);
+    });
+
+    it('declares at least one known target per feature, without duplicates', () => {
+        for (const feature of SDK_FEATURES) {
+            expect(
+                feature.appliesTo.length,
+                `${feature.key} must apply to at least one target`,
+            ).toBeGreaterThan(0);
+            expect(new Set(feature.appliesTo).size).toEqual(
+                feature.appliesTo.length,
+            );
+            for (const target of feature.appliesTo) {
+                expect(SDK_FEATURE_TARGETS).toContain(target);
+            }
+        }
     });
 
     it('covers every *:available message literal in the SDK source (drift guard)', () => {

--- a/packages/query-sdk/src/features.ts
+++ b/packages/query-sdk/src/features.ts
@@ -8,10 +8,25 @@
  * stable identifiers; label/description feed the host's "What's new" UI.
  */
 
+/**
+ * Which kind of bundle a capability is meaningful for. Every bundle on a
+ * given SDK version reports the whole registry, so the host uses this to
+ * offer only what the app kind can use: a chart type never runs queries or
+ * exports to Sheets, an app never receives a viz context.
+ */
+export type SdkFeatureTarget = 'data_app' | 'chart_type';
+
+export const SDK_FEATURE_TARGETS: SdkFeatureTarget[] = [
+    'data_app',
+    'chart_type',
+];
+
 export type SdkFeature = {
     key: string;
     label: string;
     description: string;
+    /** Non-empty; features used by both kinds list both targets. */
+    appliesTo: SdkFeatureTarget[];
     /** Agent-facing note on the app-code wiring the feature needs before the
      *  host can use it (absent = zero wiring; it activates automatically once
      *  the bundle runs on a current SDK). Never rendered in user-facing UI. */
@@ -21,12 +36,14 @@ export type SdkFeature = {
 export const SDK_FEATURES: SdkFeature[] = [
     {
         key: 'query',
+        appliesTo: ['data_app'],
         label: 'Semantic layer queries',
         description:
             'Run metric and dimension queries against the Lightdash semantic layer.',
     },
     {
         key: 'metric-filters',
+        appliesTo: ['data_app'],
         label: 'Metric filters',
         description:
             'Filter grouped query results by metric values, including metrics used only as filters.',
@@ -34,24 +51,28 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'saved-chart',
+        appliesTo: ['data_app'],
         label: 'Saved chart queries',
         description:
             'Fetch results from existing saved charts instead of ad-hoc queries.',
     },
     {
         key: 'drill-down',
+        appliesTo: ['data_app'],
         label: 'Drill-down helper',
         description:
             'Derive drill-down queries from a clicked result row to build explore-style interactions.',
     },
     {
         key: 'inspect',
+        appliesTo: ['data_app'],
         label: 'Element inspection',
         description:
             'Lets the Lightdash editor highlight and select app elements to reference them in prompts.',
     },
     {
         key: 'lineage',
+        appliesTo: ['data_app'],
         label: 'Inspect data',
         description:
             'Click any chart to trace it back to the query and fields behind it, from the Inspect data button in the editor.',
@@ -59,36 +80,42 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'screenshot',
+        appliesTo: ['data_app', 'chart_type'],
         label: 'In-app screenshots',
         description:
             'Lets the host rasterize the app to an image for thumbnails and scheduled deliveries.',
     },
     {
         key: 'external-fetch',
+        appliesTo: ['data_app'],
         label: 'External data fetch',
         description:
             'Fetch approved external HTTP data sources through the Lightdash proxy.',
     },
     {
         key: 'gsheet-export',
+        appliesTo: ['data_app'],
         label: 'Google Sheets export',
         description:
             'Export tabular results from the app straight to Google Sheets.',
     },
     {
         key: 'url-state',
+        appliesTo: ['data_app'],
         label: 'Shareable URL state',
         description:
             'Sync in-app state to the page URL so app views can be shared and restored.',
     },
     {
         key: 'viz-context',
+        appliesTo: ['chart_type'],
         label: 'Dashboard visualization context',
         description:
             'Receive query context when app visualizations are embedded in dashboards.',
     },
     {
         key: 'viz-config-options',
+        appliesTo: ['chart_type'],
         label: 'Visualization config options',
         description:
             "Let viewers adjust the visualization from the Lightdash config panel — toggles, dropdowns, numbers, text and colours — and take series colours from the chart's palette, without regenerating the app.",
@@ -96,6 +123,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-pivoted-results',
+        appliesTo: ['chart_type'],
         label: 'Pivoted results',
         description:
             'Render reusable charts and tables from backend-pivoted rows and their complete layout metadata.',
@@ -103,6 +131,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-resolved-colors',
+        appliesTo: ['chart_type'],
         label: 'Consistent visualization colors',
         description:
             'Honor model-defined colors and shared dashboard color assignments in reusable visualizations.',
@@ -110,6 +139,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'follow-host-theme',
+        appliesTo: ['data_app', 'chart_type'],
         label: 'Follow the host light/dark mode',
         description:
             "Match the light or dark mode of the viewer's Lightdash (or embed) instead of a fixed theme, and restyle live when they switch.",
@@ -117,6 +147,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'delivery-render',
+        appliesTo: ['data_app'],
         label: 'Full data in scheduled deliveries',
         description:
             "Scheduled deliveries and their preview render every tab or slide's data, not just the one currently visible.",
@@ -124,6 +155,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-underlying-data',
+        appliesTo: ['chart_type'],
         label: 'View underlying data',
         description:
             'Open the raw result rows behind a clicked data point in a reusable visualization, with CSV/XLSX download.',
@@ -131,6 +163,7 @@ export const SDK_FEATURES: SdkFeature[] = [
     },
     {
         key: 'viz-drill-down',
+        appliesTo: ['chart_type'],
         label: 'Drill into data points',
         description:
             'Drill into a clicked data point in a reusable visualization — pick a dimension in Lightdash and open the drilled view in explore.',

--- a/packages/query-sdk/src/index.ts
+++ b/packages/query-sdk/src/index.ts
@@ -22,8 +22,10 @@ export { createPostMessageTransport } from './postMessageTransport';
 export {
     SDK_FEATURES,
     SDK_FEATURE_KEYS,
+    SDK_FEATURE_TARGETS,
     SDK_MANIFEST_MESSAGE_TYPE,
     type SdkFeature,
+    type SdkFeatureTarget,
     type SdkManifestMessage,
 } from './features';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes: GLITCH-779

### Problem

Data apps and custom chart types share one SDK feature registry, and every bundle reports the whole registry in its manifest. The upgrade flow read that flat list as "what this app kind can do", so:

- Chart types were offered query, Sheets export, delivery and other app-only features they can never use, and the upgrade status message listed some of them as **Now active**.
- Data apps were offered the `viz-*` features that only work inside a chart type.
- Either kind was nagged to upgrade whenever *any* registry key was missing, applicable or not.

### Fix

Each registry entry now says which bundle kinds it applies to, and every consumer only looks at the applicable subset.

- `SdkFeature.appliesTo` is set for all 18 entries in the SDK registry and its common mirror (10 data-app-only, 6 chart-type-only, 2 both). The existing mirror-sync test covers it, plus a new test that every entry has a known, non-empty target.
- `useSdkUpgradeStatus` takes a `target`. A bundle missing only inapplicable features is `current`, not `stale`. The data-app editor derives the target from the persisted template; the chart-type builder passes `chart_type`.
- `AppGenerateService` re-filters the client's candidate list from the app's template before building the agent prompt or the chart-type status message, and drops unknown keys.
- The upgrade modal strips `appliesTo` from the request, so the API contract is unchanged.

No API, schema or migration changes. The manifest protocol is untouched: bundles still report the full registry.

### Screenshots

Tested on a local stack with simulated manifests, since no bundle in the dev DB reports a partial one.

**Chart type missing the six viz features plus Sheets export and delivery render.** Only the six viz features are offered.

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/3e716fd0-7b59-432b-abf1-4873e546a357" />

**Data app missing Inspect data plus the six viz features.** Only Inspect data is offered.

<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/70d87447-e1e2-456d-ada2-eea2f7dc44f0" />

### Risk assessment

- [ ] This is a high-risk change

Low risk: host-side interpretation only, reversible, covered by unit tests in `features.test.ts`, `useSdkUpgradeStatus.test.tsx`, `AppUpgradeModal.test.tsx` and `AppGenerateService.upgrade.test.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a08fc7-8e9d-7799-a512-99b9d97710ff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a08fc7-8e9d-7799-a512-99b9d97710ff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

