### PR TITLE
feat: add roadmap link to main navbar

### DIFF
--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { LightdashMode } from '@lightdash/common';
 import { Button, getDefaultZIndex, Menu } from '@mantine/core';
 import { modals } from '@mantine/modals';
@@ -5,18 +6,28 @@ import {
     IconBook,
     IconHelp,
     IconMessages,
+    IconRoad,
     IconSos,
     IconUsers,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { Link } from 'react-router';
 import { useIntercom } from 'react-use-intercom';
 import useHealth from '../../hooks/health/useHealth';
+import useApp from '../../providers/App/useApp';
 import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
 import LargeMenuItem from '../common/LargeMenuItem';
 import MantineIcon from '../common/MantineIcon';
 
 const HelpMenu: FC = () => {
     const health = useHealth();
+    const { user } = useApp();
+    const canViewRoadmap = user.data?.ability.can(
+        'view',
+        subject('Roadmap', {
+            organizationUuid: user.data.organizationUuid,
+        }),
+    );
     const isCloudCustomer = health.data?.mode === LightdashMode.CLOUD_BETA;
     const isDevelopment = health.data?.mode === LightdashMode.DEV;
 
@@ -65,6 +76,16 @@ const HelpMenu: FC = () => {
                     description="Chat with the Lightdash docs AI assistant"
                     icon={IconBook}
                 />
+
+                {canViewRoadmap && (
+                    <LargeMenuItem
+                        component={Link}
+                        to="/generalSettings/roadmap"
+                        title="Roadmap"
+                        description="Explore what we're building and track feature requests"
+                        icon={IconRoad}
+                    />
+                )}
 
                 {isCloudCustomer && (
                     <LargeMenuItem


### PR DESCRIPTION
## What changed

## Summary
- Add Roadmap inside the main navbar’s Help menu, beneath Ask the docs.
- Show the link based only on the organization-scoped CASL `view:Roadmap` permission; remove the obsolete roadmap feature-flag dependency.
- Rebase onto current origin/main, which includes the roadmap flag removal.
- Keep the PR scoped to HelpMenu with no new unit tests or standalone navbar shortcut.

Refreshed visual evidence shows Roadmap in the open Help menu on the rebased version.

## Verification

- Rebased onto `origin/main` at `2c7c697dbe7dd752919e0511fad57600bcd236c9`; ancestry confirmed with `git merge-base --is-ancestor 2c7c697dbe7dd752919e0511fad57600bcd236c9 HEAD`. Local and published work was reconciled first; identical patches were deduplicated by Git during rebase.
- Refreshed dependencies using Socket Firewall: `ulimit -n 4096; /home/exedev/linear-agent/npm/bin/sfw pnpm install --frozen-lockfile --network-concurrency=4 --no-runtime` — passed. Used the prepared Node 24.18.0 because the runtime download for 24.18.1 hit a certificate error. No dependency or lockfile changes committed.
- `pnpm -F common build` — passed, refreshing stale shared artifacts after the rebase.
- `pnpm -F frontend exec oxfmt src/components/NavBar/HelpMenu.tsx --check` — passed.
- `pnpm -F @lightdash/frontend run typecheck` — passed after dependency/artifact refresh.
- `pnpm -F frontend lint` — passed, 0 warnings/errors after refresh.
- `pnpm -F frontend exec vitest related src/components/NavBar/HelpMenu.tsx --run` — 2 existing test files, 12 tests passed. No unit tests added.
- `git diff --check origin/main HEAD` — passed; committed worktree clean; final PR diff changes only HelpMenu.tsx.
- Refreshed screenshot at `63753c216e4bc19459b1056d2e1069a1e2447832`: https://dodo.lightdash.dev/evidence/6372d6c1a5842a5fbdca8f7df809f84127e398984a85d48fcbdcec1ec3039d4a.png. Observations confirm one visible Roadmap menu item linking to `/generalSettings/roadmap` and no standalone Roadmap navbar shortcut.
- Standards review found no issues; spec review's pending visual-evidence note was resolved by the refreshed capture.

## Visual evidence

### After rebasing onto main, Roadmap remains inside the Help menu and its visibility checks only the organization-scoped CASL permission, with no roadmap feature-flag dependency.

![Lightdash development environment screenshot](https://dodo.lightdash.dev/evidence/6372d6c1a5842a5fbdca8f7df809f84127e398984a85d48fcbdcec1ec3039d4a.png)

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-11199-a026644ba0de.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-11199](https://linear.app/lightdash/issue/PROD-11199)

