### PR TITLE
fix(chart-registry): detail modal screenshots fit the modal and follow the scheme

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.module.css
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.module.css
@@ -19,15 +19,11 @@
     object-fit: cover;
 }
 
-.screenshotRow {
-    display: flex;
-    gap: var(--mantine-spacing-sm);
-}
-
+/* Screenshots fit the modal width and keep their natural aspect ratio —
+   the modal must never grow with (or side-scroll for) a wide capture. */
 .screenshot {
-    height: 220px;
-    flex-shrink: 0;
+    width: 100%;
+    height: auto;
     border: 1px solid var(--mantine-color-ldGray-1);
     border-radius: var(--mantine-radius-md);
-    object-fit: cover;
 }

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -3,15 +3,7 @@ import {
     assertUnreachable,
     type RegistryChartTypeListItem,
 } from '@lightdash/common';
-import {
-    Box,
-    Button,
-    Group,
-    ScrollArea,
-    SimpleGrid,
-    Stack,
-    Text,
-} from '@mantine/core';
+import { Box, Button, Group, SimpleGrid, Stack, Text } from '@mantine/core';
 import { IconPhoto } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
 import Callout from '../../../components/common/Callout';
@@ -49,6 +41,14 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
     const { track } = useTracking();
     const { colorScheme } = useAppColorScheme();
     const thumbnail = registryThumbnailPath(item, colorScheme);
+    // screenshots[0] is the thumbnail by registry convention — swap it for
+    // the dark variant when the app is in dark mode.
+    const screenshots =
+        colorScheme === 'dark' &&
+        item.thumbnailDark &&
+        item.screenshots.length > 0
+            ? [item.thumbnailDark, ...item.screenshots.slice(1)]
+            : item.screenshots;
 
     const handleInstall = () => {
         track({
@@ -136,23 +136,17 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
             {...footerProps}
         >
             <Stack gap="md">
-                {item.screenshots.length > 0 ? (
-                    <ScrollArea type="auto" offsetScrollbars>
-                        <Group
-                            gap="sm"
-                            wrap="nowrap"
-                            className={classes.screenshotRow}
-                        >
-                            {item.screenshots.map((path) => (
-                                <img
-                                    key={path}
-                                    src={registryAssetUrl(path)}
-                                    alt={item.name}
-                                    className={classes.screenshot}
-                                />
-                            ))}
-                        </Group>
-                    </ScrollArea>
+                {screenshots.length > 0 ? (
+                    <Stack gap="sm">
+                        {screenshots.map((path) => (
+                            <img
+                                key={path}
+                                src={registryAssetUrl(path)}
+                                alt={item.name}
+                                className={classes.screenshot}
+                            />
+                        ))}
+                    </Stack>
                 ) : thumbnail ? (
                     <Box className={classes.preview}>
                         <img


### PR DESCRIPTION
## What

Two fixes to the chart type library detail modal, following up #29045 (merged):

1. **No more side-scrolling.** Screenshots rendered in a fixed-220px-height horizontal scroll row, so a wide capture (the new card-ratio thumbnails are 2560×592) forced the modal to grow/side-scroll. They now stack vertically at natural aspect, fitted to the modal width — the modal never grows with an image; tall content scrolls vertically via the modal body as before.

2. **Dark mode shows the dark capture.** The screenshot row always rendered the light `screenshots` list; only the no-screenshots fallback was scheme-aware. Since `screenshots[0]` is the thumbnail by registry convention, it's now swapped for `thumbnailDark` when the app scheme is dark and the chart publishes one.

## Verification

Frontend typecheck clean. Verified in the browser against the live registry (agent-harness stack): dark-mode cartesian modal shows the dark capture fitted to the modal width with no horizontal scroll; charts without a dark variant fall back to their light screenshots unchanged.

Relates: GLITCH-714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN