### PR TITLE
fix(underlying-data): only include unnested tables the source query reached

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.test.ts
@@ -3,6 +3,7 @@ import {
     FieldType,
     MetricType,
     type CompiledExploreJoin,
+    type CompiledTable,
     type Dimension,
     type Explore,
     type ItemsMap,
@@ -17,9 +18,67 @@ const join = (table: string): CompiledExploreJoin => ({
     compiledSqlOn: `("customers".customer_id) = ("${table}".customer_id)`,
 });
 
-const customersExplore: Pick<Explore, 'baseTable' | 'joinedTables'> = {
-    baseTable: 'customers',
-    joinedTables: [join('orders'), join('payments')],
+const table = (
+    name: string,
+    nestedFrom?: CompiledTable['nestedFrom'],
+): CompiledTable => ({
+    name,
+    label: name,
+    database: 'db',
+    schema: 'schema',
+    sqlTable: `"${name}"`,
+    dimensions: {},
+    metrics: {},
+    lineageGraph: {},
+    ...(nestedFrom ? { nestedFrom } : {}),
+});
+
+const customersExplore: Pick<Explore, 'baseTable' | 'joinedTables' | 'tables'> =
+    {
+        baseTable: 'customers',
+        joinedTables: [join('orders'), join('payments')],
+        tables: {
+            customers: table('customers'),
+            orders: table('orders'),
+            payments: table('payments'),
+        },
+    };
+
+const nestedExplore: Pick<Explore, 'baseTable' | 'joinedTables' | 'tables'> = {
+    baseTable: 'orders',
+    joinedTables: [
+        join('customers'),
+        join('orders__line_items'),
+        join('orders__line_items__discounts'),
+        join('orders__tags'),
+    ],
+    tables: {
+        orders: table('orders'),
+        customers: table('customers'),
+        orders__line_items: table('orders__line_items', {
+            parentTable: 'orders',
+            columnPath: 'line_items',
+        }),
+        orders__line_items__discounts: table('orders__line_items__discounts', {
+            parentTable: 'orders__line_items',
+            columnPath: 'discounts',
+        }),
+        orders__tags: table('orders__tags', {
+            parentTable: 'orders',
+            columnPath: 'tags',
+        }),
+    },
+};
+
+const discountCode: Dimension = {
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: 'code',
+    label: 'Code',
+    table: 'orders__line_items__discounts',
+    tableLabel: 'Orders: Line items: Discounts',
+    sql: '${TABLE}.code',
+    hidden: false,
 };
 
 const ordersFulfillmentRate: Metric = {
@@ -102,5 +161,27 @@ describe('getUnderlyingDataAvailableTables', () => {
         );
 
         expect([...tables]).toEqual(['customers', 'orders', 'payments']);
+    });
+
+    it('leaves out unnested virtual tables the source query did not reach', () => {
+        const fields: ItemsMap = {
+            orders_fulfillment_rate: ordersFulfillmentRate,
+        };
+
+        const tables = getUnderlyingDataAvailableTables(nestedExplore, fields);
+
+        expect([...tables]).toEqual(['orders', 'customers']);
+    });
+
+    it('includes a queried unnested table and its unnested ancestors', () => {
+        const fields: ItemsMap = {
+            orders__line_items__discounts_code: discountCode,
+        };
+
+        const tables = getUnderlyingDataAvailableTables(nestedExplore, fields);
+
+        expect(tables.has('orders__line_items__discounts')).toBe(true);
+        expect(tables.has('orders__line_items')).toBe(true);
+        expect(tables.has('orders__tags')).toBe(false);
     });
 });

--- a/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
+++ b/packages/backend/src/services/AsyncQueryService/getUnderlyingDataAvailableTables.ts
@@ -1,14 +1,40 @@
 import { isField, type Explore, type ItemsMap } from '@lightdash/common';
 
-// The base table is always in the FROM clause, so it is always available.
+const nestedAncestors = (
+    tables: Explore['tables'],
+    table: string,
+): string[] => {
+    const parent = tables[table]?.nestedFrom?.parentTable;
+    return parent ? [parent, ...nestedAncestors(tables, parent)] : [];
+};
+
+// Unnested virtual tables multiply rows, so only the ones the source query
+// already reached (and their ancestors) belong in the underlying rows; the
+// rest would cross-join every sibling array into the result.
 export const getUnderlyingDataAvailableTables = (
-    explore: Pick<Explore, 'baseTable' | 'joinedTables'>,
+    explore: Pick<Explore, 'baseTable' | 'joinedTables' | 'tables'>,
     metricQueryFields: ItemsMap,
-): Set<string> =>
-    new Set([
+): Set<string> => {
+    const isNested = (table: string) =>
+        explore.tables[table]?.nestedFrom !== undefined;
+    const queriedTables = Object.values(metricQueryFields)
+        .filter(isField)
+        .map((field) => field.table);
+    const reachedNestedTables = new Set(
+        queriedTables
+            .filter(isNested)
+            .flatMap((table) => [
+                table,
+                ...nestedAncestors(explore.tables, table),
+            ]),
+    );
+    return new Set([
         explore.baseTable,
-        ...explore.joinedTables.map((joinedTable) => joinedTable.table),
-        ...Object.values(metricQueryFields)
-            .filter(isField)
-            .map((field) => field.table),
+        ...explore.joinedTables
+            .map((joinedTable) => joinedTable.table)
+            .filter(
+                (table) => !isNested(table) || reachedNestedTables.has(table),
+            ),
+        ...queriedTables,
     ]);
+};


### PR DESCRIPTION
"View underlying data" collects dimensions from every joined table in the explore. With repeated columns unnested into virtual tables, that meant every array on the model, and on every aliased join of it, was unnested at once: on the GA sample a session's hits, products, custom dimensions and channel words were cross-joined into one result, with the fan-out warning attached to a view the user never asked to build that way. The view now keeps only the unnested tables the source query already reached, and their ancestors, so the underlying rows keep the grain of the number that was clicked.

Closes: #7905
