### PR TITLE
fix(dashboards): open version history from the in-dashboard chart editor

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.header.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.header.test.tsx
@@ -132,7 +132,7 @@ const renderModal = (
     return { onClose };
 };
 
-describe('DashboardChartEditorModal rename', () => {
+describe('DashboardChartEditorModal header', () => {
     let chartOnServer: SavedChart;
 
     beforeEach(() => {
@@ -212,7 +212,7 @@ describe('DashboardChartEditorModal rename', () => {
         expect(onClose).not.toHaveBeenCalled();
     });
 
-    it('hides the rename control on a verified chart the user may not mutate', async () => {
+    it('hides the rename and history controls on a verified chart the user may not mutate', async () => {
         renderModal(manageChartAbility, {
             ...editChart,
             verification: {
@@ -231,9 +231,25 @@ describe('DashboardChartEditorModal rename', () => {
         expect(
             screen.queryByRole('button', { name: 'Edit name and description' }),
         ).toBeNull();
+        expect(
+            screen.queryByRole('link', { name: 'Version history' }),
+        ).toBeNull();
     });
 
-    it('hides the rename control when the user cannot manage the chart', async () => {
+    it('links to the chart version history in a new tab', async () => {
+        renderModal(manageChartAbility);
+
+        const historyLink = await screen.findByRole('link', {
+            name: 'Version history',
+        });
+        expect(historyLink).toHaveAttribute(
+            'href',
+            '/projects/project-uuid/saved/chart-uuid/history',
+        );
+        expect(historyLink).toHaveAttribute('target', '_blank');
+    });
+
+    it('hides the rename and history controls when the user cannot manage the chart', async () => {
         renderModal(viewOnlyAbility);
 
         expect(
@@ -241,6 +257,9 @@ describe('DashboardChartEditorModal rename', () => {
         ).toBeVisible();
         expect(
             screen.queryByRole('button', { name: 'Edit name and description' }),
+        ).toBeNull();
+        expect(
+            screen.queryByRole('link', { name: 'Version history' }),
         ).toBeNull();
     });
 });

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.rename.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.rename.test.tsx
@@ -1,0 +1,246 @@
+import { Ability } from '@casl/ability';
+import {
+    ChartType,
+    type PossibleAbilities,
+    type SavedChart,
+} from '@lightdash/common';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { lightdashApi } from '../../api';
+import { AbilityContext } from '../../providers/Ability/context';
+import { renderWithProviders } from '../../testing/testUtils';
+import DashboardChartEditorModal from './DashboardChartEditorModal';
+
+vi.mock('../../api', () => ({ lightdashApi: vi.fn() }));
+
+// The Explorer is out of scope here; a probe exposes the store's saved chart
+// so the test can see the rename reach the editing session.
+vi.mock('../Explorer', async () => {
+    const { selectSavedChart, useExplorerSelector } =
+        await import('../../features/explorer/store');
+    const StoreProbe = () => {
+        const savedChart = useExplorerSelector(selectSavedChart);
+        return (
+            <div data-testid="store-chart">
+                {savedChart?.name}|{savedChart?.description}
+            </div>
+        );
+    };
+    return { default: StoreProbe };
+});
+
+vi.mock('../Explorer/ExploreSideBar', () => ({ default: () => null }));
+
+vi.mock('../../hooks/useExplore', () => ({
+    useExplore: () => ({ data: undefined, error: null }),
+}));
+
+vi.mock('../../hooks/useExplorerQueryEffects', () => ({
+    useExplorerQueryEffects: vi.fn(),
+}));
+
+vi.mock('../../hooks/dashboard/useDashboardCustomMetricSeed', () => ({
+    useDashboardCustomMetricSeed: () => ({
+        seededMetrics: [],
+        dashboardMetricIds: new Set(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../hooks/dashboard/useUpdateDashboardCustomMetric', () => ({
+    useDeleteDashboardCustomMetric: () => ({
+        mutate: vi.fn(),
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../hooks/toaster/useToaster', () => ({
+    default: () => ({
+        showToastSuccess: vi.fn(),
+        showToastError: vi.fn(),
+        showToastApiError: vi.fn(),
+    }),
+}));
+
+vi.mock('../../ee/providers/Embed/useEmbed', () => ({
+    default: () => ({ projectUuid: 'project-uuid' }),
+}));
+
+const ORGANIZATION_UUID = '172a2270-000f-42be-9c68-c4752c23ae51';
+
+const editChart = {
+    uuid: 'chart-uuid',
+    projectUuid: 'project-uuid',
+    organizationUuid: ORGANIZATION_UUID,
+    name: 'Revenue per payment method',
+    description: 'Monthly revenue split by payment method',
+    tableName: 'payments',
+    metricQuery: {
+        exploreName: 'payments',
+        dimensions: ['payments_payment_method'],
+        metrics: ['payments_total_revenue'],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+        additionalMetrics: [],
+    },
+    chartConfig: {
+        type: ChartType.CARTESIAN,
+        config: {
+            layout: { xField: 'payments_payment_method', yField: [] },
+            eChartsConfig: { series: [] },
+        },
+    },
+    tableConfig: { columnOrder: [] },
+    pivotConfig: undefined,
+    colorPaletteUuid: 'palette-uuid',
+} as unknown as SavedChart;
+
+const manageChartAbility = new Ability<PossibleAbilities>([
+    {
+        action: 'manage',
+        subject: 'SavedChart',
+        conditions: { organizationUuid: ORGANIZATION_UUID },
+    },
+]);
+const viewOnlyAbility = new Ability<PossibleAbilities>([]);
+
+const renderModal = (
+    ability: Ability<PossibleAbilities>,
+    chart: SavedChart = editChart,
+) => {
+    const onClose = vi.fn();
+    renderWithProviders(
+        <MemoryRouter>
+            <AbilityContext.Provider value={ability}>
+                <DashboardChartEditorModal
+                    opened
+                    dashboard={{ uuid: 'dashboard-uuid', name: 'Payments' }}
+                    editChart={chart}
+                    customMetricsEnabled={false}
+                    onChartSaved={vi.fn()}
+                    onRegistryMetricEdited={vi.fn()}
+                    onRegistryMetricDeleted={vi.fn()}
+                    onClose={onClose}
+                />
+            </AbilityContext.Provider>
+        </MemoryRouter>,
+    );
+    return { onClose };
+};
+
+describe('DashboardChartEditorModal rename', () => {
+    let chartOnServer: SavedChart;
+
+    beforeEach(() => {
+        chartOnServer = editChart;
+        vi.mocked(lightdashApi).mockImplementation((async ({
+            url,
+            method,
+            body,
+        }) => {
+            if (
+                method === 'GET' &&
+                url === '/projects/project-uuid/saved/chart-uuid'
+            ) {
+                return chartOnServer;
+            }
+            if (method === 'PATCH' && url === '/saved/chart-uuid') {
+                const patch = JSON.parse(body as string) as Pick<
+                    SavedChart,
+                    'name' | 'description'
+                >;
+                chartOnServer = {
+                    ...chartOnServer,
+                    name: patch.name,
+                    description: patch.description,
+                };
+                return chartOnServer;
+            }
+            return new Promise(() => {});
+        }) as typeof lightdashApi);
+    });
+
+    it('renames the chart and edits its description without leaving the editor', async () => {
+        const user = userEvent.setup();
+        const { onClose } = renderModal(manageChartAbility);
+
+        expect(
+            await screen.findByText('Edit Revenue per payment method'),
+        ).toBeVisible();
+
+        await user.click(
+            screen.getByRole('button', { name: 'Edit name and description' }),
+        );
+
+        const nameInput = await screen.findByLabelText(/Chart name/);
+        await waitFor(() =>
+            expect(nameInput).toHaveValue('Revenue per payment method'),
+        );
+        await user.clear(nameInput);
+        await user.type(nameInput, 'Revenue by payment method');
+
+        const descriptionInput = screen.getByLabelText('Chart description');
+        await user.clear(descriptionInput);
+        await user.type(descriptionInput, 'Renamed from the dashboard');
+
+        await user.click(screen.getByRole('button', { name: 'Save' }));
+
+        await waitFor(() =>
+            expect(lightdashApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: 'PATCH',
+                    url: '/saved/chart-uuid',
+                    body: expect.stringContaining(
+                        '"name":"Revenue by payment method"',
+                    ),
+                }),
+            ),
+        );
+
+        expect(
+            await screen.findByText('Edit Revenue by payment method'),
+        ).toBeVisible();
+        await waitFor(() =>
+            expect(screen.getByTestId('store-chart')).toHaveTextContent(
+                'Revenue by payment method|Renamed from the dashboard',
+            ),
+        );
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('hides the rename control on a verified chart the user may not mutate', async () => {
+        renderModal(manageChartAbility, {
+            ...editChart,
+            verification: {
+                verifiedBy: {
+                    userUuid: 'someone-else',
+                    firstName: 'Ada',
+                    lastName: 'Lovelace',
+                },
+                verifiedAt: new Date('2026-09-01T00:00:00Z'),
+            },
+        });
+
+        expect(
+            await screen.findByText('Edit Revenue per payment method'),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('button', { name: 'Edit name and description' }),
+        ).toBeNull();
+    });
+
+    it('hides the rename control when the user cannot manage the chart', async () => {
+        renderModal(viewOnlyAbility);
+
+        expect(
+            await screen.findByText('Edit Revenue per payment method'),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('button', { name: 'Edit name and description' }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -17,6 +17,7 @@ import {
     IconAlertTriangle,
     IconChartBar,
     IconExternalLink,
+    IconHistory,
     IconPencil,
 } from '@tabler/icons-react';
 import {
@@ -422,6 +423,19 @@ const DashboardChartEditorModal: FC<Props> = ({
                                         aria-label="Open saved chart in new tab"
                                     >
                                         <MantineIcon icon={IconExternalLink} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
+                            {dashboard && canManageChart && (
+                                <Tooltip label="Version history">
+                                    <ActionIcon
+                                        component="a"
+                                        href={`/projects/${editChart.projectUuid}/saved/${editChart.uuid}/history`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        aria-label="Version history"
+                                    >
+                                        <MantineIcon icon={IconHistory} />
                                     </ActionIcon>
                                 </Tooltip>
                             )}

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartEditorModal.tsx
@@ -1,4 +1,6 @@
+import { subject } from '@casl/ability';
 import {
+    canMutateVerifiedContent,
     type AdditionalMetric,
     type DashboardCustomMetricAffectedChart,
     type SavedChart,
@@ -15,9 +17,11 @@ import {
     IconAlertTriangle,
     IconChartBar,
     IconExternalLink,
+    IconPencil,
 } from '@tabler/icons-react';
 import {
     useCallback,
+    useEffect,
     useLayoutEffect,
     useMemo,
     useRef,
@@ -27,9 +31,11 @@ import {
 import { Provider } from 'react-redux';
 import {
     createExplorerStore,
+    explorerActions,
     selectActiveFields,
     selectHasUnsavedChanges,
     selectSavedChart,
+    useExplorerDispatch,
     useExplorerSelector,
 } from '../../features/explorer/store';
 import { MergeProvider } from '../../features/mergeQuery/context/MergeContext';
@@ -38,9 +44,12 @@ import { useDeleteDashboardCustomMetric } from '../../hooks/dashboard/useUpdateD
 import useToaster from '../../hooks/toaster/useToaster';
 import { useExplore } from '../../hooks/useExplore';
 import { useExplorerQueryEffects } from '../../hooks/useExplorerQueryEffects';
+import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
+import useApp from '../../providers/App/useApp';
 import { ModalHostedContext } from '../../providers/Explorer/useIsModalHosted';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
+import ChartUpdateModal from '../common/modal/ChartUpdateModal';
 import Page from '../common/Page/Page';
 import TruncatedText from '../common/TruncatedText';
 import Explorer from '../Explorer';
@@ -50,9 +59,14 @@ import ExploreSideBar from '../Explorer/ExploreSideBar';
 import PageSpinner from '../PageSpinner';
 import { buildDashboardEditorInitialState } from './buildDashboardEditorInitialState';
 
+type ChartMetadata = Pick<SavedChart, 'name' | 'description'>;
+type RenamedChart = Pick<SavedChart, 'uuid' | 'name' | 'description'>;
+
 type ContentProps = {
     exploreId: string;
     editChart?: SavedChart;
+    /** Name and description saved from the header; null until renamed. */
+    chartMetadata: ChartMetadata | null;
     seededMetrics: AdditionalMetric[];
     onDirtyChange: (isDirty: boolean) => void;
     onExploreSelect: (exploreName: string) => void;
@@ -91,6 +105,7 @@ const DashboardChartEditorView: FC<
 const DashboardChartEditorContent: FC<ContentProps> = ({
     exploreId,
     editChart,
+    chartMetadata,
     seededMetrics,
     onDirtyChange,
     onExploreSelect,
@@ -114,6 +129,7 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
         <Provider store={store}>
             <ExplorerEffects />
             <UnsavedChangesBridge onDirtyChange={onDirtyChange} />
+            <SavedChartMetadataBridge metadata={chartMetadata} />
             <DashboardChartEditorView
                 editChart={editChart}
                 onExploreSelect={onExploreSelect}
@@ -127,6 +143,25 @@ const DashboardChartEditorContent: FC<ContentProps> = ({
 // Query effects must run inside the store Provider.
 const ExplorerEffects: FC = () => {
     useExplorerQueryEffects();
+    return null;
+};
+
+// Keeps the session's saved chart in step with a rename made from the header.
+const SavedChartMetadataBridge: FC<{ metadata: ChartMetadata | null }> = ({
+    metadata,
+}) => {
+    const dispatch = useExplorerDispatch();
+    const savedChart = useExplorerSelector(selectSavedChart);
+    useEffect(() => {
+        if (!metadata || !savedChart) return;
+        if (
+            metadata.name === savedChart.name &&
+            metadata.description === savedChart.description
+        ) {
+            return;
+        }
+        dispatch(explorerActions.setSavedChartMetadata(metadata));
+    }, [metadata, savedChart, dispatch]);
     return null;
 };
 
@@ -175,6 +210,37 @@ const DashboardChartEditorModal: FC<Props> = ({
 }) => {
     const [pickedExploreId, setPickedExploreId] = useState<string>();
     const exploreId = editChart ? editChart.tableName : pickedExploreId;
+
+    const ability = useAbilityContext();
+    const { user } = useApp();
+    // Same gate as the chart page: manage the chart, and its verification
+    const canManageChart =
+        editChart !== undefined &&
+        ability.can('manage', subject('SavedChart', { ...editChart })) &&
+        canMutateVerifiedContent(
+            ability,
+            {
+                organizationUuid: editChart.organizationUuid,
+                projectUuid: editChart.projectUuid,
+            },
+            editChart.verification,
+            user.data?.userUuid,
+        );
+    // The rename dialog reports what it saved; the tile's copy in editChart
+    // is otherwise the freshest source, so no cache read here.
+    const [renamedChart, setRenamedChart] = useState<RenamedChart | null>(null);
+    const chartMetadata = useMemo<ChartMetadata | null>(
+        () =>
+            renamedChart && renamedChart.uuid === editChart?.uuid
+                ? {
+                      name: renamedChart.name,
+                      description: renamedChart.description,
+                  }
+                : null,
+        [renamedChart, editChart?.uuid],
+    );
+    const chartName = chartMetadata?.name ?? editChart?.name;
+    const [isRenamingChart, setIsRenamingChart] = useState(false);
 
     const {
         seededMetrics,
@@ -334,8 +400,18 @@ const DashboardChartEditorModal: FC<Props> = ({
                                 maxWidth="100%"
                                 miw={0}
                             >
-                                {`Edit ${editChart.name}`}
+                                {`Edit ${chartName}`}
                             </TruncatedText>
+                            {dashboard && canManageChart && (
+                                <Tooltip label="Edit name and description">
+                                    <ActionIcon
+                                        aria-label="Edit name and description"
+                                        onClick={() => setIsRenamingChart(true)}
+                                    >
+                                        <MantineIcon icon={IconPencil} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
                             {dashboard && (
                                 <Tooltip label="Open saved chart in new tab">
                                     <ActionIcon
@@ -370,6 +446,7 @@ const DashboardChartEditorModal: FC<Props> = ({
                         }-${editChart?.uuid ?? 'new'}`}
                         exploreId={exploreId ?? ''}
                         editChart={editChart}
+                        chartMetadata={chartMetadata}
                         seededMetrics={seededMetrics}
                         onDirtyChange={handleDirtyChange}
                         onExploreSelect={setPickedExploreId}
@@ -413,6 +490,21 @@ const DashboardChartEditorModal: FC<Props> = ({
                     onBack={() => setRegistryDeletePreview(null)}
                     onConfirm={handleConfirmRegistryDelete}
                 />
+                {editChart && dashboard && canManageChart && (
+                    <ChartUpdateModal
+                        opened={isRenamingChart}
+                        uuid={editChart.uuid}
+                        onClose={() => setIsRenamingChart(false)}
+                        onConfirm={(chart) => {
+                            setRenamedChart({
+                                uuid: chart.uuid,
+                                name: chart.name,
+                                description: chart.description,
+                            });
+                            setIsRenamingChart(false);
+                        }}
+                    />
+                )}
             </ModalHostedContext.Provider>
         </MantineModal>
     );

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.test.tsx
@@ -1,0 +1,69 @@
+import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import TileBase from './index';
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) =>
+        selector({ hasTileComments: () => false, dashboard: undefined }),
+    ),
+}));
+
+const hiddenTitleTile: Dashboard['tiles'][number] = {
+    uuid: 'tile-1',
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 2,
+    w: 2,
+    tabUuid: undefined,
+    properties: {
+        savedChartUuid: 'chart-1',
+        title: 'Revenue',
+        hideTitle: true,
+    },
+};
+
+const CHART_HREF = '/projects/jaffle-shop/saved/revenue/';
+
+const renderTile = (
+    props: Partial<{ isEditMode: boolean; minimal: boolean }> = {},
+) =>
+    renderWithProviders(
+        <TileBase
+            tile={hiddenTitleTile}
+            title="Revenue"
+            titleHref={CHART_HREF}
+            isEditMode={props.isEditMode ?? false}
+            minimal={props.minimal ?? false}
+            lockHeaderVisibility
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+        >
+            <div>chart</div>
+        </TileBase>,
+    );
+
+describe('TileBase chart page link', () => {
+    it('offers the chart page from the hover pill when the title is hidden', () => {
+        renderTile();
+
+        const viewChart = screen.getByRole('link', { name: 'View chart' });
+        expect(viewChart).toHaveAttribute('href', CHART_HREF);
+        expect(viewChart).toHaveAttribute('target', '_blank');
+    });
+
+    it('does not offer the chart page while editing the dashboard', () => {
+        renderTile({ isEditMode: true });
+
+        expect(screen.queryByRole('link', { name: 'View chart' })).toBeNull();
+        expect(screen.getByTestId('tile-icon-more')).toBeInTheDocument();
+    });
+
+    it('does not offer the chart page in minimal mode', () => {
+        renderTile({ minimal: true });
+
+        expect(screen.queryByRole('link', { name: 'View chart' })).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -22,6 +22,7 @@ import {
     IconCircleCheckFilled,
     IconDots,
     IconEdit,
+    IconExternalLink,
     IconGripVertical,
     IconLink,
     IconTrash,
@@ -100,11 +101,14 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
     const copyTileLink = useCopyTileLink(tile);
     const canCopyTileLink = !minimal && copyTileLink !== null;
+    // The title is the only link to the chart page and hidden titles have
+    // none, so the pill carries one in view mode.
+    const canViewChart = !minimal && !isEditMode && !!titleHref;
 
     const hasMenuContent = isEditMode || !!extraMenuItems || canCopyTileLink;
     const isVerified = verification !== null && verification !== undefined;
     const hasHeaderContent =
-        hasMenuContent || isVerified || hasNonMenuHeaderContent;
+        hasMenuContent || isVerified || hasNonMenuHeaderContent || canViewChart;
 
     return (
         <div ref={containerRef} className={styles.tileWrapper}>
@@ -157,6 +161,21 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                         color: 'var(--mantine-color-green-6)',
                                     }}
                                 />
+                            </Tooltip>
+                        )}
+
+                        {canViewChart && (
+                            <Tooltip label="View chart">
+                                <ActionIcon
+                                    component="a"
+                                    size="sm"
+                                    href={titleHref}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    aria-label="View chart"
+                                >
+                                    <MantineIcon icon={IconExternalLink} />
+                                </ActionIcon>
                             </Tooltip>
                         )}
 

--- a/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartUpdateModal.tsx
@@ -16,7 +16,7 @@ import MantineModal from '../MantineModal';
 
 interface ChartUpdateModalProps extends Pick<ModalProps, 'opened' | 'onClose'> {
     uuid: string;
-    onConfirm?: () => void;
+    onConfirm?: (chart: SavedChart) => void;
 }
 
 type FormState = Pick<SavedChart, 'name' | 'description'>;
@@ -60,11 +60,11 @@ const ChartUpdateModal: FC<ChartUpdateModalProps> = ({
     }
 
     const handleConfirm = form.onSubmit(async (data) => {
-        await mutateAsync({
+        const updatedChart = await mutateAsync({
             name: data.name,
             description: data.description,
         });
-        onConfirm?.();
+        onConfirm?.(updatedChart);
     });
 
     return (

--- a/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.test.ts
@@ -324,3 +324,47 @@ describe('explorerSlice chart type authoring', () => {
         expect(cleared.unsavedChartVersion.tableName).toBe('orders');
     });
 });
+
+describe('explorerSlice saved chart metadata', () => {
+    const savedChart = {
+        uuid: 'chart-uuid',
+        name: 'Old name',
+        description: 'Old description',
+        colorPaletteUuid: 'saved-palette',
+    } as unknown as Parameters<typeof explorerActions.setSavedChart>[0];
+
+    it('renames the saved chart without touching the staged palette', () => {
+        const withChart = explorerReducer(
+            undefined,
+            explorerActions.setSavedChart(savedChart),
+        );
+        const withStagedPalette = explorerReducer(
+            withChart,
+            explorerActions.setColorPaletteUuid('staged-palette'),
+        );
+
+        const result = explorerReducer(
+            withStagedPalette,
+            explorerActions.setSavedChartMetadata({
+                name: 'New name',
+                description: 'New description',
+            }),
+        );
+
+        expect(result.savedChart?.name).toBe('New name');
+        expect(result.savedChart?.description).toBe('New description');
+        expect(result.unsavedColorPaletteUuid).toBe('staged-palette');
+    });
+
+    it('ignores metadata for a session with no saved chart', () => {
+        const result = explorerReducer(
+            undefined,
+            explorerActions.setSavedChartMetadata({
+                name: 'New name',
+                description: undefined,
+            }),
+        );
+
+        expect(result.savedChart).toBeUndefined();
+    });
+});

--- a/packages/frontend/src/features/explorer/store/explorerSlice.ts
+++ b/packages/frontend/src/features/explorer/store/explorerSlice.ts
@@ -163,6 +163,16 @@ const explorerSlice = createSlice({
             state.unsavedColorPaletteUuid =
                 action.payload?.colorPaletteUuid ?? null;
         },
+        // Name and description only, so a rename mid-session leaves the
+        // staged palette alone (setSavedChart would reset it).
+        setSavedChartMetadata: (
+            state,
+            action: PayloadAction<Pick<SavedChart, 'name' | 'description'>>,
+        ) => {
+            if (!state.savedChart) return;
+            state.savedChart.name = action.payload.name;
+            state.savedChart.description = action.payload.description;
+        },
         setColorPaletteUuid: (state, action: PayloadAction<string | null>) => {
             state.unsavedColorPaletteUuid = action.payload;
         },


### PR DESCRIPTION
## Summary

The in-dashboard chart editor had no way to reach a chart's version history. The only route was the "Open saved chart in new tab" link, then the chart page's actions menu, then "Version history".

- The editor header now has a "Version history" control next to the new-tab link. It opens the chart's history page in a new tab, so unsaved edits in the editor are never lost to a navigation.
- Shown only when the user can manage the chart, matching the gate on the chart page's menu entry.

Hosting the history view inside the editor itself was considered. The history page is a full route with its own preview and restore flow, so that is a larger refactor and can follow the shared editor host work rather than block this.

Stacked on #29066, which sits on #29063.

## Test plan

- [x] `DashboardChartEditorModal.header.test.tsx`: link target and new-tab attributes, hidden without manage permission
- [x] Frontend typecheck and lint
- [x] Manual run on a local dashboard: the control opens the history page in a new tab with the version list and preview

Closes: #29056

