### PR TITLE
fix(chart-registry): point the default registry URL at the renamed lightdash-library repo

### DIFF
--- a/docs/chart-types.md
+++ b/docs/chart-types.md
@@ -7,13 +7,13 @@ Custom chart types themselves (viz schema, explorer behaviour, saved-chart
 version pinning) are data apps — see the "Custom chart types" section of
 [`docs/data-apps.md`](./data-apps.md). The registry's own repo, publish
 pipeline, and authoring runbook are documented in
-[lightdash/lightdash-gallery](https://github.com/lightdash/lightdash-gallery).
+[lightdash/lightdash-library](https://github.com/lightdash/lightdash-library).
 
 ---
 
 ## What it is
 
-- The official registry (`lightdash/lightdash-gallery`, served from GitHub
+- The official registry (`lightdash/lightdash-library`, served from GitHub
   Pages) publishes prebuilt custom chart types. A Lightdash deployment
   points at one registry URL; the in-product chart type gallery gains a
   **chart type library** section to browse them and install them per
@@ -31,7 +31,7 @@ pipeline, and authoring runbook are documented in
   screenshots.
 - The contract is shared code: `chartRegistryIndexSchema` and the semver
   helpers in `packages/common/src/ee/apps/registry.ts` validate the index
-  both in the product (on fetch) and in the gallery repo's CI (on publish).
+  both in the product (on fetch) and in the registry repo's CI (on publish).
   Entries carry slug, name, description, semver version, tags, changelog,
   `minLightdashVersion`, the viz schema, a curated icon, screenshots, and
   artifact digests.
@@ -40,7 +40,7 @@ pipeline, and authoring runbook are documented in
   publish pipeline digest-verifies already-published versions and hard-fails
   on drift rather than overwriting. Old versions stay served forever.
 - Registry charts are template-deps-only: no dependencies beyond the data
-  app template's own `package.json`, enforced by gallery CI.
+  app template's own `package.json`, enforced by the registry repo's CI.
 
 ## Listing in product
 
@@ -113,6 +113,6 @@ pipeline, and authoring runbook are documented in
   section, and detail/fork/uninstall modals.
 - `packages/backend/src/database/migrations/20260831121540_add_chart_registry_provenance.ts`
   — provenance and fork-lineage columns.
-- [lightdash/lightdash-gallery](https://github.com/lightdash/lightdash-gallery)
+- [lightdash/lightdash-library](https://github.com/lightdash/lightdash-library)
   — the official registry: seed charts, publish pipeline, validation CI,
   and the authoring/publishing runbook.

--- a/docs/chart-types/CONTEXT.md
+++ b/docs/chart-types/CONTEXT.md
@@ -17,7 +17,7 @@ app/viz side and this glossary for the registry/library side.
 The static index and artifacts a Lightdash deployment reads installable
 chart types from: an `index.json` catalog plus, per published version,
 prebuilt `dist.tar`/`source.tar` with sha256 digests and screenshots. The
-official registry is the `lightdash/lightdash-gallery` repo served from
+official registry is the `lightdash/lightdash-library` repo served from
 GitHub Pages; a deployment points at exactly one registry URL.
 _Avoid_: marketplace, store, hub, gallery (that is the in-product page)
 

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -2379,9 +2379,9 @@ export type PostmarkConfig = {
 
 const DEFAULT_JOB_TIMEOUT = 1000 * 60 * 10; // 10 minutes
 
-// The official chart type registry (lightdash/lightdash-gallery, GitHub Pages).
+// The official chart type registry (lightdash/lightdash-library, GitHub Pages).
 const DEFAULT_CHART_REGISTRY_URL: string | null =
-    'https://lightdash.github.io/lightdash-gallery';
+    'https://lightdash.github.io/lightdash-library';
 
 const parseSandboxProvider = (
     value: string | undefined,

--- a/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
+++ b/packages/cli/src/handlers/apps/authoring/chart-type/README.md.tmpl
@@ -18,4 +18,4 @@ Root config (`vite.config.js`, `tsconfig.json`, etc.) is read-only reference —
 `.npmrc` sets `ignore-scripts=true` so dependencies' lifecycle scripts never run on your machine. Keep it; explicit commands such as `npm run build` still work.
 
 ## Publishing to the official registry
-Once it works in your instance, a chart type can be proposed for the official chart registry (`lightdash/lightdash-gallery`): copy this folder under that repo's `charts/<slug>/`, run `node scripts/prepare-chart.mjs charts/<slug>` there (it prunes the local scaffold and shapes the folder for the registry), add real screenshots, and open a PR — see that repo's README.
+Once it works in your instance, a chart type can be proposed for the official chart registry (`lightdash/lightdash-library`): copy this folder under that repo's `charts/<slug>/`, run `node scripts/prepare-chart.mjs charts/<slug>` there (it prunes the local scaffold and shapes the folder for the registry), add real screenshots, and open a PR — see that repo's README.

--- a/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
+++ b/packages/cli/src/handlers/apps/authoring/developing-chart-types-locally/SKILL.md
@@ -48,7 +48,7 @@ Root config files (`vite.config.js`, `tsconfig.json`, ...) are read-only referen
 
 ## Publishing to the official registry
 
-Once the chart type works in an instance, it can be proposed for the official chart registry (the `lightdash/lightdash-gallery` repo, served to every Lightdash deployment with the chart type library enabled):
+Once the chart type works in an instance, it can be proposed for the official chart registry (the `lightdash/lightdash-library` repo, served to every Lightdash deployment with the chart type library enabled):
 
 1. Copy this folder into that repo under `charts/<slug>/`.
 2. Run `node scripts/prepare-chart.mjs charts/<slug>` there — it prunes the local scaffold (these skills, configs, AGENTS/README), scrubs instance-side manifest fields, and shapes the folder for the registry. The folder name becomes the **permanent official registry slug**; pass `--slug <official-slug>` if the local slug isn't the identity that should ship.


### PR DESCRIPTION
Part of renaming the official chart-type registry repo `lightdash/lightdash-gallery` → `lightdash/lightdash-library` ahead of the public announcement.

- `DEFAULT_CHART_REGISTRY_URL` now points at `https://lightdash.github.io/lightdash-library`. GitHub Pages URLs are **not** redirected when a repo is renamed, so the old default 404s the moment the rename happens.
- Docs and CLI scaffold text updated to the new repo name (github.com links would redirect, but the stale name would outlive the announcement). Also swapped two glossary-violating "gallery CI" mentions in `docs/chart-types.md` for "registry repo's CI" — per the domain glossary, "gallery" is the in-product page.

⚠️ **Merge only after the repo rename** — until then the new URL serves nothing.

Rollout context (details on the ticket): already-released versions keep the old baked-in default, so the internal analytics deployment gets a `LIGHTDASH_CHART_REGISTRY_URL` env override at rename time to bridge until this ships. Installed chart types are unaffected either way — artifacts are copied to S3 at install, matching keys off `registry_slug`, and `apps.registry_url` is write-only provenance.

Typed `fix` (not `chore`) so the squash cuts a release immediately.

Relates: GLITCH-784