### PR TITLE
fix(formatting): serialise struct and array cells as JSON instead of [object Object]

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1301,6 +1301,21 @@ describe('Formatting', () => {
             expect(formatItemValue(undefined, 5)).toEqual('5');
         });
 
+        test('formatItemValue serialises a structured cell of a string dimension as JSON', () => {
+            expect(
+                formatItemValue(
+                    { ...dimension, type: DimensionType.STRING },
+                    { city: 'NYC', tags: ['gift'] },
+                ),
+            ).toEqual('{"city":"NYC","tags":["gift"]}');
+            expect(
+                formatItemValue({ ...dimension, type: DimensionType.STRING }, [
+                    'gift',
+                    'rush',
+                ]),
+            ).toEqual('["gift","rush"]');
+        });
+
         test('formatItemValue should return the right format when field is Dimension', () => {
             expect(formatItemValue(dimension, undefined)).toEqual('-');
             expect(formatItemValue(dimension, null)).toEqual('∅');
@@ -2754,6 +2769,15 @@ describe('Formatting', () => {
         });
         it('should handle strings', () => {
             expect(applyDefaultFormat('foo')).toBe('foo');
+        });
+        it('serialises objects and arrays as JSON', () => {
+            expect(applyDefaultFormat({ sku: 'A1', qty: 2 })).toBe(
+                '{"sku":"A1","qty":2}',
+            );
+            expect(applyDefaultFormat(['gift', 'rush'])).toBe(
+                '["gift","rush"]',
+            );
+            expect(applyDefaultFormat([])).toBe('[]');
         });
         it('should handle numbers', () => {
             expect(applyDefaultFormat(1234567)).toBe('1,234,567');

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import dayjsTimezone from 'dayjs/plugin/timezone';
+import isPlainObject from 'lodash/isPlainObject';
 import moment, { type MomentInput } from 'moment-timezone';
 import {
     addLocale,
@@ -532,9 +533,20 @@ export function formatNumberValue(
     }
 }
 
+// Warehouse clients that don't serialise STRUCT/ARRAY cells hand over plain
+// objects and arrays; template-string coercion would print [object Object].
+const isStructuredValue = (value: unknown): boolean =>
+    Array.isArray(value) || isPlainObject(value);
+
+const formatStructuredValue = (value: unknown): string =>
+    isStructuredValue(value) ? JSON.stringify(value) : `${value}`;
+
 export function applyDefaultFormat(value: unknown) {
     if (value === null) return '∅';
     if (value === undefined) return '-';
+    // Before the number check: Number([]) is 0, so an empty array would
+    // otherwise format as a blank number.
+    if (isStructuredValue(value)) return JSON.stringify(value);
     if (!isNumber(value)) {
         return `${value}`;
     }
@@ -1464,7 +1476,7 @@ export function formatItemValue(
                 case TableCalculationType.STRING:
                 case DimensionType.STRING:
                 case MetricType.STRING:
-                    return `${value}`;
+                    return formatStructuredValue(value);
                 case DimensionType.BOOLEAN:
                 case MetricType.BOOLEAN:
                 case TableCalculationType.BOOLEAN:


### PR DESCRIPTION
A struct or array cell that reaches the formatter as a plain object, which is what every warehouse client except BigQuery hands over for nested columns, was coerced with a template string and came out as `[object Object]` in the formatted value, CSV and Excel exports and scheduled deliveries. The results table hid it by rendering the raw value through the JSON viewer, so the file was the first place anyone saw it. Structured cells are now serialised as the same JSON text the table shows. An empty array also used to pass the numeric check as zero and format as a blank.

Closes: PROD-11047
