### PR TITLE
fix(chart-registry): install bypasses the index TTL; expiry revalidates with ETag

### DIFF
--- a/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.test.ts
@@ -132,6 +132,111 @@ describe('ChartRegistryClient', () => {
         expect(fetchImpl).toHaveBeenCalledTimes(2);
     });
 
+    it('forceRefresh fetches even when the cache is fresh and updates it', async () => {
+        const updated = {
+            ...index,
+            charts: [{ ...index.charts[0], version: '1.3.0' }],
+        };
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(index))
+            .mockResolvedValueOnce(jsonResponse(updated));
+        const client = makeClient(fetchImpl);
+
+        await client.getIndex();
+        const refreshed = await client.getIndex({ forceRefresh: true });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(refreshed.charts[0].version).toBe('1.3.0');
+        // The forced result replaces the cache for later plain reads.
+        expect((await client.getIndex()).charts[0].version).toBe('1.3.0');
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the stale cache when a forced refresh fails', async () => {
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(index))
+            .mockRejectedValueOnce(new Error('network down'));
+        const client = makeClient(fetchImpl);
+
+        const first = await client.getIndex();
+        const second = await client.getIndex({ forceRefresh: true });
+        expect(second).toBe(first);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('revalidates with the stored ETag and keeps the index on 304', async () => {
+        vi.useFakeTimers();
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ...jsonResponse(index),
+                etag: 'W/"abc"',
+            })
+            .mockResolvedValueOnce({
+                status: 304,
+                body: Buffer.alloc(0),
+                contentType: null,
+            });
+        const client = makeClient(fetchImpl);
+
+        const first = await client.getIndex();
+        await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+        const second = await client.getIndex();
+        expect(second).toBe(first);
+        expect(fetchImpl).toHaveBeenNthCalledWith(
+            2,
+            `${BASE}/index.json`,
+            expect.any(Number),
+            { headers: { 'if-none-match': 'W/"abc"' } },
+        );
+        // The 304 refreshed the TTL: an immediate third read stays cached.
+        const third = await client.getIndex();
+        expect(third).toBe(first);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+    });
+
+    it('sends If-Modified-Since when only Last-Modified was stored', async () => {
+        vi.useFakeTimers();
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ...jsonResponse(index),
+                lastModified: 'Thu, 11 Sep 2026 10:00:00 GMT',
+            })
+            .mockResolvedValueOnce({
+                status: 304,
+                body: Buffer.alloc(0),
+                contentType: null,
+            });
+        const client = makeClient(fetchImpl);
+
+        await client.getIndex();
+        await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+        await client.getIndex();
+        expect(fetchImpl).toHaveBeenNthCalledWith(
+            2,
+            `${BASE}/index.json`,
+            expect.any(Number),
+            {
+                headers: {
+                    'if-modified-since': 'Thu, 11 Sep 2026 10:00:00 GMT',
+                },
+            },
+        );
+    });
+
+    it('rejects a non-2xx index response when nothing is cached', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            status: 404,
+            body: Buffer.from('not found'),
+            contentType: 'text/plain',
+        });
+        await expect(makeClient(fetchImpl).getIndex()).rejects.toThrow(
+            'status 404',
+        );
+    });
+
     it('rejects an invalid index loudly', async () => {
         const fetchImpl = vi
             .fn()

--- a/packages/backend/src/ee/clients/ChartRegistryClient.ts
+++ b/packages/backend/src/ee/clients/ChartRegistryClient.ts
@@ -15,7 +15,10 @@ import {
     validatePublicHttpUrl,
 } from '../../utils/ssrfProtection';
 
-const INDEX_TTL_MS = 60 * 60 * 1000;
+// Short because expiry only triggers a conditional revalidation (ETag /
+// Last-Modified) — an unchanged registry answers 304 with no body, so the
+// steady-state cost of a small TTL is one header exchange per interval.
+const INDEX_TTL_MS = 5 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 20_000;
 const MAX_INDEX_BYTES = 8 * 1024 * 1024;
 const MAX_ARTIFACT_BYTES = 50 * 1024 * 1024;
@@ -48,11 +51,20 @@ export type ChartRegistryRawResponse = {
     status: number;
     body: Buffer;
     contentType: string | null;
+    /** Response validators, captured so the index can be revalidated cheaply. */
+    etag?: string | null;
+    lastModified?: string | null;
+};
+
+export type ChartRegistryFetchOptions = {
+    /** Conditional-request headers (If-None-Match / If-Modified-Since). */
+    headers?: Record<string, string>;
 };
 
 export type ChartRegistryFetch = (
     url: string,
     maxBytes: number,
+    options?: ChartRegistryFetchOptions,
 ) => Promise<ChartRegistryRawResponse>;
 
 /** Reads a fetch response body, aborting the moment it exceeds maxBytes. */
@@ -172,7 +184,11 @@ export function createPinnedLookup(
  */
 export async function chartRegistryFetch(
     url: string,
-    options: { maxBytes: number; allowPrivateAddresses: boolean },
+    options: {
+        maxBytes: number;
+        allowPrivateAddresses: boolean;
+        headers?: Record<string, string>;
+    },
 ): Promise<ChartRegistryRawResponse> {
     const parsedUrl = await validatePublicHttpUrl(url, {
         allowedProtocols: options.allowPrivateAddresses
@@ -203,6 +219,7 @@ export async function chartRegistryFetch(
         const response = await fetch(url, {
             redirect: 'manual',
             signal: controller.signal,
+            ...(options.headers ? { headers: options.headers } : {}),
             ...(dispatcher ? { dispatcher } : {}),
         });
         // validatePublicHttpUrl only validated this URL; a redirect target
@@ -223,6 +240,8 @@ export async function chartRegistryFetch(
             status: response.status,
             body,
             contentType: response.headers.get('content-type'),
+            etag: response.headers.get('etag'),
+            lastModified: response.headers.get('last-modified'),
         };
     } finally {
         clearTimeout(timeout);
@@ -239,8 +258,12 @@ export class ChartRegistryClient {
 
     private readonly fetchImpl: ChartRegistryFetch;
 
-    private cache: { index: ChartRegistryIndex; fetchedAt: number } | null =
-        null;
+    private cache: {
+        index: ChartRegistryIndex;
+        fetchedAt: number;
+        etag: string | null;
+        lastModified: string | null;
+    } | null = null;
 
     constructor(args: {
         lightdashConfig: LightdashConfig;
@@ -281,20 +304,58 @@ export class ChartRegistryClient {
         return resolved;
     }
 
-    async getIndex(): Promise<ChartRegistryIndex> {
+    /**
+     * `forceRefresh` skips the TTL for explicit "check the registry now"
+     * actions (install/upgrade). Whenever a cached copy exists, the request
+     * carries its validators, so an unchanged registry answers 304 and the
+     * cached index is kept — forced or not, a refresh of an unchanged
+     * registry costs one header exchange. Any fetch failure falls back to
+     * the stale cache, as before.
+     */
+    async getIndex(options?: {
+        forceRefresh?: boolean;
+    }): Promise<ChartRegistryIndex> {
         if (!this.baseUrl) {
             throw new ParameterError('Chart registry is not configured');
         }
-        if (this.cache && Date.now() - this.cache.fetchedAt < INDEX_TTL_MS) {
+        if (
+            !options?.forceRefresh &&
+            this.cache &&
+            Date.now() - this.cache.fetchedAt < INDEX_TTL_MS
+        ) {
             return this.cache.index;
         }
         try {
-            const { body } = await this.fetchImpl(
-                this.resolveUrl(this.indexFileName).toString(),
-                MAX_INDEX_BYTES,
-            );
-            const index = this.parseIndex(body);
-            this.cache = { index, fetchedAt: Date.now() };
+            const url = this.resolveUrl(this.indexFileName).toString();
+            const conditionalHeaders: Record<string, string> = {};
+            if (this.cache?.etag) {
+                conditionalHeaders['if-none-match'] = this.cache.etag;
+            } else if (this.cache?.lastModified) {
+                conditionalHeaders['if-modified-since'] =
+                    this.cache.lastModified;
+            }
+            const response =
+                Object.keys(conditionalHeaders).length > 0
+                    ? await this.fetchImpl(url, MAX_INDEX_BYTES, {
+                          headers: conditionalHeaders,
+                      })
+                    : await this.fetchImpl(url, MAX_INDEX_BYTES);
+            if (response.status === 304 && this.cache) {
+                this.cache = { ...this.cache, fetchedAt: Date.now() };
+                return this.cache.index;
+            }
+            if (response.status < 200 || response.status >= 300) {
+                throw new ParameterError(
+                    `Chart registry index request failed with status ${response.status}`,
+                );
+            }
+            const index = this.parseIndex(response.body);
+            this.cache = {
+                index,
+                fetchedAt: Date.now(),
+                etag: response.etag ?? null,
+                lastModified: response.lastModified ?? null,
+            };
             return index;
         } catch (e) {
             if (this.cache) {
@@ -320,8 +381,11 @@ export class ChartRegistryClient {
         return chartRegistryIndexSchema.parse(parsed);
     }
 
-    async getEntry(slug: string): Promise<ChartRegistryEntry | undefined> {
-        const index = await this.getIndex();
+    async getEntry(
+        slug: string,
+        options?: { forceRefresh?: boolean },
+    ): Promise<ChartRegistryEntry | undefined> {
+        const index = await this.getIndex(options);
         return index.charts.find((chart) => chart.slug === slug);
     }
 
@@ -387,10 +451,12 @@ export class ChartRegistryClient {
     private defaultFetch(
         url: string,
         maxBytes: number,
+        options?: ChartRegistryFetchOptions,
     ): Promise<ChartRegistryRawResponse> {
         return chartRegistryFetch(url, {
             maxBytes,
             allowPrivateAddresses: this.allowInsecure,
+            ...(options?.headers ? { headers: options.headers } : {}),
         });
     }
 }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -8782,7 +8782,12 @@ export class AppGenerateService extends BaseService {
             'Insufficient permissions to install chart types',
         );
 
-        const entry = await this.chartRegistryClient.getEntry(chartSlug);
+        // Install/upgrade is an explicit "check the registry now" action —
+        // bypass the index TTL so a just-published version installs
+        // immediately instead of returning "unchanged" until expiry.
+        const entry = await this.chartRegistryClient.getEntry(chartSlug, {
+            forceRefresh: true,
+        });
         if (!entry) {
             throw new NotFoundError(
                 `Chart type "${chartSlug}" not found in the registry`,


### PR DESCRIPTION
## Problem

The registry index was cached in memory for 1 hour with no bypass. After publishing a new chart-type version, Install/Upgrade returned `action: "unchanged"` until the TTL expired (hit on analytics after publishing `customizable-cartesian-chart`), and every registry-adjacent workflow this week ended with "restart the API to bust the cache".

Implements `~/.claude/specs/2026-09-11-chart-registry-index-cache-refresh.md` — both parts:

## Changes

1. **`getIndex({ forceRefresh: true })`** — skips the TTL; used only from the install/upgrade path (an explicit, permission-gated "check the registry now" action). The listing and asset proxy keep normal caching. Stale-cache-on-fetch-error behavior is preserved, forced or not.
2. **Conditional revalidation** — the cache stores the response's `ETag`/`Last-Modified` (GitHub Pages serves both) and revalidates with `If-None-Match`/`If-Modified-Since`; a 304 keeps the parsed index and refreshes the TTL. Since an unchanged registry now costs one header exchange, **`INDEX_TTL_MS` drops from 1 hour to 5 minutes**, which also shrinks the documented index/asset cache-generation straddling window to minutes.
3. **Explicit status handling** — a non-2xx index response now fails with its status (previously a 404 only failed at JSON-parse depth); with no cache it throws, with a cache it falls back, unchanged.

The `ChartRegistryFetch` contract gains an optional third `{ headers }` argument and the response gains `etag`/`lastModified` — both optional, so existing fakes and the hardened `chartRegistryFetch` (SSRF validation, pinned lookup, no-redirect, byte caps) are unchanged in behavior.

Deliberately skipped from the spec: the optional `?refresh=true` listing query param — redundant once install force-refreshes and the TTL is minutes, and it would add OpenAPI surface.

## Tests

`ChartRegistryClient.test.ts` 33/33 (5 new: force-refresh fetch+cache-update, forced-failure stale fallback, ETag 304 revalidation with TTL refresh, If-Modified-Since fallback, non-2xx rejection); registry install suite 22/22; backend typecheck clean.

Relates: GLITCH-741

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8sCUbSEj5R8babs36CnDN