### PR TITLE
fix(learn): remove duplicate Coming Soon label from lesson cards

### DIFF
--- a/packages/frontend/src/features/learn/LearnPage.test.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.test.tsx
@@ -364,7 +364,7 @@ describe('LearnPage unsupported modules', () => {
         const card = container.querySelector(
             '[data-learn-module="view:Analytics"]',
         )!;
-        expect(card.textContent).toContain('Coming Soon');
+        expect(card.textContent?.match(/Coming Soon/g)).toHaveLength(1);
         expect(card.querySelector('button')).toBeDisabled();
         expect(card.textContent).not.toContain('Complete');
         expect(localStorage.getItem('lightdash.learn.completed')).toBe(

--- a/packages/frontend/src/features/learn/LearnPage.tsx
+++ b/packages/frontend/src/features/learn/LearnPage.tsx
@@ -112,13 +112,9 @@ const ModuleCard: FC<{
                             <MantineIcon icon={IconCircleCheck} size={14} />
                             Complete
                         </span>
-                    ) : (
-                        <span>
-                            {module.available
-                                ? `${module.stepCount} steps`
-                                : 'Coming Soon'}
-                        </span>
-                    )}
+                    ) : module.available ? (
+                        <span>{module.stepCount} steps</span>
+                    ) : null}
                     {note && <span>{note}</span>}
                 </Box>
                 <Button


### PR DESCRIPTION
## What changed

## Summary
- Keep one “Coming Soon” label on the disabled lesson button and remove the repeated footer text.
- Preserve available lessons’ step counts, completion status, and actions.
- Strengthen the existing unsupported-lesson test to require exactly one label.

The broader non-functional card styling remains scoped to PROD-11193.

## Verification

- `pnpm -F frontend exec oxfmt src/features/learn/LearnPage.tsx src/features/learn/LearnPage.test.tsx --check` — passed.
- `pnpm -F frontend exec vitest related src/features/learn/LearnPage.tsx src/features/learn/LearnPage.test.tsx --run` — 1 file, 13 tests passed.
- Regression check: ran `pnpm -F frontend test src/features/learn/LearnPage.test.tsx` with the unmodified production component; the strengthened assertion failed on two labels (12 passed, 1 failed). Restoring the fix passes all 13 tests.
- `pnpm -F frontend lint` — 0 errors, 1 unrelated warning in roadmapApi.ts.
- `pnpm -F frontend typecheck` — failed with existing common-export/Mantine type errors. Repeated with the production component restored to baseline 45ad8a58146d00cc89ca58e4aa1145d359bc1b8b; output was identical (`cmp` passed).
- `git diff --check` — passed; commit hooks passed; worktrees clean.
- Standards review: 0 findings. Spec review: 0 findings.
- Visual capture attempted for the unavailable Analytics lesson card; bootstrap failed because the frontend bundle did not become ready. No screenshot was produced.

## References

Closes: [PROD-11192](https://linear.app/lightdash/issue/PROD-11192)

