### PR TITLE
fix(learn): distinguish coming-soon lesson cards

### DIFF
--- a/packages/frontend/src/features/learn/Learn.module.css
+++ b/packages/frontend/src/features/learn/Learn.module.css
@@ -428,14 +428,30 @@
         box-shadow 0.12s ease;
 }
 
-.card:hover {
+.card:not(.cardSoon):hover {
     transform: translateY(-1px);
     box-shadow: 0 8px 22px
         light-dark(rgba(16, 16, 20, 0.08), rgba(0, 0, 0, 0.4));
 }
 
 .cardSoon {
-    opacity: 0.7;
+    background: transparent;
+    border-style: dashed;
+    color: var(--mantine-color-dimmed);
+    transition: none;
+}
+
+.cardSoon .band {
+    background: var(--lu-sunken);
+}
+
+.cardSoon .blob {
+    background: transparent;
+    color: var(--mantine-color-dimmed);
+}
+
+.cardSoon .foot {
+    color: var(--mantine-color-dimmed);
 }
 
 .band {


### PR DESCRIPTION
## What changed

## Summary
- Give coming-soon lesson cards neutral headers and dashed, transparent outlines instead of fading the whole card.
- Remove their hover lift/shadow while preserving available lessons and existing Start-button behavior.
- Leave duplicate-label cleanup to PROD-11192.

### Review notes
Standards review raised one judgment call: the CSS-only patch mirrors the shared dotted placeholder style rather than migrating the existing container to `Paper variant="dotted"`. Kept the existing markup to minimize scope and preserve available-card layout; the shared variant is a reasonable alternative if reviewers prefer consolidating the styling. Spec review found no issues.

## Verification

- `pnpm -F frontend exec oxfmt src/features/learn/Learn.module.css` and `pnpm -F frontend exec oxfmt src/features/learn/Learn.module.css --check` — passed.
- `pnpm -F frontend lint` — passed, 0 warnings/errors.
- `pnpm -F frontend typecheck` — completed without errors.
- `pnpm -F frontend exec vitest related src/features/learn/Learn.module.css --run` — passed, 3 files / 23 tests.
- `git diff --check` — passed; committed worktree is clean.
- Live browser: searched for “virtual view” to compare an available lesson with two coming-soon cards. Coming-soon cards have no focusable controls; hover leaves transform and shadow at `none`. Available-card hover retains its original lift/shadow.
- Light/dark screenshots confirm dashed neutral placeholders, full text opacity, and no Start buttons alongside the unchanged available lesson. Initial capture was blocked by Learn being disabled in the seeded environment; enabled Learn and provisioned its training project locally, then both captures succeeded.

## Visual evidence

### Searching the Learn library for “virtual view” shows an available lesson alongside two coming-soon cards with neutral headers and dashed borders. Only the available lesson has a Start button.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/de0e05bad0268cc5123684f879aba0379e09c950ff5811ccbac6b2ae424e0905.png)

### The same virtual-view lessons in dark mode: coming-soon cards remain neutral, dashed, and without Start buttons; the available lesson keeps its colored header and action.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/06b1acea6bd662920c93824de16437acd710b6de5a312816ff57f76ab25e1e1f.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-11193-88aa17ccfa52.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-11193](https://linear.app/lightdash/issue/PROD-11193)

