### PR TITLE
fix: explain when analytics data is not available yet

### DIFF
--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.test.ts
@@ -1,5 +1,8 @@
 import { GetObjectCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { DuckDBInstance } from '@duckdb/node-api';
+import { ParameterError } from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
 import { createS3ClientFromConfig } from '../../../clients/Aws/S3BaseClient';
 import { createS3AnalyticsSourceResolver } from './S3AnalyticsSource';
 
@@ -7,6 +10,10 @@ vi.mock('../../../clients/Aws/S3BaseClient', () => ({
     createS3ClientFromConfig: vi.fn(),
 }));
 vi.mock('@aws-sdk/s3-request-presigner', () => ({ getSignedUrl: vi.fn() }));
+vi.mock('@duckdb/node-api', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@duckdb/node-api')>()),
+    DuckDBInstance: { create: vi.fn() },
+}));
 
 describe('signed analytics file manifests', () => {
     const org = '00000000-0000-0000-0000-000000000001';
@@ -25,6 +32,16 @@ describe('signed analytics file manifests', () => {
         `${prefix}stream=${stream}/dt=${date}/part-1.parquet`;
     const send = vi.fn();
     const destroy = vi.fn();
+    const noDataMessage =
+        'No analytics data is available yet. Newly captured events become available after daily processing. Try again after the next daily update.';
+    const connection = { run: vi.fn(), closeSync: vi.fn() };
+    const closeInstance = vi.fn();
+
+    const testConnection = () =>
+        new DuckdbWarehouseClient({
+            type: 'duckdb_parquet',
+            resolveSource: createS3AnalyticsSourceResolver(config),
+        }).test();
 
     beforeEach(() => {
         vi.resetAllMocks();
@@ -34,6 +51,10 @@ describe('signed analytics file manifests', () => {
         } as unknown as ReturnType<typeof createS3ClientFromConfig>);
         send.mockResolvedValue({ Contents: [{ Key: key() }] });
         vi.mocked(getSignedUrl).mockResolvedValue('signed-url');
+        vi.mocked(DuckDBInstance.create).mockResolvedValue({
+            connect: async () => connection,
+            closeSync: closeInstance,
+        } as unknown as Awaited<ReturnType<typeof DuckDBInstance.create>>);
     });
 
     it('uses writer config only for prefix listing and signing exact GETs', async () => {
@@ -134,10 +155,8 @@ describe('signed analytics file manifests', () => {
 
     it.each([
         { Contents: [{ Key: 'events/compacted/org_id=other/file.parquet' }] },
-        { Contents: [] },
-        { Contents: [{ Key: `${prefix}../other/part.parquet` }] },
         { Contents: [], IsTruncated: true },
-    ])('fails closed on invalid or empty manifests', async (response) => {
+    ])('fails closed on invalid or incomplete manifests', async (response) => {
         send.mockResolvedValue(response);
         await expect(createS3AnalyticsSourceResolver(config)()).rejects.toThrow(
             'Analytics storage access failed',
@@ -145,6 +164,60 @@ describe('signed analytics file manifests', () => {
         expect(getSignedUrl).not.toHaveBeenCalled();
         expect(destroy).toHaveBeenCalledOnce();
     });
+
+    it.each([
+        { Contents: [], IsTruncated: false },
+        { IsTruncated: false },
+        { Contents: [{ Key: key('other') }] },
+        { Contents: [{ Key: `${prefix}../other/part.parquet` }] },
+    ])(
+        'explains missing data through the project connection test',
+        async (response) => {
+            send.mockResolvedValue(response);
+            await expect(testConnection()).rejects.toEqual(
+                new ParameterError(noDataMessage),
+            );
+            expect(getSignedUrl).not.toHaveBeenCalled();
+            expect(destroy).toHaveBeenCalledOnce();
+            expect(connection.closeSync).toHaveBeenCalledOnce();
+            expect(closeInstance).toHaveBeenCalledOnce();
+        },
+    );
+
+    it('waits for all listing pages before reporting no data', async () => {
+        send.mockResolvedValueOnce({
+            Contents: [],
+            IsTruncated: true,
+            NextContinuationToken: 'next',
+        }).mockResolvedValueOnce({ Contents: [], IsTruncated: false });
+        await expect(testConnection()).rejects.toEqual(
+            new ParameterError(noDataMessage),
+        );
+        expect(send).toHaveBeenCalledTimes(2);
+        expect(send.mock.calls[1][0].input.ContinuationToken).toBe('next');
+    });
+
+    it.each(['storage failure', 'incomplete pagination', 'later page failure'])(
+        'keeps %s sanitized through the project connection test',
+        async (failure) => {
+            if (failure === 'storage failure') {
+                send.mockRejectedValue(new ParameterError('writer-secret'));
+            } else if (failure === 'incomplete pagination') {
+                send.mockResolvedValue({ Contents: [], IsTruncated: true });
+            } else {
+                send.mockResolvedValueOnce({
+                    Contents: [],
+                    IsTruncated: true,
+                    NextContinuationToken: 'next',
+                }).mockRejectedValueOnce(new Error('writer-secret'));
+            }
+            await expect(testConnection()).rejects.toThrow(
+                /^Internal analytics query failed\. Check storage access and query permissions\.$/,
+            );
+            expect(getSignedUrl).not.toHaveBeenCalled();
+            expect(destroy).toHaveBeenCalledOnce();
+        },
+    );
 
     it('sanitizes SDK errors without falling back to bucket credentials', async () => {
         send.mockRejectedValue(

--- a/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
+++ b/packages/backend/src/services/ProjectService/analyticsProject/S3AnalyticsSource.ts
@@ -56,8 +56,8 @@ export const createS3AnalyticsSourceResolver = ({
     };
     return async () => {
         const client = createS3ClientFromConfig(config);
+        const tables = new Map<string, string[]>();
         try {
-            const tables = new Map<string, string[]>();
             let continuationToken: string | undefined;
             let pages = 0;
             let fileCount = 0;
@@ -107,17 +107,6 @@ export const createS3AnalyticsSourceResolver = ({
                 if (page.IsTruncated && (!continuationToken || pages >= 100))
                     throw new Error('Analytics listing cannot be completed');
             } while (continuationToken);
-            if (tables.size === 0) {
-                throw new Error('No compacted analytics files found');
-            }
-            return {
-                scope,
-                signedUrls: true,
-                tables: [...tables].map(([name, urls]) => ({
-                    name,
-                    urls: urls.sort(),
-                })),
-            };
         } catch {
             // SDK errors may contain credentials, signatures, or object contents.
             throw new Error(
@@ -126,5 +115,18 @@ export const createS3AnalyticsSourceResolver = ({
         } finally {
             client.destroy();
         }
+        if (tables.size === 0) {
+            throw new ParameterError(
+                'No analytics data is available yet. Newly captured events become available after daily processing. Try again after the next daily update.',
+            );
+        }
+        return {
+            scope,
+            signedUrls: true,
+            tables: [...tables].map(([name, urls]) => ({
+                name,
+                urls: urls.sort(),
+            })),
+        };
     };
 };


### PR DESCRIPTION
Creating an analytics project before any supported compacted events exist currently reports a storage/permissions failure. After a successful complete organization-scoped listing, return a safe, actionable message explaining that newly captured events become available after daily processing and to retry after the next daily update.

The no-data check now runs outside the SDK error sanitizer and uses the existing `ParameterError` handling in DuckDB. Storage errors, incomplete listings, file limits, and native query errors retain their existing sanitization. No changes to project creation behavior, authorization, migrations, or other DuckDB connections.

Validation:
- Reproduced the generic error in five failing cases through the real resolver and `DuckdbWarehouseClient.test()` before the fix; all 20 resolver tests pass after it.
- All 124 existing DuckDB client tests pass, including native-error redaction and ordinary connection behavior.
- Scoped lint, formatting, and diff checks pass.
- Full backend typecheck was attempted but is blocked by unrelated stale common-package declarations in the available local dependency tree (roadmap, chart-registry, and AI exports). No changed-file type errors were reported. Tests resolve workspace source directly.
- No deployed runtime retest; SDK and DuckDB I/O are mocked in the regression tests.

Relates: PROD-11059
