### PR TITLE
fix(preview): copy dashboards before their charts so preview content copy needs no per-row updates

### DIFF
--- a/packages/api-tests/tests/previewContentCopy.test.ts
+++ b/packages/api-tests/tests/previewContentCopy.test.ts
@@ -18,7 +18,7 @@ const projectUuid = SEED_PROJECT.project_uuid;
 describe('Preview content copy', () => {
     let admin: ApiClient;
     const tracker = new TestResourceTracker();
-    let previewProjectUuid: string | undefined;
+    let previewProjectUuid: string | null = null;
     let sourceDashboard: Dashboard;
     let sourceChart: SavedChart;
 
@@ -52,7 +52,6 @@ describe('Preview content copy', () => {
                 tabs: [],
                 tiles: [
                     {
-                        tabUuid: undefined,
                         type: DashboardTileTypes.SAVED_CHART,
                         x: 0,
                         y: 0,
@@ -80,8 +79,9 @@ describe('Preview content copy', () => {
             name: uniqueName('preview content copy'),
             copyContent: true,
         });
+        // Capture before asserting so a failed assertion still cleans the project up
+        previewProjectUuid = previewResponse.body.results?.projectUuid ?? null;
         expect(previewResponse.status).toBe(200);
-        previewProjectUuid = previewResponse.body.results.projectUuid;
 
         const dashboardsResponse = await admin.get<{
             results: DashboardBasicDetails[];
@@ -90,12 +90,14 @@ describe('Preview content copy', () => {
         const previewDashboardSummary = dashboardsResponse.body.results.find(
             (dashboard) => dashboard.name === sourceDashboard.name,
         );
-        expect(previewDashboardSummary).toBeDefined();
-        expect(previewDashboardSummary?.uuid).not.toBe(sourceDashboard.uuid);
+        if (!previewDashboardSummary) {
+            throw new Error('Dashboard was not copied into the preview');
+        }
+        expect(previewDashboardSummary.uuid).not.toBe(sourceDashboard.uuid);
 
         const previewDashboardResponse = await admin.get<{
             results: Dashboard;
-        }>(`${apiUrl}/dashboards/${previewDashboardSummary?.uuid}`);
+        }>(`${apiUrl}/dashboards/${previewDashboardSummary.uuid}`);
         expect(previewDashboardResponse.status).toBe(200);
         const previewDashboard = previewDashboardResponse.body.results;
         expect(previewDashboard.projectUuid).toBe(previewProjectUuid);
@@ -103,12 +105,11 @@ describe('Preview content copy', () => {
         const chartTile = previewDashboard.tiles.find(
             (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
         );
-        expect(chartTile).toBeDefined();
-        const previewChartUuid =
-            chartTile?.type === DashboardTileTypes.SAVED_CHART
-                ? chartTile.properties.savedChartUuid
-                : null;
-        expect(previewChartUuid).toBeTruthy();
+        if (chartTile?.type !== DashboardTileTypes.SAVED_CHART) {
+            throw new Error('Chart tile was not copied into the preview');
+        }
+        const previewChartUuid = chartTile.properties.savedChartUuid;
+        expect(previewChartUuid).not.toBeNull();
         expect(previewChartUuid).not.toBe(sourceChart.uuid);
 
         const previewChartResponse = await admin.get<{ results: SavedChart }>(

--- a/packages/api-tests/tests/previewContentCopy.test.ts
+++ b/packages/api-tests/tests/previewContentCopy.test.ts
@@ -1,0 +1,131 @@
+import {
+    DashboardTileTypes,
+    SEED_PROJECT,
+    type ApiCreatePreviewResults,
+    type Dashboard,
+    type DashboardBasicDetails,
+    type SavedChart,
+} from '@lightdash/common';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+import { chartMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
+
+const apiUrl = '/api/v1';
+const projectUuid = SEED_PROJECT.project_uuid;
+
+describe('Preview content copy', () => {
+    let admin: ApiClient;
+    const tracker = new TestResourceTracker();
+    let previewProjectUuid: string | undefined;
+    let sourceDashboard: Dashboard;
+    let sourceChart: SavedChart;
+
+    beforeAll(async () => {
+        admin = await login();
+
+        const dashboardResponse = await admin.post<{ results: Dashboard }>(
+            `${apiUrl}/projects/${projectUuid}/dashboards`,
+            { name: uniqueName('preview copy dashboard'), tiles: [], tabs: [] },
+        );
+        expect(dashboardResponse.status).toBe(201);
+        sourceDashboard = dashboardResponse.body.results;
+        tracker.trackDashboard(sourceDashboard.uuid);
+
+        const chartResponse = await admin.post<{ results: SavedChart }>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            {
+                ...chartMock,
+                name: uniqueName('preview copy chart'),
+                dashboardUuid: sourceDashboard.uuid,
+                spaceUuid: null,
+            },
+        );
+        expect(chartResponse.status).toBe(200);
+        sourceChart = chartResponse.body.results;
+        tracker.trackChart(sourceChart.uuid);
+
+        const tileResponse = await admin.patch<{ results: Dashboard }>(
+            `${apiUrl}/dashboards/${sourceDashboard.uuid}`,
+            {
+                tabs: [],
+                tiles: [
+                    {
+                        tabUuid: undefined,
+                        type: DashboardTileTypes.SAVED_CHART,
+                        x: 0,
+                        y: 0,
+                        h: 5,
+                        w: 5,
+                        properties: { savedChartUuid: sourceChart.uuid },
+                    },
+                ],
+            },
+        );
+        expect(tileResponse.status).toBe(200);
+    });
+
+    afterAll(async () => {
+        if (previewProjectUuid) {
+            await admin.delete(`${apiUrl}/org/projects/${previewProjectUuid}`);
+        }
+        await tracker.cleanup(admin);
+    });
+
+    it('copies a chart that belongs to a dashboard onto the preview dashboard', async () => {
+        const previewResponse = await admin.post<{
+            results: ApiCreatePreviewResults;
+        }>(`${apiUrl}/projects/${projectUuid}/createPreview`, {
+            name: uniqueName('preview content copy'),
+            copyContent: true,
+        });
+        expect(previewResponse.status).toBe(200);
+        previewProjectUuid = previewResponse.body.results.projectUuid;
+
+        const dashboardsResponse = await admin.get<{
+            results: DashboardBasicDetails[];
+        }>(`${apiUrl}/projects/${previewProjectUuid}/dashboards`);
+        expect(dashboardsResponse.status).toBe(200);
+        const previewDashboardSummary = dashboardsResponse.body.results.find(
+            (dashboard) => dashboard.name === sourceDashboard.name,
+        );
+        expect(previewDashboardSummary).toBeDefined();
+        expect(previewDashboardSummary?.uuid).not.toBe(sourceDashboard.uuid);
+
+        const previewDashboardResponse = await admin.get<{
+            results: Dashboard;
+        }>(`${apiUrl}/dashboards/${previewDashboardSummary?.uuid}`);
+        expect(previewDashboardResponse.status).toBe(200);
+        const previewDashboard = previewDashboardResponse.body.results;
+        expect(previewDashboard.projectUuid).toBe(previewProjectUuid);
+
+        const chartTile = previewDashboard.tiles.find(
+            (tile) => tile.type === DashboardTileTypes.SAVED_CHART,
+        );
+        expect(chartTile).toBeDefined();
+        const previewChartUuid =
+            chartTile?.type === DashboardTileTypes.SAVED_CHART
+                ? chartTile.properties.savedChartUuid
+                : null;
+        expect(previewChartUuid).toBeTruthy();
+        expect(previewChartUuid).not.toBe(sourceChart.uuid);
+
+        const previewChartResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${previewChartUuid}`,
+        );
+        expect(previewChartResponse.status).toBe(200);
+        const previewChart = previewChartResponse.body.results;
+        expect(previewChart.projectUuid).toBe(previewProjectUuid);
+        expect(previewChart.dashboardUuid).toBe(previewDashboard.uuid);
+        expect(previewChart.spaceUuid).toBe(previewDashboard.spaceUuid);
+        expect(previewChart.name).toBe(sourceChart.name);
+
+        const sourceChartResponse = await admin.get<{ results: SavedChart }>(
+            `${apiUrl}/saved/${sourceChart.uuid}`,
+        );
+        expect(sourceChartResponse.body.results.dashboardUuid).toBe(
+            sourceDashboard.uuid,
+        );
+    });
+});

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4188,10 +4188,7 @@ export class ProjectModel {
                 );
             }
 
-            // 8888b.     db    .dP"Y8 88  88 88""Yb  dP"Yb     db    88""Yb 8888b.  .dP"Y8
-            //  8I  Yb   dPYb   `Ybo." 88  88 88__dP dP   Yb   dPYb   88__dP  8I  Yb `Ybo."
-            //  8I  dY  dP__Yb  o.`Y8b 888888 88""Yb Yb   dP  dP__Yb  88"Yb   8I  dY o.`Y8b
-            // 8888Y"  dP""""Yb 8bodP' 88  88 88oodP  YbodP  dP""""Yb 88  Yb 8888Y"  8bodP'
+            // Dashboards
             const dashboards = await trx(DashboardsTableName)
                 .leftJoin(
                     SpaceTableName,
@@ -4269,10 +4266,7 @@ export class ProjectModel {
                 return previewDashboardUuid;
             };
 
-            // .dP"Y8    db    Yb    dP 888888 8888b.      .dP"Y8  dP"Yb  88
-            // `Ybo."   dPYb    Yb  dP  88__    8I  Yb     `Ybo." dP   Yb 88
-            // o.`Y8b  dP__Yb    YbdP   88""    8I  dY     o.`Y8b Yb b dP 88  .o
-            // 8bodP' dP""""Yb    YP    888888 8888Y"      8bodP'  `"YoYo 88ood8
+            // Saved SQL
 
             // Get all the saved SQLs
             const savedSQLs = await trx(SavedSqlTableName)
@@ -4454,10 +4448,7 @@ export class ProjectModel {
                 newId: newSavedSQLVersions[i].saved_sql_version_uuid,
             }));
 
-            //  dP""b8 88  88    db    88""Yb 888888 .dP"Y8
-            // dP   `" 88  88   dPYb   88__dP   88   `Ybo."
-            // Yb      888888  dP__Yb  88"Yb    88   o.`Y8b
-            //  YboodP 88  88 dP""""Yb 88  Yb   88   8bodP'
+            // Charts
             const charts = await trx(SavedChartsTableName)
                 .leftJoin(
                     SpaceTableName,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4188,6 +4188,69 @@ export class ProjectModel {
                 );
             }
 
+            // 8888b.     db    .dP"Y8 88  88 88""Yb  dP"Yb     db    88""Yb 8888b.  .dP"Y8
+            //  8I  Yb   dPYb   `Ybo." 88  88 88__dP dP   Yb   dPYb   88__dP  8I  Yb `Ybo."
+            //  8I  dY  dP__Yb  o.`Y8b 888888 88""Yb Yb   dP  dP__Yb  88"Yb   8I  dY o.`Y8b
+            // 8888Y"  dP""""Yb 8bodP' 88  88 88oodP  YbodP  dP""""Yb 88  Yb 8888Y"  8bodP'
+            const dashboards = await trx(DashboardsTableName)
+                .leftJoin(
+                    SpaceTableName,
+                    `${DashboardsTableName}.space_id`,
+                    `${SpaceTableName}.space_id`,
+                )
+                .whereIn(`${DashboardsTableName}.space_id`, spaceIds)
+                .andWhere(`${SpaceTableName}.project_id`, projectId)
+                .whereNull(`${DashboardsTableName}.deleted_at`)
+                .whereNull(`${SpaceTableName}.deleted_at`)
+                .select<DbDashboard[]>(`${DashboardsTableName}.*`);
+
+            const dashboardIds = dashboards.map((d) => d.dashboard_id);
+
+            Logger.info(
+                `Copying ${dashboards.length} dashboards on ${previewProjectUuid}`,
+            );
+
+            const newDashboards =
+                dashboards.length > 0
+                    ? await chunkedInsertReturning<DbDashboard>(
+                          trx,
+                          DashboardsTableName,
+                          dashboards.map((d) => {
+                              type CloneDashboard = Omit<
+                                  DbDashboard,
+                                  | 'dashboard_id'
+                                  | 'dashboard_uuid'
+                                  | 'search_vector'
+                              > & {
+                                  search_vector?: string;
+                                  dashboard_id?: number;
+                                  dashboard_uuid?: string;
+                              };
+                              const createDashboard: CloneDashboard = {
+                                  ...replaceProjectUuid(d, previewProjectUuid),
+                                  search_vector: undefined,
+                                  dashboard_id: undefined,
+                                  dashboard_uuid: undefined,
+                                  space_id: getNewSpaceId(d.space_id),
+                              };
+                              delete createDashboard.search_vector;
+                              delete createDashboard.dashboard_id;
+                              delete createDashboard.dashboard_uuid;
+                              return createDashboard;
+                          }),
+                      )
+                    : [];
+
+            const dashboardMapping = dashboards.map((c, i) => ({
+                id: c.dashboard_id,
+                newId: newDashboards[i].dashboard_id,
+                uuid: c.dashboard_uuid,
+                newUuid: newDashboards[i].dashboard_uuid,
+            }));
+            const previewDashboardUuidBySource = new Map(
+                dashboardMapping.map((m) => [m.uuid, m.newUuid]),
+            );
+
             // .dP"Y8    db    Yb    dP 888888 8888b.      .dP"Y8  dP"Yb  88
             // `Ybo."   dPYb    Yb  dP  88__    8I  Yb     `Ybo." dP   Yb 88
             // o.`Y8b  dP__Yb    YbdP   88""    8I  dY     o.`Y8b Yb b dP 88  .o
@@ -4244,17 +4307,17 @@ export class ProjectModel {
                     mappedSavedSQLsPromises,
                 );
                 // Insert all the saved SQLs after they have been mapped and return the result
-                const newSavedSQLs = await trx(SavedSqlTableName)
-                    .insert(mappedSavedSQLs)
-                    .returning('*');
-                return newSavedSQLs;
+                return chunkedInsertReturning<DbSavedSql>(
+                    trx,
+                    SavedSqlTableName,
+                    mappedSavedSQLs,
+                );
             };
 
             // Create the saved SQLs
             const newSavedSQLs = await createSavedSQLs(savedSQLs);
 
-            // Create a mapping of the old saved SQLs to the new saved SQLs
-            const savedSQLInDashboards = await trx(SavedSqlTableName)
+            const sourceSavedSQLInDashboards = await trx(SavedSqlTableName)
                 .leftJoin(
                     DashboardsTableName,
                     function nonDeletedDashboardJoin() {
@@ -4276,41 +4339,48 @@ export class ProjectModel {
                 .whereNull(`${SavedSqlTableName}.deleted_at`)
                 .select<DbSavedSql[]>(`${SavedSqlTableName}.*`);
 
-            Logger.info(
-                `Copying ${savedSQLInDashboards.length} charts in dashboards on ${previewProjectUuid}`,
+            // A chart whose dashboard was not copied has no home in the preview
+            const savedSQLInDashboards = sourceSavedSQLInDashboards.filter(
+                (d) =>
+                    d.dashboard_uuid !== null &&
+                    previewDashboardUuidBySource.has(d.dashboard_uuid),
             );
 
-            // Create the saved SQLs in the dashboards
+            Logger.info(
+                `Copying ${savedSQLInDashboards.length} SQL charts in dashboards on ${previewProjectUuid}, skipping ${
+                    sourceSavedSQLInDashboards.length -
+                    savedSQLInDashboards.length
+                } whose dashboard was not copied`,
+            );
+
             const newSavedSQLInDashboards =
                 savedSQLInDashboards.length > 0
-                    ? await trx(SavedSqlTableName)
-                          .insert(
-                              savedSQLInDashboards.map((d) => {
-                                  if (!d.dashboard_uuid) {
-                                      throw new Error(
-                                          `Chart ${d.saved_sql_uuid} has no dashboard_uuid`,
-                                      );
-                                  }
-                                  const createSavedSQL: CloneSavedSQL = {
-                                      // The dashboard UUID is remapped after
-                                      // dashboards are cloned below. Keep the
-                                      // destination project UUID throughout
-                                      // this transaction.
-                                      ...replaceProjectUuid(
-                                          d,
-                                          previewProjectUuid,
-                                      ),
-                                      dashboard_uuid: d.dashboard_uuid,
-                                      search_vector: undefined,
-                                      saved_sql_uuid: undefined,
-                                      space_uuid: null,
-                                  };
-                                  delete createSavedSQL.search_vector;
-                                  delete createSavedSQL.saved_sql_uuid;
-                                  return createSavedSQL;
-                              }),
-                          )
-                          .returning('*')
+                    ? await chunkedInsertReturning<DbSavedSql>(
+                          trx,
+                          SavedSqlTableName,
+                          savedSQLInDashboards.map((d) => {
+                              const newDashboardUuid = d.dashboard_uuid
+                                  ? previewDashboardUuidBySource.get(
+                                        d.dashboard_uuid,
+                                    )
+                                  : undefined;
+                              if (!newDashboardUuid) {
+                                  throw new Error(
+                                      `Chart ${d.saved_sql_uuid} has no copied dashboard`,
+                                  );
+                              }
+                              const createSavedSQL: CloneSavedSQL = {
+                                  ...replaceProjectUuid(d, previewProjectUuid),
+                                  dashboard_uuid: newDashboardUuid,
+                                  search_vector: undefined,
+                                  saved_sql_uuid: undefined,
+                                  space_uuid: null,
+                              };
+                              delete createSavedSQL.search_vector;
+                              delete createSavedSQL.saved_sql_uuid;
+                              return createSavedSQL;
+                          }),
+                      )
                     : [];
 
             // Create a mapping of the old saved SQLs to the new saved SQLs
@@ -4348,27 +4418,29 @@ export class ProjectModel {
 
             const newSavedSQLVersions =
                 savedSQLVersions.length > 0
-                    ? await trx('saved_sql_versions')
-                          .insert(
-                              savedSQLVersions.map((d) => {
-                                  const newSavedSQLUuid = savedSQLMapping.find(
-                                      (m) => m.id === d.saved_sql_uuid,
-                                  )?.newId;
-                                  if (!newSavedSQLUuid) {
-                                      throw new Error(
-                                          `Cannot find new saved SQL uuid for ${d.saved_sql_uuid}`,
-                                      );
-                                  }
-                                  const createSavedSQLVersion = {
-                                      ...d,
-                                      saved_sql_version_uuid: undefined,
-                                      saved_sql_uuid: newSavedSQLUuid,
-                                  };
-                                  delete createSavedSQLVersion.saved_sql_version_uuid;
-                                  return createSavedSQLVersion;
-                              }),
-                          )
-                          .returning('*')
+                    ? await chunkedInsertReturning<
+                          (typeof savedSQLVersions)[number]
+                      >(
+                          trx,
+                          'saved_sql_versions',
+                          savedSQLVersions.map((d) => {
+                              const newSavedSQLUuid = savedSQLMapping.find(
+                                  (m) => m.id === d.saved_sql_uuid,
+                              )?.newId;
+                              if (!newSavedSQLUuid) {
+                                  throw new Error(
+                                      `Cannot find new saved SQL uuid for ${d.saved_sql_uuid}`,
+                                  );
+                              }
+                              const createSavedSQLVersion = {
+                                  ...d,
+                                  saved_sql_version_uuid: undefined,
+                                  saved_sql_uuid: newSavedSQLUuid,
+                              };
+                              delete createSavedSQLVersion.saved_sql_version_uuid;
+                              return createSavedSQLVersion;
+                          }),
+                      )
                     : [];
 
             const savedSQLVersionMapping = savedSQLVersions.map((c, i) => ({
@@ -4428,7 +4500,7 @@ export class ProjectModel {
                       )
                     : [];
 
-            const chartsInDashboards = await trx(SavedChartsTableName)
+            const sourceChartsInDashboards = await trx(SavedChartsTableName)
                 .leftJoin(
                     DashboardsTableName,
                     function nonDeletedDashboardJoin() {
@@ -4451,27 +4523,40 @@ export class ProjectModel {
                 .whereNull(`${SavedChartsTableName}.deleted_at`)
                 .select<DbSavedChart[]>(`${SavedChartsTableName}.*`);
 
-            Logger.info(
-                `Copying ${chartsInDashboards.length} charts in dashboards on ${previewProjectUuid}`,
+            // A chart whose dashboard was not copied has no home in the preview
+            const chartsInDashboards = sourceChartsInDashboards.filter(
+                (d) =>
+                    d.dashboard_uuid !== null &&
+                    previewDashboardUuidBySource.has(d.dashboard_uuid),
             );
 
-            // We also copy charts in dashboards, we will replace the dashboard_uuid later
+            Logger.info(
+                `Copying ${chartsInDashboards.length} charts in dashboards on ${previewProjectUuid}, skipping ${
+                    sourceChartsInDashboards.length - chartsInDashboards.length
+                } whose dashboard was not copied`,
+            );
+
             const newChartsInDashboards =
                 chartsInDashboards.length > 0
                     ? await chunkedInsertReturning<DbSavedChart>(
                           trx,
                           SavedChartsTableName,
                           chartsInDashboards.map((d) => {
-                              if (!d.dashboard_uuid) {
+                              const newDashboardUuid = d.dashboard_uuid
+                                  ? previewDashboardUuidBySource.get(
+                                        d.dashboard_uuid,
+                                    )
+                                  : undefined;
+                              if (!newDashboardUuid) {
                                   throw new Error(
-                                      `Chart in dashboard ${d.saved_query_id} has no dashboard_uuid`,
+                                      `Chart in dashboard ${d.saved_query_id} has no copied dashboard`,
                                   );
                               }
                               const createChart: CloneChart = {
                                   ...replaceProjectUuid(d, previewProjectUuid),
                                   search_vector: undefined,
                                   space_id: null,
-                                  dashboard_uuid: d.dashboard_uuid,
+                                  dashboard_uuid: newDashboardUuid,
                               };
                               delete createChart.search_vector;
                               delete createChart.saved_query_id;
@@ -4650,69 +4735,6 @@ export class ProjectModel {
                 },
             );
 
-            // 8888b.     db    .dP"Y8 88  88 88""Yb  dP"Yb     db    88""Yb 8888b.  .dP"Y8
-            //  8I  Yb   dPYb   `Ybo." 88  88 88__dP dP   Yb   dPYb   88__dP  8I  Yb `Ybo."
-            //  8I  dY  dP__Yb  o.`Y8b 888888 88""Yb Yb   dP  dP__Yb  88"Yb   8I  dY o.`Y8b
-            // 8888Y"  dP""""Yb 8bodP' 88  88 88oodP  YbodP  dP""""Yb 88  Yb 8888Y"  8bodP'
-            const dashboards = await trx(DashboardsTableName)
-                .leftJoin(
-                    SpaceTableName,
-                    `${DashboardsTableName}.space_id`,
-                    `${SpaceTableName}.space_id`,
-                )
-                .whereIn(`${DashboardsTableName}.space_id`, spaceIds)
-                .andWhere(`${SpaceTableName}.project_id`, projectId)
-                .whereNull(`${DashboardsTableName}.deleted_at`)
-                .whereNull(`${SpaceTableName}.deleted_at`)
-                .select<DbDashboard[]>(`${DashboardsTableName}.*`);
-
-            const dashboardIds = dashboards.map((d) => d.dashboard_id);
-
-            Logger.info(
-                `Copying ${dashboards.length} dashboards on ${previewProjectUuid}`,
-            );
-
-            const newDashboards =
-                dashboards.length > 0
-                    ? await trx(DashboardsTableName)
-                          .insert(
-                              dashboards.map((d) => {
-                                  type CloneDashboard = Omit<
-                                      DbDashboard,
-                                      | 'dashboard_id'
-                                      | 'dashboard_uuid'
-                                      | 'search_vector'
-                                  > & {
-                                      search_vector?: string;
-                                      dashboard_id?: number;
-                                      dashboard_uuid?: string;
-                                  };
-                                  const createDashboard: CloneDashboard = {
-                                      ...replaceProjectUuid(
-                                          d,
-                                          previewProjectUuid,
-                                      ),
-                                      search_vector: undefined,
-                                      dashboard_id: undefined,
-                                      dashboard_uuid: undefined,
-                                      space_id: getNewSpaceId(d.space_id),
-                                  };
-                                  delete createDashboard.search_vector;
-                                  delete createDashboard.dashboard_id;
-                                  delete createDashboard.dashboard_uuid;
-                                  return createDashboard;
-                              }),
-                          )
-                          .returning('*')
-                    : [];
-
-            const dashboardMapping = dashboards.map((c, i) => ({
-                id: c.dashboard_id,
-                newId: newDashboards[i].dashboard_id,
-                uuid: c.dashboard_uuid,
-                newUuid: newDashboards[i].dashboard_uuid,
-            }));
-
             // Get last version of a dashboard
             const lastDashboardVersionsIds = await trx('dashboard_versions')
                 .whereIn('dashboard_id', dashboardIds)
@@ -4822,56 +4844,6 @@ export class ProjectModel {
             const dashboardTileUuids = dashboardTiles.map(
                 (dv) => dv.dashboard_tile_uuid,
             );
-
-            Logger.info(
-                `Updating ${chartsInDashboards.length} charts in dashboards`,
-            );
-            // Update chart in dashboards with new dashboardUuids
-            const updateChartInDashboards = newChartsInDashboards.map(
-                (chart) => {
-                    const newDashboardUuid = dashboardMapping.find(
-                        (m) => m.uuid === chart.dashboard_uuid,
-                    )?.newUuid;
-
-                    if (!newDashboardUuid) {
-                        // The dashboard was not copied, perhaps becuase it belongs to a space the user doesn't have access to
-                        // We delete this chart in dashboard
-                        return trx(SavedChartsTableName)
-                            .where('saved_query_id', chart.saved_query_id)
-                            .delete();
-                    }
-                    return trx(SavedChartsTableName)
-                        .update({
-                            dashboard_uuid: newDashboardUuid,
-                        })
-                        .where('saved_query_id', chart.saved_query_id);
-                },
-            );
-            await Promise.all(updateChartInDashboards);
-
-            // update saved_sqls in dashboards
-            const updateSavedSQLInDashboards = newSavedSQLInDashboards.map(
-                (chart) => {
-                    const newDashboardUuid = dashboardMapping.find(
-                        (m) => m.uuid === chart.dashboard_uuid,
-                    )?.newUuid;
-
-                    if (!newDashboardUuid) {
-                        // The dashboard was not copied, perhaps becuase it belongs to a space the user doesn't have access to
-                        // We delete this chart in dashboard
-                        return trx(SavedSqlTableName)
-                            .where('saved_sql_uuid', chart.saved_sql_uuid)
-                            .delete();
-                    }
-                    return trx(SavedSqlTableName)
-                        .update({
-                            dashboard_uuid: newDashboardUuid,
-                        })
-                        .where('saved_sql_uuid', chart.saved_sql_uuid)
-                        .whereNull('deleted_at');
-                },
-            );
-            await Promise.all(updateSavedSQLInDashboards);
 
             const newDashboardTiles =
                 dashboardTiles.length > 0

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -4250,6 +4250,24 @@ export class ProjectModel {
             const previewDashboardUuidBySource = new Map(
                 dashboardMapping.map((m) => [m.uuid, m.newUuid]),
             );
+            // Dashboard content is only copied when its dashboard was
+            const hasCopiedDashboard = <
+                T extends { dashboard_uuid: string | null },
+            >(
+                row: T,
+            ): row is T & { dashboard_uuid: string } =>
+                row.dashboard_uuid !== null &&
+                previewDashboardUuidBySource.has(row.dashboard_uuid);
+            const getPreviewDashboardUuid = (sourceDashboardUuid: string) => {
+                const previewDashboardUuid =
+                    previewDashboardUuidBySource.get(sourceDashboardUuid);
+                if (!previewDashboardUuid) {
+                    throw new UnexpectedServerError(
+                        `Missing preview dashboard mapping for ${sourceDashboardUuid}`,
+                    );
+                }
+                return previewDashboardUuid;
+            };
 
             // .dP"Y8    db    Yb    dP 888888 8888b.      .dP"Y8  dP"Yb  88
             // `Ybo."   dPYb    Yb  dP  88__    8I  Yb     `Ybo." dP   Yb 88
@@ -4339,12 +4357,8 @@ export class ProjectModel {
                 .whereNull(`${SavedSqlTableName}.deleted_at`)
                 .select<DbSavedSql[]>(`${SavedSqlTableName}.*`);
 
-            // A chart whose dashboard was not copied has no home in the preview
-            const savedSQLInDashboards = sourceSavedSQLInDashboards.filter(
-                (d) =>
-                    d.dashboard_uuid !== null &&
-                    previewDashboardUuidBySource.has(d.dashboard_uuid),
-            );
+            const savedSQLInDashboards =
+                sourceSavedSQLInDashboards.filter(hasCopiedDashboard);
 
             Logger.info(
                 `Copying ${savedSQLInDashboards.length} SQL charts in dashboards on ${previewProjectUuid}, skipping ${
@@ -4359,19 +4373,11 @@ export class ProjectModel {
                           trx,
                           SavedSqlTableName,
                           savedSQLInDashboards.map((d) => {
-                              const newDashboardUuid = d.dashboard_uuid
-                                  ? previewDashboardUuidBySource.get(
-                                        d.dashboard_uuid,
-                                    )
-                                  : undefined;
-                              if (!newDashboardUuid) {
-                                  throw new Error(
-                                      `Chart ${d.saved_sql_uuid} has no copied dashboard`,
-                                  );
-                              }
                               const createSavedSQL: CloneSavedSQL = {
                                   ...replaceProjectUuid(d, previewProjectUuid),
-                                  dashboard_uuid: newDashboardUuid,
+                                  dashboard_uuid: getPreviewDashboardUuid(
+                                      d.dashboard_uuid,
+                                  ),
                                   search_vector: undefined,
                                   saved_sql_uuid: undefined,
                                   space_uuid: null,
@@ -4523,12 +4529,8 @@ export class ProjectModel {
                 .whereNull(`${SavedChartsTableName}.deleted_at`)
                 .select<DbSavedChart[]>(`${SavedChartsTableName}.*`);
 
-            // A chart whose dashboard was not copied has no home in the preview
-            const chartsInDashboards = sourceChartsInDashboards.filter(
-                (d) =>
-                    d.dashboard_uuid !== null &&
-                    previewDashboardUuidBySource.has(d.dashboard_uuid),
-            );
+            const chartsInDashboards =
+                sourceChartsInDashboards.filter(hasCopiedDashboard);
 
             Logger.info(
                 `Copying ${chartsInDashboards.length} charts in dashboards on ${previewProjectUuid}, skipping ${
@@ -4542,21 +4544,13 @@ export class ProjectModel {
                           trx,
                           SavedChartsTableName,
                           chartsInDashboards.map((d) => {
-                              const newDashboardUuid = d.dashboard_uuid
-                                  ? previewDashboardUuidBySource.get(
-                                        d.dashboard_uuid,
-                                    )
-                                  : undefined;
-                              if (!newDashboardUuid) {
-                                  throw new Error(
-                                      `Chart in dashboard ${d.saved_query_id} has no copied dashboard`,
-                                  );
-                              }
                               const createChart: CloneChart = {
                                   ...replaceProjectUuid(d, previewProjectUuid),
                                   search_vector: undefined,
                                   space_id: null,
-                                  dashboard_uuid: newDashboardUuid,
+                                  dashboard_uuid: getPreviewDashboardUuid(
+                                      d.dashboard_uuid,
+                                  ),
                               };
                               delete createChart.search_vector;
                               delete createChart.saved_query_id;


### PR DESCRIPTION
## Problem

Creating a preview project from a project with a few thousand charts inside dashboards was slow enough to fail or be interrupted, and the preview was left with no content. The insert side was batched in #21772; what remained were the two per-row remaps in `ProjectModel.duplicateContent`: charts in dashboards and SQL charts in dashboards were inserted with the *source* dashboard uuid and then remapped with one `UPDATE` per row (plus one `DELETE` per row whose dashboard was not copied), all awaited on the single transaction connection. At ~3600 dashboard charts that is thousands of sequential round trips inside one HTTP request.

## Change

- Dashboards are now cloned **before** the saved-SQL and chart sections. Both kinds of dashboard chart are inserted with the preview dashboard uuid directly, and rows whose dashboard was not copied are skipped up front instead of inserted and deleted. The two `Promise.all` update loops are gone.
- The remaining unbounded inserts in the function (dashboards, saved SQL, saved SQL versions) go through the existing `chunkedInsertReturning` helper, so every insert in the copy is bounded.
- New api-test `previewContentCopy.test.ts`: creates a dashboard with a chart that belongs to it, creates a preview with content copy, and asserts the copied chart points at the copied dashboard inside the preview project (and that the source is untouched).

The block that moved is unchanged apart from the chunked insert; the diff is mostly the relocation plus the deleted loops.

## Benchmark

Isolated instance, Postgres behind a TCP proxy that adds a fixed delay to every client-to-server chunk (one delay per statement, since pg pipelines a query's messages in one chunk) and counts wire-protocol statements. Same seeded source project for both implementations; only `ProjectModel.ts` is swapped between runs. Copied content verified identical each time (count table over 74 rows, plus a slug/path-keyed structural diff over 29 sections with `EXCEPT` both ways).

Fixture A: 3,602 charts in dashboards, 600 SQL charts in dashboards, 1,440 space charts across 48 spaces (nested included), 310 dashboards with tabs and views, 5,194 tiles of all six types, plus every other project-scoped content type seeded.
Fixture B: the same grown to 30,002 charts in dashboards, 2,800 SQL charts in dashboards, 2,510 dashboards, 40,395 tiles.

| fixture | entry point | added RTT | `main` statements | `main` wall time | this PR statements | this PR wall time |
|---|---|---|---|---|---|---|
| A | `POST /projects/{uuid}/createPreview` (UI) | 2 ms | 4,518 | 29.6 s | 215 | 2.7 s |
| A | `POST /org/projects` (CLI `start-preview`) | 2 ms | ~4,500 | 26.4 s | ~380 incl. deploy | 2.6 s |
| B | `createPreview` | 0 ms | 33,999 | 106.9 s | 572 | 19.0 s |
| B | `createPreview` | 2 ms | 34,921 | 230.8 s | 596 | 20.9 s |
| B | `createPreview` | 5 ms | not run | | 540 | 31.4 s |

Reading it: on `main` the per-row remap is one statement per dashboard chart, so cost scales with row count times round trip (and about 90 s of it at fixture B is server time even with no network delay). On this PR the statement count is flat in the number of charts (only the 1,000-row chunks grow) and wall time is dominated by the bulk insert payload, which is why 0 ms and 5 ms differ by only 12 s. The 3m51s `main` result at fixture B with 2 ms matches the "over 3 minutes" reported from production traces. Statement counts for this PR include a few dozen scheduler-worker statements that share the proxy.

## Regression analysis

- **Orphan handling.** Before: a dashboard chart whose dashboard was not copied was inserted then hard-deleted. After: it is never inserted. Final state is the same; the `preview_content` mapping now excludes those rows, which is more accurate (they no longer exist).
- **Ordering.** The dashboards select/insert/mapping only depends on the space mapping, which is built earlier. Everything that used `dashboardMapping` / `dashboardIds` later (versions, tabs, views, tiles, pinned items, content mapping) is unchanged and still runs after it.
- **Tiles.** Tile content copying still runs after charts and SQL charts, because it needs their mappings; unchanged.
- **Positional mappings.** `chartInDashboardsMapping` and `savedSQLInDashboardsMapping` are built from the *filtered* source arrays, so indices still line up with the inserted rows.
- **Not addressed here.** Seeding every project-scoped table also showed what a preview does not copy today (verified content, metrics trees, spotlight config, homepages, announcements, project parameters, and custom-role project memberships, which the access copy skips as ineligible). None of that is touched by this PR; I'll raise it separately.

Closes: #21188

<!-- test-all: run every e2e suite regardless of changed paths -->
test-all

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157zF1BnHdNTDaxtS8xnBFo

## Review follow-ups (second commit)

Three independent reviews ran on the first commit (standards, spec, adversarial correctness). No blocker or standard breach. Applied: one type predicate plus one lookup replace the duplicated filter-and-guard in the two dashboard-content sections, the unreachable inline throws are gone, and the lookup fails with an `UnexpectedServerError` like the neighbouring slug-mapping helper. The api-test captures the preview uuid before asserting so a failed assertion still cleans up, narrows with explicit throws, and uses `null` for absence.

Structural verification, beyond the count table: a canonical uuid-free form of the preview (29 sections keyed by slug, path and name: nested-space parent paths, chart versions with all sub-tables, slug aliases, tiles with their chart or SQL chart slug and tab, pinned items, agents, apps, access) compared against the source with `EXCEPT` in both directions. Result on this branch and on `main` is identical: zero differences in every section except one project membership on a custom role, which the pre-existing access copy already skips as ineligible. The only chart-config keys excluded from the comparison are `dataAppVizUuid` and `dataAppVizVersion`, which the data-app duplication remaps on purpose.

A SQL-chart-in-dashboard api-test case was requested by review but is not writable: `SavedSqlModel.create` hardcodes a null dashboard, so no product path creates one today. The scaled fixture (600 such rows seeded directly) is the proof for that branch.
