### PR TITLE
fix(chart-registry): graceful fallback when the chart library registry is unreachable

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -8,13 +8,11 @@ import { type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicPaperButton } from '../../../components/common/PolymorphicPaperButton';
 import { useAppColorScheme } from '../../../providers/ColorSchemeContext';
-import {
-    registryAssetUrl,
-    registryThumbnailPath,
-} from '../utils/registryAssetUrl';
+import { registryThumbnailPath } from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryCard.module.css';
 import OfficialChartTypeBadge from './OfficialChartTypeBadge';
+import RegistryAssetImage from './RegistryAssetImage';
 
 const StateBadge: FC<{ item: RegistryChartTypeListItem }> = ({ item }) => {
     switch (item.state) {
@@ -54,6 +52,13 @@ type Props = {
 const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => {
     const { colorScheme } = useAppColorScheme();
     const thumbnail = registryThumbnailPath(item, colorScheme);
+    const placeholder = (
+        <Paper variant="dotted" h="100%" radius={0}>
+            <Stack align="center" justify="center" gap="xs" h="100%">
+                <MantineIcon icon={IconPhoto} size="xl" color="ldGray.5" />
+            </Stack>
+        </Paper>
+    );
     return (
         <PolymorphicPaperButton
             component="button"
@@ -66,26 +71,14 @@ const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => {
         >
             <Box className={classes.preview}>
                 {thumbnail ? (
-                    <img
-                        src={registryAssetUrl(thumbnail)}
+                    <RegistryAssetImage
+                        path={thumbnail}
                         alt={item.name}
                         className={classes.previewImage}
+                        fallback={placeholder}
                     />
                 ) : (
-                    <Paper variant="dotted" h="100%" radius={0}>
-                        <Stack
-                            align="center"
-                            justify="center"
-                            gap="xs"
-                            h="100%"
-                        >
-                            <MantineIcon
-                                icon={IconPhoto}
-                                size="xl"
-                                color="ldGray.5"
-                            />
-                        </Stack>
-                    </Paper>
+                    placeholder
                 )}
             </Box>
             <Stack gap="xs" p="sm">

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryDetailModal.tsx
@@ -5,7 +5,7 @@ import {
 } from '@lightdash/common';
 import { Box, Button, Group, SimpleGrid, Stack, Text } from '@mantine/core';
 import { IconPhoto } from '@tabler/icons-react';
-import { type FC, type ReactNode } from 'react';
+import { useState, type FC, type ReactNode } from 'react';
 import Callout from '../../../components/common/Callout';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
@@ -16,13 +16,11 @@ import { useAppColorScheme } from '../../../providers/ColorSchemeContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import { useInstallRegistryChartType } from '../hooks/useInstallRegistryChartType';
-import {
-    registryAssetUrl,
-    registryThumbnailPath,
-} from '../utils/registryAssetUrl';
+import { registryThumbnailPath } from '../utils/registryAssetUrl';
 import ChartTypeBetaBadge from './ChartTypeBetaBadge';
 import classes from './ChartTypeLibraryDetailModal.module.css';
 import DataAppVizFieldsList from './DataAppVizFieldsList';
+import RegistryAssetImage from './RegistryAssetImage';
 
 type Props = {
     projectUuid: string;
@@ -49,6 +47,20 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
         item.screenshots.length > 0
             ? [item.thumbnailDark, ...item.screenshots.slice(1)]
             : item.screenshots;
+    // Failed screenshots are dropped rather than shown as broken images
+    // (the registry may be unreachable); when none survive, the placeholder
+    // below takes over.
+    const [failedPaths, setFailedPaths] = useState<Set<string>>(new Set());
+    const visibleScreenshots = screenshots.filter(
+        (path) => !failedPaths.has(path),
+    );
+    const markFailed = (path: string) =>
+        setFailedPaths((prev) => new Set(prev).add(path));
+    const placeholderContent = (
+        <Stack align="center" justify="center" gap="xs" h="100%">
+            <MantineIcon icon={IconPhoto} size="xl" color="ldGray.5" />
+        </Stack>
+    );
 
     const handleInstall = () => {
         track({
@@ -136,40 +148,30 @@ const ChartTypeLibraryDetailModal: FC<Props> = ({
             {...footerProps}
         >
             <Stack gap="md">
-                {screenshots.length > 0 ? (
+                {visibleScreenshots.length > 0 ? (
                     <Stack gap="sm">
-                        {screenshots.map((path) => (
-                            <img
+                        {visibleScreenshots.map((path) => (
+                            <RegistryAssetImage
                                 key={path}
-                                src={registryAssetUrl(path)}
+                                path={path}
                                 alt={item.name}
                                 className={classes.screenshot}
+                                fallback={null}
+                                onLoadError={() => markFailed(path)}
                             />
                         ))}
                     </Stack>
-                ) : thumbnail ? (
+                ) : screenshots.length === 0 && thumbnail ? (
                     <Box className={classes.preview}>
-                        <img
-                            src={registryAssetUrl(thumbnail)}
+                        <RegistryAssetImage
+                            path={thumbnail}
                             alt={item.name}
                             className={classes.previewImage}
+                            fallback={placeholderContent}
                         />
                     </Box>
                 ) : (
-                    <Box className={classes.preview}>
-                        <Stack
-                            align="center"
-                            justify="center"
-                            gap="xs"
-                            h="100%"
-                        >
-                            <MantineIcon
-                                icon={IconPhoto}
-                                size="xl"
-                                color="ldGray.5"
-                            />
-                        </Stack>
-                    </Box>
+                    <Box className={classes.preview}>{placeholderContent}</Box>
                 )}
 
                 <Text fz="sm" c="ldGray.7" lh={1.55}>

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.test.tsx
@@ -144,21 +144,23 @@ describe('ChartTypeLibrarySection', () => {
         ).not.toBeInTheDocument();
     });
 
-    it('shows the quiet offline state when the fetch fails with no cached data', () => {
+    it('shows the offline state with a retry when the fetch fails with no cached data', () => {
         setFlag(true);
+        const refetch = vi.fn();
         mockedUseRegistryChartTypes.mockReturnValue({
             data: undefined,
             isInitialLoading: false,
             error: { name: 'Error', message: 'boom' },
+            refetch,
         } as unknown as ReturnType<typeof useRegistryChartTypes>);
         renderSection();
 
         expect(screen.getByText('Chart type library')).toBeInTheDocument();
         expect(
-            screen.getByText(
-                'The chart type library is unavailable right now.',
-            ),
+            screen.getByText(/The chart type library can't be reached/),
         ).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(refetch).toHaveBeenCalled();
     });
 
     it('keeps showing cached data through a background fetch error', () => {
@@ -170,9 +172,7 @@ describe('ChartTypeLibrarySection', () => {
 
         expect(screen.getByText('Radial gauge')).toBeInTheDocument();
         expect(
-            screen.queryByText(
-                'The chart type library is unavailable right now.',
-            ),
+            screen.queryByText(/The chart type library can't be reached/),
         ).not.toBeInTheDocument();
     });
 

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -2,6 +2,7 @@ import { FeatureFlags } from '@lightdash/common';
 import { Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
 import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
+import InlineErrorState from '../../../components/common/InlineErrorState';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
@@ -105,11 +106,10 @@ const ChartTypeLibrarySection: FC<Props> = ({
             {registryQuery.isInitialLoading ? (
                 <EmptyStateLoader title="Loading chart type library…" />
             ) : isOffline ? (
-                <Paper variant="dotted" p="xl">
-                    <Text ta="center" fz="xs" c="dimmed">
-                        The chart type library is unavailable right now.
-                    </Text>
-                </Paper>
+                <InlineErrorState
+                    message="The chart type library can't be reached right now. It may be a temporary outage or a network restriction on this instance."
+                    onRetry={() => void registryQuery.refetch()}
+                />
             ) : visibleCharts.length === 0 ? (
                 <Paper variant="dotted" p="xl">
                     <Text ta="center" fz="xs" c="dimmed">

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -1,6 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
 import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
 import InlineErrorState from '../../../components/common/InlineErrorState';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -97,11 +98,11 @@ const ChartTypeLibrarySection: FC<Props> = ({
                 </Group>
             )}
 
-            <Text fz="sm" c="dimmed">
+            <Callout variant="info">
                 These chart types are available to add to your instance. Once
                 installed, they can be used by anyone building charts in your
                 organization.
-            </Text>
+            </Callout>
 
             {registryQuery.isInitialLoading ? (
                 <EmptyStateLoader title="Loading chart type library…" />

--- a/packages/frontend/src/features/chartTypes/components/RegistryAssetImage.test.tsx
+++ b/packages/frontend/src/features/chartTypes/components/RegistryAssetImage.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import RegistryAssetImage from './RegistryAssetImage';
+
+describe('RegistryAssetImage', () => {
+    it('renders the proxied image and swaps to the fallback on load error', () => {
+        render(
+            <RegistryAssetImage
+                path="charts/heatmap/0.1.0/thumbnail.png"
+                alt="Heatmap"
+                fallback={<span>fallback</span>}
+            />,
+        );
+        const img = screen.getByRole('img', { name: 'Heatmap' });
+        expect(img).toHaveAttribute(
+            'src',
+            expect.stringContaining('/api/v1/ee/chart-registry/assets?path='),
+        );
+        expect(screen.queryByText('fallback')).not.toBeInTheDocument();
+
+        fireEvent.error(img);
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+        expect(screen.getByText('fallback')).toBeInTheDocument();
+    });
+
+    it('renders nothing on load error when the fallback is null', () => {
+        render(
+            <RegistryAssetImage
+                path="missing.png"
+                alt="Gone"
+                fallback={null}
+            />,
+        );
+
+        fireEvent.error(screen.getByRole('img', { name: 'Gone' }));
+
+        expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/features/chartTypes/components/RegistryAssetImage.tsx
+++ b/packages/frontend/src/features/chartTypes/components/RegistryAssetImage.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState, type FC, type ReactNode } from 'react';
+import { registryAssetUrl } from '../utils/registryAssetUrl';
+
+type Props = {
+    path: string;
+    alt: string;
+    className?: string;
+    /** Rendered instead of the image when it fails to load. */
+    fallback: ReactNode;
+    onLoadError?: () => void;
+};
+
+// Registry assets stream through the backend proxy, which fails when the
+// registry itself is unreachable — render a quiet fallback instead of the
+// browser's broken-image glyph.
+const RegistryAssetImage: FC<Props> = ({
+    path,
+    alt,
+    className,
+    fallback,
+    onLoadError,
+}) => {
+    const [failed, setFailed] = useState(false);
+    useEffect(() => setFailed(false), [path]);
+    if (failed) return <>{fallback}</>;
+    return (
+        <img
+            src={registryAssetUrl(path)}
+            alt={alt}
+            className={className}
+            onError={() => {
+                setFailed(true);
+                onLoadError?.();
+            }}
+        />
+    );
+};
+
+export default RegistryAssetImage;


### PR DESCRIPTION
When the configured chart registry can't be reached, the chart type library showed broken things instead of saying so. Two failure shapes, both now handled:

- **Stale index, dead assets** (the backend keeps serving its cached `index.json` after a failed refresh — by design): cards rendered with the browser's broken-image glyph because the thumbnail asset proxy fails live. Thumbnails now fall back to the same dotted photo placeholder used when a chart has no thumbnail (new shared `RegistryAssetImage` with an `onError` swap). The detail modal drops failed screenshots instead of stacking broken images, and shows the placeholder when none survive.
- **No index at all** (cold process, registry unreachable): the listing endpoint errors and the section already showed a quiet "unavailable" note. That state is now the house `InlineErrorState` with a Retry button wired to the query refetch.

The installed-charts tab is unaffected — installed chart types render from artifacts copied to S3 at install and never touch the registry.

Covered by tests (`RegistryAssetImage.test.tsx`, updated `ChartTypeLibrarySection.test.tsx`); frontend typecheck, targeted lint, and oxfmt clean. Not browser-verified against a dead registry — reviewers can simulate by pointing `LIGHTDASH_CHART_REGISTRY_URL` at a 404ing URL.

Context: found while renaming the registry repo (GitHub Pages URLs don't redirect), but this applies to any self-hosted instance with restricted egress or a registry outage.

Relates: GLITCH-784