### PR TITLE
feat(dashboards): view all comments on a dashboard in one panel

### DIFF
--- a/packages/backend/src/database/seeds/development/17_dashboard_comments.ts
+++ b/packages/backend/src/database/seeds/development/17_dashboard_comments.ts
@@ -1,0 +1,520 @@
+import {
+    CreateDashboardChartTile,
+    CreateDashboardLoomTile,
+    CreateDashboardMarkdownTile,
+    DashboardTileTypes,
+    generateSlug,
+    sanitizeHtml,
+    SEED_ORG_1_ADMIN,
+    SEED_ORG_1_EDITOR,
+    SEED_ORG_1_VIEWER,
+    SEED_PROJECT,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { v4 as uuidv4 } from 'uuid';
+import { lightdashConfig } from '../../../config/lightdashConfig';
+import { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { SavedChartModel } from '../../../models/SavedChartModel';
+import { SpaceModel } from '../../../models/SpaceModel';
+import { DashboardTileCommentsTableName } from '../../entities/comments';
+import {
+    DbNotificationResourceType,
+    NotificationsTableName,
+} from '../../entities/notifications';
+
+// A dashboard with a thread on every tile, across two tabs, so the
+// dashboard-wide comments panel has something to show: replies, mentions,
+// resolved threads, and unread notifications for the demo user.
+
+const DASHBOARD_NAME = 'Weekly revenue review';
+
+type SeedUser = {
+    user_uuid: string;
+    first_name: string;
+    last_name: string;
+};
+
+const david = SEED_ORG_1_ADMIN;
+const editor = SEED_ORG_1_EDITOR;
+const viewer = SEED_ORG_1_VIEWER;
+
+const fullName = (user: SeedUser) => `${user.first_name} ${user.last_name}`;
+
+const mention = (user: SeedUser) =>
+    `<span style="color: #228be6; font-weight: 500;">@${fullName(user)}</span>`;
+
+type SeedComment = {
+    author: SeedUser;
+    text: string;
+    /** HTML with mentions; defaults to the text wrapped in a paragraph. */
+    html?: string;
+    mentions?: SeedUser[];
+    daysAgo: number;
+    resolved?: boolean;
+    replies?: Omit<SeedComment, 'replies' | 'resolved'>[];
+};
+
+type SeedTileComments = {
+    tileUuid: string;
+    tileTitle: string;
+    threads: SeedComment[];
+};
+
+const revenueIntro = `This review covers the trailing 12 months of Jaffle Shop revenue. Numbers refresh every morning; leave a comment on any tile if something looks off.`;
+const ordersIntro = `Order volume, customer spend, and customers we have not seen in a while.`;
+
+async function createDashboard(knex: Knex) {
+    const dashboardModel = new DashboardModel({ database: knex });
+    const spaceModel = new SpaceModel({ database: knex });
+    const chartModel = new SavedChartModel({
+        database: knex,
+        lightdashConfig,
+    });
+
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
+    if (!spaceUuid) throw new Error('No space found for seeding');
+
+    const savedCharts = await chartModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+    });
+    const getChartUuid = (name: string) => {
+        const chart = savedCharts.find(
+            ({ name: chartName }) => chartName === name,
+        );
+        if (!chart) {
+            throw new Error(`Could not find seeded chart with name ${name}`);
+        }
+        return chart.uuid;
+    };
+
+    const revenueIntroTileUuid = uuidv4();
+    const totalRevenueTileUuid = uuidv4();
+    const revenueByPaymentTileUuid = uuidv4();
+    const signupsTileUuid = uuidv4();
+    const ordersIntroTileUuid = uuidv4();
+    const ordersOverTimeTileUuid = uuidv4();
+    const averageSpendTileUuid = uuidv4();
+    const lapsedCustomersTileUuid = uuidv4();
+    const walkthroughTileUuid = uuidv4();
+
+    const revenueTab = { uuid: uuidv4(), name: 'Revenue', order: 0 };
+    const ordersTab = { uuid: uuidv4(), name: 'Orders', order: 1 };
+
+    const chartTile = (
+        uuid: string,
+        tabUuid: string,
+        position: { x: number; y: number; w: number; h: number },
+        chartName: string,
+    ): CreateDashboardChartTile => ({
+        uuid,
+        ...position,
+        type: DashboardTileTypes.SAVED_CHART,
+        tabUuid,
+        properties: { savedChartUuid: getChartUuid(chartName) },
+    });
+
+    const revenueIntroTile: CreateDashboardMarkdownTile = {
+        uuid: revenueIntroTileUuid,
+        x: 0,
+        y: 0,
+        w: 36,
+        h: 3,
+        type: DashboardTileTypes.MARKDOWN,
+        tabUuid: revenueTab.uuid,
+        properties: { title: 'About this review', content: revenueIntro },
+    };
+    const totalRevenueTile = chartTile(
+        totalRevenueTileUuid,
+        revenueTab.uuid,
+        { x: 0, y: 3, w: 12, h: 6 },
+        "What's our total revenue to date?",
+    );
+    const revenueByPaymentTile = chartTile(
+        revenueByPaymentTileUuid,
+        revenueTab.uuid,
+        { x: 12, y: 3, w: 24, h: 9 },
+        'How much revenue do we have per payment method?',
+    );
+    const signupsTile = chartTile(
+        signupsTileUuid,
+        revenueTab.uuid,
+        { x: 0, y: 9, w: 12, h: 9 },
+        'Customer signups by month',
+    );
+
+    const ordersIntroTile: CreateDashboardMarkdownTile = {
+        uuid: ordersIntroTileUuid,
+        x: 0,
+        y: 0,
+        w: 36,
+        h: 3,
+        type: DashboardTileTypes.MARKDOWN,
+        tabUuid: ordersTab.uuid,
+        properties: {
+            title: 'Orders and customer activity',
+            content: ordersIntro,
+        },
+    };
+    const ordersOverTimeTile = chartTile(
+        ordersOverTimeTileUuid,
+        ordersTab.uuid,
+        { x: 0, y: 3, w: 24, h: 9 },
+        'How many orders we have over time ?',
+    );
+    const averageSpendTile = chartTile(
+        averageSpendTileUuid,
+        ordersTab.uuid,
+        { x: 24, y: 3, w: 12, h: 9 },
+        "What's the average spend per customer?",
+    );
+    const lapsedCustomersTile = chartTile(
+        lapsedCustomersTileUuid,
+        ordersTab.uuid,
+        { x: 0, y: 12, w: 24, h: 9 },
+        'Which customers have not recently ordered an item?',
+    );
+    const walkthroughTile: CreateDashboardLoomTile = {
+        uuid: walkthroughTileUuid,
+        x: 24,
+        y: 12,
+        w: 12,
+        h: 9,
+        type: DashboardTileTypes.LOOM,
+        tabUuid: ordersTab.uuid,
+        properties: {
+            title: 'Walkthrough of this review',
+            url: 'https://www.loom.com/share/6b8d3d5ccc644fa8bf68ffb754cbb783',
+        },
+    };
+
+    const dashboard = await dashboardModel.create(
+        spaceUuid,
+        {
+            name: DASHBOARD_NAME,
+            description:
+                'Weekly look at revenue and orders, reviewed by the whole team.',
+            tiles: [
+                revenueIntroTile,
+                totalRevenueTile,
+                revenueByPaymentTile,
+                signupsTile,
+                ordersIntroTile,
+                ordersOverTimeTile,
+                averageSpendTile,
+                lapsedCustomersTile,
+                walkthroughTile,
+            ],
+            tabs: [revenueTab, ordersTab],
+            slug: generateSlug(DASHBOARD_NAME),
+        },
+        { userUuid: david.user_uuid },
+        SEED_PROJECT.project_uuid,
+    );
+
+    const tileComments: SeedTileComments[] = [
+        {
+            tileUuid: revenueIntroTileUuid,
+            tileTitle: 'About this review',
+            threads: [
+                {
+                    author: editor,
+                    text: 'Can we say which date range this covers? Reviewers keep asking.',
+                    daysAgo: 9,
+                    resolved: true,
+                    replies: [
+                        {
+                            author: david,
+                            text: 'Added a line about the trailing 12 months.',
+                            daysAgo: 8,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            tileUuid: totalRevenueTileUuid,
+            tileTitle: "What's our total revenue to date?",
+            threads: [
+                {
+                    author: viewer,
+                    text: 'Does this include refunded orders? The finance number is about 4% lower.',
+                    daysAgo: 6,
+                    replies: [
+                        {
+                            author: editor,
+                            text: `${fullName(
+                                david,
+                            )} can you confirm whether the orders model filters refunds?`,
+                            html: `<p>${mention(
+                                david,
+                            )} can you confirm whether the orders model filters refunds?</p>`,
+                            mentions: [david],
+                            daysAgo: 5,
+                        },
+                        {
+                            author: david,
+                            text: "It doesn't yet. I'll add an is_refunded flag to the model this week.",
+                            daysAgo: 4,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            tileUuid: revenueByPaymentTileUuid,
+            tileTitle: 'How much revenue do we have per payment method?',
+            threads: [
+                {
+                    author: david,
+                    text: 'Gift card looks unusually high for March. Worth checking whether the bulk corporate order got coded as gift card.',
+                    daysAgo: 7,
+                },
+                {
+                    author: viewer,
+                    text: 'Could we sort this descending? Easier to scan.',
+                    daysAgo: 10,
+                    resolved: true,
+                    replies: [
+                        {
+                            author: david,
+                            text: 'Done.',
+                            daysAgo: 9,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            tileUuid: signupsTileUuid,
+            tileTitle: 'Customer signups by month',
+            threads: [
+                {
+                    author: viewer,
+                    text: 'Twelve slices is hard to read. A bar chart would work better here.',
+                    daysAgo: 3,
+                },
+            ],
+        },
+        {
+            tileUuid: ordersIntroTileUuid,
+            tileTitle: 'Orders and customer activity',
+            threads: [
+                {
+                    author: editor,
+                    text: 'Typo in the second sentence: "activty".',
+                    daysAgo: 11,
+                    resolved: true,
+                },
+            ],
+        },
+        {
+            tileUuid: ordersOverTimeTileUuid,
+            tileTitle: 'How many orders we have over time ?',
+            threads: [
+                {
+                    author: viewer,
+                    text: 'The dip in the second week of February lines up with the site outage, so it is real, not a data gap.',
+                    daysAgo: 5,
+                    replies: [
+                        {
+                            author: david,
+                            text: 'Thanks, I will add that as an annotation.',
+                            daysAgo: 4,
+                        },
+                    ],
+                },
+                {
+                    author: editor,
+                    text: 'Can we get this weekly instead of daily? Daily is too noisy to spot the trend.',
+                    daysAgo: 1,
+                },
+            ],
+        },
+        {
+            tileUuid: averageSpendTileUuid,
+            tileTitle: "What's the average spend per customer?",
+            threads: [
+                {
+                    author: editor,
+                    text: `${fullName(
+                        viewer,
+                    )} this is the chart you asked about in standup.`,
+                    html: `<p>${mention(
+                        viewer,
+                    )} this is the chart you asked about in standup.</p>`,
+                    mentions: [viewer],
+                    daysAgo: 2,
+                },
+            ],
+        },
+        {
+            tileUuid: lapsedCustomersTileUuid,
+            tileTitle: 'Which customers have not recently ordered an item?',
+            threads: [
+                {
+                    author: viewer,
+                    text: 'Could we add the last order date as a column?',
+                    daysAgo: 2,
+                },
+                {
+                    author: david,
+                    text: 'Hiding the customer id column would make this readable on a laptop.',
+                    daysAgo: 12,
+                    resolved: true,
+                },
+            ],
+        },
+        {
+            tileUuid: walkthroughTileUuid,
+            tileTitle: 'Walkthrough of this review',
+            threads: [
+                {
+                    author: editor,
+                    text: 'Worth re-recording once the refund filter lands.',
+                    daysAgo: 1,
+                },
+            ],
+        },
+    ];
+
+    return { dashboard, tileComments };
+}
+
+const daysAgo = (days: number, hour: number) => {
+    const date = new Date();
+    date.setDate(date.getDate() - days);
+    date.setHours(hour, 0, 0, 0);
+    return date;
+};
+
+export async function seed(knex: Knex): Promise<void> {
+    const { dashboard, tileComments } = await createDashboard(knex);
+
+    const insertComment = async (
+        tileUuid: string,
+        comment: Omit<SeedComment, 'replies'>,
+        replyTo: string | null,
+        hour: number,
+    ): Promise<string> => {
+        const [row] = await knex(DashboardTileCommentsTableName)
+            .insert({
+                text: comment.text,
+                text_html: sanitizeHtml(
+                    comment.html ?? `<p>${comment.text}</p>`,
+                ),
+                dashboard_tile_uuid: tileUuid,
+                reply_to: replyTo,
+                user_uuid: comment.author.user_uuid,
+                saved_chart_uuid: null,
+                mentions: (comment.mentions ?? []).map((u) => u.user_uuid),
+                resolved: comment.resolved ?? false,
+                created_at: daysAgo(comment.daysAgo, hour),
+            })
+            .returning('comment_id');
+        return row.comment_id;
+    };
+
+    const notify = async (
+        recipientUuid: string,
+        author: SeedUser,
+        commentId: string,
+        tileUuid: string,
+        tileTitle: string,
+        tagged: boolean,
+    ) => {
+        await knex(NotificationsTableName).insert({
+            user_uuid: recipientUuid,
+            resource_uuid: commentId,
+            resource_type: DbNotificationResourceType.DashboardComments,
+            message: `${fullName(author)} ${
+                tagged ? 'tagged you' : 'commented'
+            } in dashboard "${dashboard.name}" in tile "${tileTitle}"`,
+            url: `/dashboards/${dashboard.uuid}`,
+            metadata: JSON.stringify({
+                dashboard_uuid: dashboard.uuid,
+                dashboard_name: dashboard.name,
+                dashboard_tile_uuid: tileUuid,
+                dashboard_tile_name: tileTitle,
+            }),
+        });
+    };
+
+    const seedThread = async (
+        tileUuid: string,
+        tileTitle: string,
+        thread: SeedComment,
+    ) => {
+        const threadId = await insertComment(tileUuid, thread, null, 9);
+        const replies = thread.replies ?? [];
+        // Replies inherit the thread's resolved state.
+        const replyIds = await Promise.all(
+            replies.map((reply, index) =>
+                insertComment(
+                    tileUuid,
+                    { ...reply, resolved: thread.resolved },
+                    threadId,
+                    10 + index,
+                ),
+            ),
+        );
+        if (thread.resolved) return;
+
+        const notifyMentions = (
+            comment: Pick<SeedComment, 'author' | 'mentions'>,
+            commentId: string,
+        ) =>
+            (comment.mentions ?? []).map((mentioned) =>
+                notify(
+                    mentioned.user_uuid,
+                    comment.author,
+                    commentId,
+                    tileUuid,
+                    tileTitle,
+                    true,
+                ),
+            );
+
+        await Promise.all([
+            ...notifyMentions(thread, threadId),
+            ...replies.flatMap((reply, index) => {
+                const replyId = replyIds[index];
+                const mentionedUuids = (reply.mentions ?? []).map(
+                    (u) => u.user_uuid,
+                );
+                const earlierAuthors = new Set(
+                    [thread, ...replies.slice(0, index)].map(
+                        (c) => c.author.user_uuid,
+                    ),
+                );
+                const participantsToNotify = [...earlierAuthors].filter(
+                    (uuid) =>
+                        uuid !== reply.author.user_uuid &&
+                        !mentionedUuids.includes(uuid),
+                );
+                return [
+                    ...notifyMentions(reply, replyId),
+                    ...participantsToNotify.map((uuid) =>
+                        notify(
+                            uuid,
+                            reply.author,
+                            replyId,
+                            tileUuid,
+                            tileTitle,
+                            false,
+                        ),
+                    ),
+                ];
+            }),
+        ]);
+    };
+
+    await Promise.all(
+        tileComments.flatMap(({ tileUuid, tileTitle, threads }) =>
+            threads.map((thread) => seedThread(tileUuid, tileTitle, thread)),
+        ),
+    );
+}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -820,45 +820,44 @@ const DashboardHeader = memo(
                                 </Tooltip>
                             )}
 
-                        {canViewDashboardComments && !isFullscreen && (
-                            <Tooltip
-                                label="Comments"
-                                position="bottom"
-                                openDelay={200}
-                                transitionProps={{
-                                    transition: 'fade',
-                                    duration: 150,
-                                }}
-                            >
-                                <Indicator
-                                    inline
-                                    label={openThreadCount}
-                                    size={14}
-                                    offset={4}
-                                    disabled={openThreadCount === 0}
-                                    color={unreadCount > 0 ? 'red' : 'gray'}
-                                    styles={{
-                                        indicator: {
-                                            fontSize: 10,
-                                            padding: 0,
-                                        },
+                        {canViewDashboardComments &&
+                            !isFullscreen &&
+                            openThreadCount > 0 && (
+                                <Tooltip
+                                    label="Comments"
+                                    position="bottom"
+                                    openDelay={200}
+                                    transitionProps={{
+                                        transition: 'fade',
+                                        duration: 150,
                                     }}
                                 >
-                                    <ActionIcon
-                                        variant="default"
-                                        size="md"
-                                        aria-label="Dashboard comments"
-                                        data-testid="dashboard-comments-button"
-                                        onClick={openCommentsPanel}
+                                    <Indicator
+                                        inline
+                                        color="red"
+                                        size={7}
+                                        offset={3}
+                                        disabled={unreadCount === 0}
                                     >
-                                        <MantineIcon
-                                            icon={IconMessages}
-                                            size="md"
-                                        />
-                                    </ActionIcon>
-                                </Indicator>
-                            </Tooltip>
-                        )}
+                                        <Button
+                                            variant="default"
+                                            size="xs"
+                                            h={28}
+                                            px={8}
+                                            aria-label="Dashboard comments"
+                                            data-testid="dashboard-comments-button"
+                                            onClick={openCommentsPanel}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconMessages}
+                                                />
+                                            }
+                                        >
+                                            {openThreadCount}
+                                        </Button>
+                                    </Indicator>
+                                </Tooltip>
+                            )}
 
                         {userCanExportData && !isFullscreen && (
                             <ShareShortLinkButton />
@@ -873,7 +872,8 @@ const DashboardHeader = memo(
                                 disabled={
                                     !userCanManageDashboard &&
                                     !userCanExportData &&
-                                    !userCanViewContentAsCode
+                                    !userCanViewContentAsCode &&
+                                    !canViewDashboardComments
                                 }
                             >
                                 <Menu.Target>
@@ -909,6 +909,20 @@ const DashboardHeader = memo(
                                         dashboardUuid={dashboard.uuid}
                                         clickedFrom="dashboard_header"
                                     />
+                                    {canViewDashboardComments &&
+                                        openThreadCount === 0 && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconMessages}
+                                                    />
+                                                }
+                                                data-testid="dashboard-comments-menu-item"
+                                                onClick={openCommentsPanel}
+                                            >
+                                                Comments
+                                            </Menu.Item>
+                                        )}
                                     {/* TODO: add a create-issue entry point once the issues flow is finalized */}
                                     {!!userCanManageDashboard && (
                                         <>

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -14,6 +14,7 @@ import {
     Button,
     Divider,
     Group,
+    Indicator,
     Menu,
     Popover,
     Text,
@@ -37,6 +38,7 @@ import {
     IconHistory,
     IconInfoCircle,
     IconMaximize,
+    IconMessages,
     IconMinimize,
     IconPencil,
     IconPin,
@@ -57,6 +59,10 @@ import {
     RequestReviewModal,
     useContentReviewEligibility,
 } from '../../../ee/features/contentReview';
+import {
+    DashboardCommentsPanel,
+    useDashboardCommentsSummary,
+} from '../../../features/comments';
 import DashboardAsCodeModal from '../../../features/contentAsCode/components/DashboardAsCodeModal';
 import {
     DirectAccessModal,
@@ -209,6 +215,35 @@ const DashboardHeader = memo(
             grantRoles: [],
         });
         const [isPreAggAuditOpen, preAggAuditHandlers] = useDisclosure(false);
+        const [isCommentsPanelOpen, commentsPanelHandlers] =
+            useDisclosure(false);
+        const {
+            canViewDashboardComments,
+            openThreadCount,
+            unreadCount,
+            markAllAsViewed,
+        } = useDashboardCommentsSummary();
+        // Opening the panel reads the dashboard's threads, the same way
+        // opening a tile's popover reads that tile's.
+        const openCommentsPanel = useCallback(() => {
+            track({
+                name: EventName.DASHBOARD_COMMENTS_PANEL_OPENED,
+                properties: {
+                    dashboardUuid,
+                    openThreads: openThreadCount,
+                    unreadNotifications: unreadCount,
+                },
+            });
+            markAllAsViewed();
+            commentsPanelHandlers.open();
+        }, [
+            track,
+            dashboardUuid,
+            openThreadCount,
+            unreadCount,
+            markAllAsViewed,
+            commentsPanelHandlers,
+        ]);
         const [isPreAggRefreshOpen, preAggRefreshHandlers] =
             useDisclosure(false);
         const [isDashboardAsCodeModalOpen, dashboardAsCodeModalHandlers] =
@@ -785,6 +820,46 @@ const DashboardHeader = memo(
                                 </Tooltip>
                             )}
 
+                        {canViewDashboardComments && !isFullscreen && (
+                            <Tooltip
+                                label="Comments"
+                                position="bottom"
+                                openDelay={200}
+                                transitionProps={{
+                                    transition: 'fade',
+                                    duration: 150,
+                                }}
+                            >
+                                <Indicator
+                                    inline
+                                    label={openThreadCount}
+                                    size={14}
+                                    offset={4}
+                                    disabled={openThreadCount === 0}
+                                    color={unreadCount > 0 ? 'red' : 'gray'}
+                                    styles={{
+                                        indicator: {
+                                            fontSize: 10,
+                                            padding: 0,
+                                        },
+                                    }}
+                                >
+                                    <ActionIcon
+                                        variant="default"
+                                        size="md"
+                                        aria-label="Dashboard comments"
+                                        data-testid="dashboard-comments-button"
+                                        onClick={openCommentsPanel}
+                                    >
+                                        <MantineIcon
+                                            icon={IconMessages}
+                                            size="md"
+                                        />
+                                    </ActionIcon>
+                                </Indicator>
+                            </Tooltip>
+                        )}
+
                         {userCanExportData && !isFullscreen && (
                             <ShareShortLinkButton />
                         )}
@@ -1183,6 +1258,15 @@ const DashboardHeader = memo(
                                 />
                             )}
                     </Group>
+                )}
+                {canViewDashboardComments && (
+                    <DashboardCommentsPanel
+                        opened={isCommentsPanelOpen}
+                        onClose={commentsPanelHandlers.close}
+                        activeTabUuid={activeTabUuid}
+                        dashboardTabs={dashboardTabs ?? []}
+                        onSwitchTab={(tab) => onSwitchTab?.(tab)}
+                    />
                 )}
                 {preAggregatesEnabled && preAggregateStatuses && (
                     <PreAggregateAuditDrawer

--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -1,4 +1,8 @@
-import { sanitizeHtml, type Comment } from '@lightdash/common';
+import {
+    HTML_SANITIZE_DEFAULT_RULES,
+    sanitizeHtml,
+    type Comment,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Box,
@@ -23,6 +27,15 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import { getNameInitials } from '../utils';
 import styles from './CommentDetail.module.css';
 import { CommentTimestamp } from './CommentTimestamp';
+
+// Mentions are stored as styled spans; render them as the mention pill instead.
+const COMMENT_RENDER_RULES = {
+    ...HTML_SANITIZE_DEFAULT_RULES,
+    allowedAttributes: { span: ['class'] },
+    transformTags: {
+        span: () => ({ tagName: 'span', attribs: { class: 'ld-mention' } }),
+    },
+};
 
 type Props = {
     comment: Comment;
@@ -54,7 +67,7 @@ export const CommentDetail: FC<Props> = ({
      * precaution we also sanitize it before rendering.
      */
     const sanitizedCommentTextHtml = useMemo(
-        () => sanitizeHtml(comment.textHtml),
+        () => sanitizeHtml(comment.textHtml, COMMENT_RENDER_RULES),
         [comment.textHtml],
     );
 

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.module.css
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.module.css
@@ -1,11 +1,25 @@
 .root {
+    font-family: var(--mantine-font-family);
+    min-width: 180px;
+    max-width: 280px;
+    max-height: 180px;
     overflow-y: auto;
+    padding: var(--mantine-spacing-two);
 }
 
-.itemWrapper {
+.item {
+    display: block;
     width: 100%;
+    padding: var(--mantine-spacing-two) var(--mantine-spacing-xs);
+    border-radius: var(--mantine-radius-sm);
+    color: var(--mantine-color-text);
+}
 
-    &:hover {
-        background-color: var(--mantine-color-blue-1);
-    }
+.item[data-selected] {
+    background-color: var(--mantine-color-default-hover);
+}
+
+.item[data-disabled] {
+    color: var(--mantine-color-dimmed);
+    cursor: not-allowed;
 }

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/SuggestionList.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, List, Tooltip } from '@mantine/core';
+import { Paper, Text, Tooltip, UnstyledButton } from '@mantine/core';
 import { type SuggestionProps } from '@tiptap/suggestion';
 import { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
 import { type SuggestionsItem } from '../../types';
@@ -63,62 +63,34 @@ export const SuggestionList = forwardRef<
     }));
 
     return props.items.length > 0 ? (
-        <Card shadow="xs" p={0} withBorder={false} radius="sm">
-            <List
-                withPadding={false}
-                listStyleType="none"
-                mah={120}
-                classNames={{
-                    root: classes.root,
-                    itemWrapper: classes.itemWrapper,
-                }}
-            >
-                {props.items.map((item, index) => (
-                    <List.Item key={index} fz="xs">
-                        <Tooltip
-                            fz="xs"
-                            label="User doesn't have access to this Dashboard's space"
-                            disabled={!item.disabled}
-                            position="right"
-                        >
-                            <Button
-                                size="compact-sm"
-                                onClick={() => {
-                                    if (item.disabled) return;
-                                    selectItem(index);
-                                }}
-                                styles={(theme) => ({
-                                    root: {
-                                        width: '100%',
-                                        fontSize: theme.fontSizes.xs,
-                                        fontWeight: 400,
-                                        textAlign: 'left',
-                                        backgroundColor:
-                                            theme.colors.background[0],
-                                        color:
-                                            index === selectedIndex
-                                                ? theme.colors.blue[6]
-                                                : theme.colors.ldGray[7],
-                                        opacity: item.disabled ? 0.5 : 1,
-                                        cursor: item.disabled
-                                            ? 'not-allowed'
-                                            : 'pointer',
-                                        '&:hover': {
-                                            backgroundColor:
-                                                theme.colors.blue[1],
-                                        },
-                                    },
-                                    inner: {
-                                        justifyContent: 'flex-start',
-                                    },
-                                })}
-                            >
-                                {item.label}
-                            </Button>
-                        </Tooltip>
-                    </List.Item>
-                ))}
-            </List>
-        </Card>
+        <Paper shadow="md" className={classes.root} role="listbox">
+            {props.items.map((item, index) => (
+                <Tooltip
+                    key={item.id}
+                    fz="xs"
+                    label="User doesn't have access to this Dashboard's space"
+                    disabled={!item.disabled}
+                    position="right"
+                >
+                    <UnstyledButton
+                        className={classes.item}
+                        role="option"
+                        aria-selected={index === selectedIndex}
+                        aria-disabled={item.disabled || undefined}
+                        data-selected={index === selectedIndex || undefined}
+                        data-disabled={item.disabled || undefined}
+                        onMouseEnter={() => setSelectedIndex(index)}
+                        onClick={() => {
+                            if (item.disabled) return;
+                            selectItem(index);
+                        }}
+                    >
+                        <Text fz="xs" truncate>
+                            {item.label}
+                        </Text>
+                    </UnstyledButton>
+                </Tooltip>
+            ))}
+        </Paper>
     ) : null;
 });

--- a/packages/frontend/src/features/comments/components/CommentWithMentions/index.tsx
+++ b/packages/frontend/src/features/comments/components/CommentWithMentions/index.tsx
@@ -1,4 +1,3 @@
-import { useMantineTheme } from '@mantine/core';
 import { RichTextEditor } from '@mantine/tiptap';
 import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -24,8 +23,6 @@ export const CommentWithMentions: FC<Props> = ({
     shouldClearEditor,
     setShouldClearEditor,
 }) => {
-    const theme = useMantineTheme();
-
     const fetchSuggestionsRef = useRef(fetchSuggestions);
     useEffect(() => {
         fetchSuggestionsRef.current = fetchSuggestions;
@@ -44,9 +41,7 @@ export const CommentWithMentions: FC<Props> = ({
                 trailingNode: false,
             }),
             Mention.configure({
-                HTMLAttributes: {
-                    style: `color: ${theme.colors.blue['6']}; font-weight: 500;`,
-                },
+                HTMLAttributes: { class: 'ld-mention' },
                 suggestion: generateAsyncSuggestionWrapper((query) =>
                     fetchSuggestionsRef.current(query),
                 ),

--- a/packages/frontend/src/features/comments/components/DashboardCommentsPanel.module.css
+++ b/packages/frontend/src/features/comments/components/DashboardCommentsPanel.module.css
@@ -1,0 +1,61 @@
+.body {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+}
+
+.toolbar {
+    padding: 0 var(--mantine-spacing-md) var(--mantine-spacing-sm);
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+    @mixin dark {
+        border-bottom-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.scroll {
+    flex: 1;
+    min-height: 0;
+}
+
+.group {
+    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
+    border-bottom: 1px solid var(--mantine-color-ldGray-1);
+    @mixin dark {
+        border-bottom-color: var(--mantine-color-ldDark-5);
+    }
+}
+
+.group:last-child {
+    border-bottom: none;
+}
+
+.groupHeader {
+    margin-bottom: var(--mantine-spacing-xs);
+}
+
+.groupTitle {
+    min-width: 0;
+    flex: 1;
+}
+
+.tabBadge {
+    flex-shrink: 0;
+}
+
+.goToTile {
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.group:hover .goToTile,
+.group:focus-within .goToTile,
+.goToTile:focus-visible {
+    opacity: 1;
+}
+
+.empty {
+    padding: var(--mantine-spacing-xl) var(--mantine-spacing-md);
+}

--- a/packages/frontend/src/features/comments/components/DashboardCommentsPanel.module.css
+++ b/packages/frontend/src/features/comments/components/DashboardCommentsPanel.module.css
@@ -1,61 +1,76 @@
 .body {
-    display: flex;
-    flex-direction: column;
     flex: 1;
     min-height: 0;
+    overflow-y: auto;
     padding: 0;
+    background: var(--ld-color-page);
 }
 
-.toolbar {
-    padding: 0 var(--mantine-spacing-md) var(--mantine-spacing-sm);
-    border-bottom: 1px solid var(--mantine-color-ldGray-2);
-    @mixin dark {
-        border-bottom-color: var(--mantine-color-ldDark-4);
-    }
+.list {
+    padding: var(--mantine-spacing-sm);
 }
 
-.scroll {
+.sectionHeader {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    width: 100%;
+    padding: var(--mantine-spacing-xs) 0;
+    margin-bottom: var(--mantine-spacing-two);
+    background: var(--ld-color-page);
+    border-radius: 0;
+}
+
+.sectionHeader[data-active] {
+    cursor: default;
+}
+
+.sectionLabel {
     flex: 1;
-    min-height: 0;
-}
-
-.group {
-    padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
-    border-bottom: 1px solid var(--mantine-color-ldGray-1);
-    @mixin dark {
-        border-bottom-color: var(--mantine-color-ldDark-5);
-    }
-}
-
-.group:last-child {
-    border-bottom: none;
-}
-
-.groupHeader {
-    margin-bottom: var(--mantine-spacing-xs);
-}
-
-.groupTitle {
     min-width: 0;
+}
+
+.section + .section {
+    margin-top: var(--mantine-spacing-sm);
+}
+
+.tileHeader {
+    width: 100%;
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+    border-bottom: 1px solid var(--mantine-color-default-border);
+    border-radius: 0;
+    border-start-start-radius: inherit;
+    border-start-end-radius: inherit;
+}
+
+.tileHeader[data-clickable]:hover {
+    background: var(--mantine-color-default-hover);
+}
+
+.tileTitle {
     flex: 1;
+    min-width: 0;
 }
 
-.tabBadge {
-    flex-shrink: 0;
-}
-
-.goToTile {
+.goToIcon {
     flex-shrink: 0;
     opacity: 0;
     transition: opacity 0.15s ease;
 }
 
-.group:hover .goToTile,
-.group:focus-within .goToTile,
-.goToTile:focus-visible {
+.tileHeader:hover .goToIcon,
+.tileHeader:focus-visible .goToIcon {
     opacity: 1;
 }
 
-.empty {
-    padding: var(--mantine-spacing-xl) var(--mantine-spacing-md);
+.thread {
+    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
+}
+
+.thread + .thread {
+    border-top: 1px solid var(--mantine-color-ldGray-1);
+}
+
+.resolvedToggle {
+    margin-top: var(--mantine-spacing-sm);
 }

--- a/packages/frontend/src/features/comments/components/DashboardCommentsPanel.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentsPanel.tsx
@@ -1,0 +1,311 @@
+import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Drawer,
+    Group,
+    Loader,
+    Paper,
+    ScrollArea,
+    SegmentedControl,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine/core';
+import {
+    IconAppWindow,
+    IconChartBar,
+    IconFocusCentered,
+    IconHeading,
+    IconMarkdown,
+    IconMessages,
+    IconSquareOff,
+    IconVideo,
+} from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { scrollToDashboardTile } from '../../../components/common/Dashboard/scrollToDashboardTile';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import { useGetResolvedComments } from '../hooks/useComments';
+import {
+    countThreads,
+    groupCommentsByTile,
+    type TileCommentGroup,
+} from '../utils/groupCommentsByTile';
+import { DashboardCommentAndReplies } from './DashboardCommentAndReplies';
+import classes from './DashboardCommentsPanel.module.css';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    activeTabUuid: string | undefined;
+    dashboardTabs: Dashboard['tabs'];
+    onSwitchTab: (tab: Dashboard['tabs'][number]) => void;
+};
+
+type ThreadView = 'open' | 'resolved';
+
+const PANEL_WIDTH = 440;
+// Long enough for the tab switch to mount its tiles before scrolling.
+const TAB_SWITCH_SCROLL_DELAY_MS = 150;
+
+const tileIcon = (tileType: DashboardTileTypes | null) => {
+    switch (tileType) {
+        case DashboardTileTypes.SAVED_CHART:
+        case DashboardTileTypes.SQL_CHART:
+            return IconChartBar;
+        case DashboardTileTypes.MARKDOWN:
+            return IconMarkdown;
+        case DashboardTileTypes.LOOM:
+            return IconVideo;
+        case DashboardTileTypes.HEADING:
+            return IconHeading;
+        case DashboardTileTypes.DATA_APP:
+            return IconAppWindow;
+        case null:
+            return IconSquareOff;
+        default:
+            return IconChartBar;
+    }
+};
+
+const TileGroup: FC<{
+    group: TileCommentGroup;
+    tabName: string | undefined;
+    projectUuid: string;
+    dashboardUuid: string;
+    isResolved: boolean;
+    onGoToTile: (group: TileCommentGroup) => void;
+}> = ({
+    group,
+    tabName,
+    projectUuid,
+    dashboardUuid,
+    isResolved,
+    onGoToTile,
+}) => {
+    const canGoToTile = group.tileType !== null;
+    return (
+        <div className={classes.group} data-testid="dashboard-comments-group">
+            <Group
+                className={classes.groupHeader}
+                justify="space-between"
+                wrap="nowrap"
+                gap="xs"
+            >
+                <Group gap="xs" wrap="nowrap" className={classes.groupTitle}>
+                    <MantineIcon
+                        icon={tileIcon(group.tileType)}
+                        color="ldGray.6"
+                    />
+                    <Text fz="xs" fw={600} truncate>
+                        {group.title}
+                    </Text>
+                    {tabName && (
+                        <Badge
+                            size="xs"
+                            variant="light"
+                            color="gray"
+                            className={classes.tabBadge}
+                        >
+                            {tabName}
+                        </Badge>
+                    )}
+                </Group>
+                {canGoToTile && (
+                    <Tooltip label="Go to tile" position="left">
+                        <ActionIcon
+                            className={classes.goToTile}
+                            size="xs"
+                            variant="subtle"
+                            color="gray"
+                            aria-label={`Go to tile ${group.title}`}
+                            onClick={() => onGoToTile(group)}
+                        >
+                            <MantineIcon icon={IconFocusCentered} />
+                        </ActionIcon>
+                    </Tooltip>
+                )}
+            </Group>
+            <Stack gap="sm">
+                {group.threads.map((thread) => (
+                    <DashboardCommentAndReplies
+                        key={thread.commentId}
+                        comment={thread}
+                        projectUuid={projectUuid}
+                        dashboardUuid={dashboardUuid}
+                        dashboardTileUuid={group.tileUuid}
+                        targetRef={null}
+                        isResolved={isResolved}
+                    />
+                ))}
+            </Stack>
+        </div>
+    );
+};
+
+export const DashboardCommentsPanel: FC<Props> = ({
+    opened,
+    onClose,
+    activeTabUuid,
+    dashboardTabs,
+    onSwitchTab,
+}) => {
+    const projectUuid = useDashboardContext((c) => c.projectUuid);
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
+    const dashboardTiles = useDashboardContext((c) => c.dashboardTiles);
+    const openComments = useDashboardContext((c) => c.dashboardComments);
+    const canCreateDashboardComments = !!useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canCreateDashboardComments,
+    );
+    const canViewDashboardComments = !!useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canViewDashboardComments,
+    );
+
+    const [view, setView] = useState<ThreadView>('open');
+
+    const { data: resolvedComments, isInitialLoading: isLoadingResolved } =
+        useGetResolvedComments(
+            dashboardUuid ?? '',
+            projectUuid,
+            opened && canViewDashboardComments && !!dashboardUuid,
+        );
+
+    const openGroups = useMemo(
+        () =>
+            groupCommentsByTile({
+                commentsByTile: openComments ?? {},
+                tiles: dashboardTiles ?? [],
+                tabs: dashboardTabs,
+            }),
+        [openComments, dashboardTiles, dashboardTabs],
+    );
+    const resolvedGroups = useMemo(
+        () =>
+            groupCommentsByTile({
+                commentsByTile: resolvedComments ?? {},
+                tiles: dashboardTiles ?? [],
+                tabs: dashboardTabs,
+            }),
+        [resolvedComments, dashboardTiles, dashboardTabs],
+    );
+    const openCount = countThreads(openGroups);
+    const resolvedCount = countThreads(resolvedGroups);
+
+    const tabNames = useMemo(
+        () => new Map(dashboardTabs.map((tab) => [tab.uuid, tab.name])),
+        [dashboardTabs],
+    );
+    const hasTabs = dashboardTabs.length > 1;
+
+    const handleGoToTile = useCallback(
+        (group: TileCommentGroup) => {
+            const targetTab = group.tabUuid
+                ? dashboardTabs.find((tab) => tab.uuid === group.tabUuid)
+                : undefined;
+            if (targetTab && targetTab.uuid !== activeTabUuid) {
+                onSwitchTab(targetTab);
+                setTimeout(
+                    () => scrollToDashboardTile(group.tileUuid),
+                    TAB_SWITCH_SCROLL_DELAY_MS,
+                );
+                return;
+            }
+            scrollToDashboardTile(group.tileUuid);
+        },
+        [activeTabUuid, dashboardTabs, onSwitchTab],
+    );
+
+    if (!projectUuid || !dashboardUuid) return null;
+
+    const groups = view === 'open' ? openGroups : resolvedGroups;
+    const isResolvedView = view === 'resolved';
+
+    return (
+        <Drawer.Root
+            opened={opened}
+            onClose={onClose}
+            position="right"
+            size={PANEL_WIDTH}
+            lockScroll={false}
+        >
+            <Drawer.Overlay opacity={0.1} blur={0} />
+            <Drawer.Content data-testid="dashboard-comments-panel">
+                <Drawer.Header>
+                    <Drawer.Title>
+                        <Group gap="xs">
+                            <Paper p="6px" radius="md" bg="ldGray.0">
+                                <MantineIcon
+                                    icon={IconMessages}
+                                    size="sm"
+                                    color="ldDark.9"
+                                />
+                            </Paper>
+                            <Text fw={600} fz="sm">
+                                Comments
+                            </Text>
+                        </Group>
+                    </Drawer.Title>
+                    <Drawer.CloseButton />
+                </Drawer.Header>
+                <Drawer.Body className={classes.body}>
+                    <div className={classes.toolbar}>
+                        <SegmentedControl
+                            fullWidth
+                            size="xs"
+                            value={view}
+                            onChange={(value) => setView(value as ThreadView)}
+                            data={[
+                                { value: 'open', label: `Open (${openCount})` },
+                                {
+                                    value: 'resolved',
+                                    label: isLoadingResolved
+                                        ? 'Resolved'
+                                        : `Resolved (${resolvedCount})`,
+                                },
+                            ]}
+                        />
+                    </div>
+                    <ScrollArea className={classes.scroll} type="hover">
+                        {isResolvedView && isLoadingResolved ? (
+                            <Group justify="center" className={classes.empty}>
+                                <Loader size="sm" color="gray" />
+                            </Group>
+                        ) : groups.length === 0 ? (
+                            <Stack gap="two" className={classes.empty}>
+                                <Text fz="sm" fw={500} ta="center">
+                                    {isResolvedView
+                                        ? 'No resolved comments'
+                                        : 'No open comments'}
+                                </Text>
+                                {!isResolvedView && (
+                                    <Text fz="xs" c="dimmed" ta="center">
+                                        {canCreateDashboardComments
+                                            ? 'Hover over a tile and use its speech bubble to start a thread.'
+                                            : 'Threads started on any tile will show up here.'}
+                                    </Text>
+                                )}
+                            </Stack>
+                        ) : (
+                            groups.map((group) => (
+                                <TileGroup
+                                    key={group.tileUuid}
+                                    group={group}
+                                    tabName={
+                                        hasTabs && group.tabUuid
+                                            ? tabNames.get(group.tabUuid)
+                                            : undefined
+                                    }
+                                    projectUuid={projectUuid}
+                                    dashboardUuid={dashboardUuid}
+                                    isResolved={isResolvedView}
+                                    onGoToTile={handleGoToTile}
+                                />
+                            ))
+                        )}
+                    </ScrollArea>
+                </Drawer.Body>
+            </Drawer.Content>
+        </Drawer.Root>
+    );
+};

--- a/packages/frontend/src/features/comments/components/DashboardCommentsPanel.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentsPanel.tsx
@@ -1,36 +1,40 @@
 import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
 import {
-    ActionIcon,
-    Badge,
+    Button,
+    Collapse,
+    Divider,
     Drawer,
     Group,
-    Loader,
     Paper,
-    ScrollArea,
-    SegmentedControl,
     Stack,
     Text,
     Tooltip,
 } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import {
     IconAppWindow,
+    IconArrowUpRight,
     IconChartBar,
-    IconFocusCentered,
+    IconChevronDown,
+    IconChevronUp,
     IconHeading,
     IconMarkdown,
     IconMessages,
     IconSquareOff,
     IconVideo,
 } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { scrollToDashboardTile } from '../../../components/common/Dashboard/scrollToDashboardTile';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { PolymorphicGroupButton } from '../../../components/common/PolymorphicGroupButton';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
 import { useGetResolvedComments } from '../hooks/useComments';
 import {
     countThreads,
     groupCommentsByTile,
+    sectionGroupsByTab,
     type TileCommentGroup,
+    type TileCommentSection,
 } from '../utils/groupCommentsByTile';
 import { DashboardCommentAndReplies } from './DashboardCommentAndReplies';
 import classes from './DashboardCommentsPanel.module.css';
@@ -43,9 +47,7 @@ type Props = {
     onSwitchTab: (tab: Dashboard['tabs'][number]) => void;
 };
 
-type ThreadView = 'open' | 'resolved';
-
-const PANEL_WIDTH = 440;
+const PANEL_WIDTH = 420;
 // Long enough for the tab switch to mount its tiles before scrolling.
 const TAB_SWITCH_SCROLL_DELAY_MS = 150;
 
@@ -69,68 +71,72 @@ const tileIcon = (tileType: DashboardTileTypes | null) => {
     }
 };
 
-const TileGroup: FC<{
+const TileCard: FC<{
     group: TileCommentGroup;
-    tabName: string | undefined;
     projectUuid: string;
     dashboardUuid: string;
     isResolved: boolean;
     onGoToTile: (group: TileCommentGroup) => void;
-}> = ({
-    group,
-    tabName,
-    projectUuid,
-    dashboardUuid,
-    isResolved,
-    onGoToTile,
-}) => {
+}> = ({ group, projectUuid, dashboardUuid, isResolved, onGoToTile }) => {
     const canGoToTile = group.tileType !== null;
     return (
-        <div className={classes.group} data-testid="dashboard-comments-group">
-            <Group
-                className={classes.groupHeader}
-                justify="space-between"
-                wrap="nowrap"
-                gap="xs"
+        <Paper
+            className={classes.tileCard}
+            data-testid="dashboard-comments-group"
+        >
+            <Tooltip
+                label="Go to tile"
+                position="top-start"
+                openDelay={400}
+                disabled={!canGoToTile}
             >
-                <Group gap="xs" wrap="nowrap" className={classes.groupTitle}>
+                <PolymorphicGroupButton
+                    component="div"
+                    role={canGoToTile ? 'button' : undefined}
+                    tabIndex={canGoToTile ? 0 : undefined}
+                    aria-label={
+                        canGoToTile ? `Go to tile ${group.title}` : undefined
+                    }
+                    data-clickable={canGoToTile || undefined}
+                    className={classes.tileHeader}
+                    gap="xs"
+                    wrap="nowrap"
+                    onClick={canGoToTile ? () => onGoToTile(group) : undefined}
+                    onKeyDown={(event) => {
+                        if (
+                            canGoToTile &&
+                            (event.key === 'Enter' || event.key === ' ')
+                        ) {
+                            event.preventDefault();
+                            onGoToTile(group);
+                        }
+                    }}
+                >
                     <MantineIcon
                         icon={tileIcon(group.tileType)}
-                        color="ldGray.6"
+                        color="dimmed"
                     />
-                    <Text fz="xs" fw={600} truncate>
+                    <Text
+                        fz="xs"
+                        fw={500}
+                        c={canGoToTile ? undefined : 'dimmed'}
+                        truncate
+                        className={classes.tileTitle}
+                    >
                         {group.title}
                     </Text>
-                    {tabName && (
-                        <Badge
-                            size="xs"
-                            variant="light"
-                            color="gray"
-                            className={classes.tabBadge}
-                        >
-                            {tabName}
-                        </Badge>
+                    {canGoToTile && (
+                        <MantineIcon
+                            icon={IconArrowUpRight}
+                            color="dimmed"
+                            className={classes.goToIcon}
+                        />
                     )}
-                </Group>
-                {canGoToTile && (
-                    <Tooltip label="Go to tile" position="left">
-                        <ActionIcon
-                            className={classes.goToTile}
-                            size="xs"
-                            variant="subtle"
-                            color="gray"
-                            aria-label={`Go to tile ${group.title}`}
-                            onClick={() => onGoToTile(group)}
-                        >
-                            <MantineIcon icon={IconFocusCentered} />
-                        </ActionIcon>
-                    </Tooltip>
-                )}
-            </Group>
-            <Stack gap="sm">
-                {group.threads.map((thread) => (
+                </PolymorphicGroupButton>
+            </Tooltip>
+            {group.threads.map((thread) => (
+                <div key={thread.commentId} className={classes.thread}>
                     <DashboardCommentAndReplies
-                        key={thread.commentId}
                         comment={thread}
                         projectUuid={projectUuid}
                         dashboardUuid={dashboardUuid}
@@ -138,11 +144,87 @@ const TileGroup: FC<{
                         targetRef={null}
                         isResolved={isResolved}
                     />
-                ))}
-            </Stack>
-        </div>
+                </div>
+            ))}
+        </Paper>
     );
 };
+
+const SectionList: FC<{
+    sections: TileCommentSection[];
+    showSectionHeaders: boolean;
+    activeTabUuid: string | undefined;
+    projectUuid: string;
+    dashboardUuid: string;
+    isResolved: boolean;
+    onSelectTab: (tabUuid: string) => void;
+    onGoToTile: (group: TileCommentGroup) => void;
+}> = ({
+    sections,
+    showSectionHeaders,
+    activeTabUuid,
+    projectUuid,
+    dashboardUuid,
+    isResolved,
+    onSelectTab,
+    onGoToTile,
+}) => (
+    <>
+        {sections.map((section) => {
+            const { tabUuid } = section;
+            const isActive = tabUuid !== null && tabUuid === activeTabUuid;
+            const canSelect = tabUuid !== null && !isActive;
+            return (
+                <div
+                    key={section.tabUuid ?? 'removed'}
+                    className={classes.section}
+                >
+                    {(showSectionHeaders || tabUuid === null) && (
+                        <PolymorphicGroupButton
+                            component="div"
+                            role={canSelect ? 'button' : undefined}
+                            tabIndex={canSelect ? 0 : undefined}
+                            className={classes.sectionHeader}
+                            data-active={isActive || undefined}
+                            gap="xs"
+                            wrap="nowrap"
+                            onClick={
+                                tabUuid !== null && canSelect
+                                    ? () => onSelectTab(tabUuid)
+                                    : undefined
+                            }
+                        >
+                            <Text
+                                fz="xs"
+                                fw={500}
+                                c={isActive ? undefined : 'dimmed'}
+                                truncate
+                                className={classes.sectionLabel}
+                            >
+                                {section.label}
+                            </Text>
+                            <Text fz="xs" c="dimmed">
+                                {countThreads(section.groups)}
+                            </Text>
+                        </PolymorphicGroupButton>
+                    )}
+                    <Stack gap="xs">
+                        {section.groups.map((group) => (
+                            <TileCard
+                                key={group.tileUuid}
+                                group={group}
+                                projectUuid={projectUuid}
+                                dashboardUuid={dashboardUuid}
+                                isResolved={isResolved}
+                                onGoToTile={onGoToTile}
+                            />
+                        ))}
+                    </Stack>
+                </div>
+            );
+        })}
+    </>
+);
 
 export const DashboardCommentsPanel: FC<Props> = ({
     opened,
@@ -162,14 +244,13 @@ export const DashboardCommentsPanel: FC<Props> = ({
         (c) => c.dashboardCommentsCheck?.canViewDashboardComments,
     );
 
-    const [view, setView] = useState<ThreadView>('open');
+    const [showResolved, { toggle: toggleShowResolved }] = useDisclosure(false);
 
-    const { data: resolvedComments, isInitialLoading: isLoadingResolved } =
-        useGetResolvedComments(
-            dashboardUuid ?? '',
-            projectUuid,
-            opened && canViewDashboardComments && !!dashboardUuid,
-        );
+    const { data: resolvedComments } = useGetResolvedComments(
+        dashboardUuid ?? '',
+        projectUuid,
+        opened && canViewDashboardComments && !!dashboardUuid,
+    );
 
     const openGroups = useMemo(
         () =>
@@ -189,22 +270,30 @@ export const DashboardCommentsPanel: FC<Props> = ({
             }),
         [resolvedComments, dashboardTiles, dashboardTabs],
     );
+    const openSections = useMemo(
+        () => sectionGroupsByTab(openGroups, dashboardTabs),
+        [openGroups, dashboardTabs],
+    );
+    const resolvedSections = useMemo(
+        () => sectionGroupsByTab(resolvedGroups, dashboardTabs),
+        [resolvedGroups, dashboardTabs],
+    );
     const openCount = countThreads(openGroups);
     const resolvedCount = countThreads(resolvedGroups);
-
-    const tabNames = useMemo(
-        () => new Map(dashboardTabs.map((tab) => [tab.uuid, tab.name])),
-        [dashboardTabs],
-    );
     const hasTabs = dashboardTabs.length > 1;
+
+    const handleSelectTab = useCallback(
+        (tabUuid: string) => {
+            const tab = dashboardTabs.find((t) => t.uuid === tabUuid);
+            if (tab) onSwitchTab(tab);
+        },
+        [dashboardTabs, onSwitchTab],
+    );
 
     const handleGoToTile = useCallback(
         (group: TileCommentGroup) => {
-            const targetTab = group.tabUuid
-                ? dashboardTabs.find((tab) => tab.uuid === group.tabUuid)
-                : undefined;
-            if (targetTab && targetTab.uuid !== activeTabUuid) {
-                onSwitchTab(targetTab);
+            if (group.tabUuid && group.tabUuid !== activeTabUuid) {
+                handleSelectTab(group.tabUuid);
                 setTimeout(
                     () => scrollToDashboardTile(group.tileUuid),
                     TAB_SWITCH_SCROLL_DELAY_MS,
@@ -213,13 +302,15 @@ export const DashboardCommentsPanel: FC<Props> = ({
             }
             scrollToDashboardTile(group.tileUuid);
         },
-        [activeTabUuid, dashboardTabs, onSwitchTab],
+        [activeTabUuid, handleSelectTab],
     );
 
     if (!projectUuid || !dashboardUuid) return null;
 
-    const groups = view === 'open' ? openGroups : resolvedGroups;
-    const isResolvedView = view === 'resolved';
+    const summary = [
+        `${openCount} open`,
+        ...(resolvedCount > 0 ? [`${resolvedCount} resolved`] : []),
+    ].join(' · ');
 
     return (
         <Drawer.Root
@@ -233,7 +324,7 @@ export const DashboardCommentsPanel: FC<Props> = ({
             <Drawer.Content data-testid="dashboard-comments-panel">
                 <Drawer.Header>
                     <Drawer.Title>
-                        <Group gap="xs">
+                        <Group gap="xs" wrap="nowrap">
                             <Paper p="6px" radius="md" bg="ldGray.0">
                                 <MantineIcon
                                     icon={IconMessages}
@@ -241,69 +332,86 @@ export const DashboardCommentsPanel: FC<Props> = ({
                                     color="ldDark.9"
                                 />
                             </Paper>
-                            <Text fw={600} fz="sm">
-                                Comments
-                            </Text>
+                            <div>
+                                <Text fw={600} fz="sm">
+                                    Comments
+                                </Text>
+                                <Text fz="xs" c="dimmed">
+                                    {summary}
+                                </Text>
+                            </div>
                         </Group>
                     </Drawer.Title>
                     <Drawer.CloseButton />
                 </Drawer.Header>
                 <Drawer.Body className={classes.body}>
-                    <div className={classes.toolbar}>
-                        <SegmentedControl
-                            fullWidth
-                            size="xs"
-                            value={view}
-                            onChange={(value) => setView(value as ThreadView)}
-                            data={[
-                                { value: 'open', label: `Open (${openCount})` },
-                                {
-                                    value: 'resolved',
-                                    label: isLoadingResolved
-                                        ? 'Resolved'
-                                        : `Resolved (${resolvedCount})`,
-                                },
-                            ]}
-                        />
-                    </div>
-                    <ScrollArea className={classes.scroll} type="hover">
-                        {isResolvedView && isLoadingResolved ? (
-                            <Group justify="center" className={classes.empty}>
-                                <Loader size="sm" color="gray" />
-                            </Group>
-                        ) : groups.length === 0 ? (
-                            <Stack gap="two" className={classes.empty}>
-                                <Text fz="sm" fw={500} ta="center">
-                                    {isResolvedView
-                                        ? 'No resolved comments'
-                                        : 'No open comments'}
-                                </Text>
-                                {!isResolvedView && (
+                    <div className={classes.list}>
+                        {openCount === 0 && (
+                            <Paper variant="dotted" p="lg">
+                                <Stack gap="two">
+                                    <Text fz="sm" fw={500} ta="center">
+                                        No open comments
+                                    </Text>
                                     <Text fz="xs" c="dimmed" ta="center">
                                         {canCreateDashboardComments
                                             ? 'Hover over a tile and use its speech bubble to start a thread.'
                                             : 'Threads started on any tile will show up here.'}
                                     </Text>
-                                )}
-                            </Stack>
-                        ) : (
-                            groups.map((group) => (
-                                <TileGroup
-                                    key={group.tileUuid}
-                                    group={group}
-                                    tabName={
-                                        hasTabs && group.tabUuid
-                                            ? tabNames.get(group.tabUuid)
-                                            : undefined
-                                    }
-                                    projectUuid={projectUuid}
-                                    dashboardUuid={dashboardUuid}
-                                    isResolved={isResolvedView}
-                                    onGoToTile={handleGoToTile}
-                                />
-                            ))
+                                </Stack>
+                            </Paper>
                         )}
-                    </ScrollArea>
+                        <SectionList
+                            sections={openSections}
+                            showSectionHeaders={hasTabs}
+                            activeTabUuid={activeTabUuid}
+                            projectUuid={projectUuid}
+                            dashboardUuid={dashboardUuid}
+                            isResolved={false}
+                            onSelectTab={handleSelectTab}
+                            onGoToTile={handleGoToTile}
+                        />
+                        {resolvedCount > 0 && (
+                            <>
+                                <Divider
+                                    className={classes.resolvedToggle}
+                                    labelPosition="left"
+                                    label={
+                                        <Button
+                                            size="compact-xs"
+                                            variant="subtle"
+                                            color="gray"
+                                            fz="xs"
+                                            onClick={toggleShowResolved}
+                                            rightSection={
+                                                <MantineIcon
+                                                    icon={
+                                                        showResolved
+                                                            ? IconChevronUp
+                                                            : IconChevronDown
+                                                    }
+                                                />
+                                            }
+                                        >
+                                            {showResolved ? 'Hide' : 'Show'}{' '}
+                                            resolved ({resolvedCount})
+                                        </Button>
+                                    }
+                                />
+                                <Collapse expanded={showResolved}>
+                                    <SectionList
+                                        sections={resolvedSections}
+                                        showSectionHeaders={hasTabs}
+                                        activeTabUuid={activeTabUuid}
+                                        projectUuid={projectUuid}
+                                        dashboardUuid={dashboardUuid}
+                                        isResolved
+                                        onSelectTab={handleSelectTab}
+                                        onGoToTile={handleGoToTile}
+                                    />
+                                </Collapse>
+                            </>
+                        )}
+                    </div>
                 </Drawer.Body>
             </Drawer.Content>
         </Drawer.Root>

--- a/packages/frontend/src/features/comments/hooks/useDashboardCommentsSummary.ts
+++ b/packages/frontend/src/features/comments/hooks/useDashboardCommentsSummary.ts
@@ -1,0 +1,59 @@
+import { NotificationResourceType } from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import {
+    useGetNotifications,
+    useUpdateNotification,
+} from '../../notifications/hooks/useNotifications';
+
+/**
+ * Dashboard-wide view of the comment state the tiles otherwise expose one at
+ * a time: how many open threads there are, and which comment notifications
+ * for this dashboard the user has not looked at yet.
+ */
+export const useDashboardCommentsSummary = () => {
+    const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
+    const canViewDashboardComments = !!useDashboardContext(
+        (c) => c.dashboardCommentsCheck?.canViewDashboardComments,
+    );
+    const dashboardComments = useDashboardContext((c) => c.dashboardComments);
+
+    const openThreadCount = useMemo(
+        () =>
+            Object.values(dashboardComments ?? {}).reduce(
+                (total, threads) => total + threads.length,
+                0,
+            ),
+        [dashboardComments],
+    );
+
+    const { data: notifications } = useGetNotifications(
+        NotificationResourceType.DashboardComments,
+        canViewDashboardComments,
+    );
+    const unreadNotifications = useMemo(
+        () =>
+            (notifications ?? []).filter(
+                (n) => !n.viewed && n.metadata?.dashboardUuid === dashboardUuid,
+            ),
+        [notifications, dashboardUuid],
+    );
+
+    const { mutate: updateNotification } = useUpdateNotification();
+    const markAllAsViewed = useCallback(() => {
+        unreadNotifications.forEach((n) => {
+            updateNotification({
+                notificationId: n.notificationId,
+                resourceType: NotificationResourceType.DashboardComments,
+                toUpdate: { viewed: true },
+            });
+        });
+    }, [unreadNotifications, updateNotification]);
+
+    return {
+        canViewDashboardComments,
+        openThreadCount,
+        unreadCount: unreadNotifications.length,
+        markAllAsViewed,
+    };
+};

--- a/packages/frontend/src/features/comments/index.ts
+++ b/packages/frontend/src/features/comments/index.ts
@@ -1,3 +1,5 @@
+export * from './components/DashboardCommentsPanel';
 export * from './components/DashboardTileComments';
 export { useGetComments } from './hooks/useComments';
 export * from './hooks/useDashboardCommentsCheck';
+export * from './hooks/useDashboardCommentsSummary';

--- a/packages/frontend/src/features/comments/utils/groupCommentsByTile.test.ts
+++ b/packages/frontend/src/features/comments/utils/groupCommentsByTile.test.ts
@@ -1,0 +1,137 @@
+import {
+    DashboardTileTypes,
+    type Comment,
+    type DashboardTile,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import {
+    countThreads,
+    getTileTitle,
+    groupCommentsByTile,
+    REMOVED_TILE_TITLE,
+} from './groupCommentsByTile';
+
+const comment = (commentId: string): Comment => ({
+    commentId,
+    text: commentId,
+    textHtml: `<p>${commentId}</p>`,
+    createdAt: new Date('2026-09-01T00:00:00Z'),
+    user: {
+        name: 'Ada Lovelace',
+        userUuid: 'user-1',
+        avatarUrl: null,
+        avatarGradient: null,
+    },
+    replyTo: undefined,
+    replies: [],
+    resolved: false,
+    canRemove: false,
+    mentions: [],
+});
+
+const chartTile = (
+    uuid: string,
+    position: { x: number; y: number; tabUuid?: string },
+    title?: string,
+): DashboardTile => ({
+    uuid,
+    x: position.x,
+    y: position.y,
+    w: 6,
+    h: 3,
+    tabUuid: position.tabUuid,
+    type: DashboardTileTypes.SAVED_CHART,
+    properties: {
+        title,
+        savedChartUuid: `chart-${uuid}`,
+        chartName: `Chart ${uuid}`,
+    },
+});
+
+describe('groupCommentsByTile', () => {
+    it('orders groups by tab, then row, then column', () => {
+        const tiles = [
+            chartTile('b', { x: 6, y: 0, tabUuid: 'tab-1' }),
+            chartTile('d', { x: 0, y: 0, tabUuid: 'tab-2' }),
+            chartTile('a', { x: 0, y: 0, tabUuid: 'tab-1' }),
+            chartTile('c', { x: 0, y: 3, tabUuid: 'tab-1' }),
+        ];
+        const groups = groupCommentsByTile({
+            commentsByTile: {
+                d: [comment('d1')],
+                c: [comment('c1')],
+                b: [comment('b1')],
+                a: [comment('a1'), comment('a2')],
+            },
+            tiles,
+            tabs: [
+                { uuid: 'tab-2', name: 'Second', order: 1 },
+                { uuid: 'tab-1', name: 'First', order: 0 },
+            ],
+        });
+
+        expect(groups.map((group) => group.tileUuid)).toEqual([
+            'a',
+            'b',
+            'c',
+            'd',
+        ]);
+        expect(groups[0].tabUuid).toBe('tab-1');
+        expect(countThreads(groups)).toBe(5);
+    });
+
+    it('skips tiles without comments', () => {
+        const groups = groupCommentsByTile({
+            commentsByTile: { a: [comment('a1')], b: [] },
+            tiles: [
+                chartTile('a', { x: 0, y: 0 }),
+                chartTile('b', { x: 0, y: 3 }),
+            ],
+            tabs: [],
+        });
+
+        expect(groups.map((group) => group.tileUuid)).toEqual(['a']);
+    });
+
+    it('keeps threads on tiles that are no longer on the dashboard, after the rest', () => {
+        const groups = groupCommentsByTile({
+            commentsByTile: {
+                removed: [comment('r1')],
+                a: [comment('a1')],
+            },
+            tiles: [chartTile('a', { x: 0, y: 0 })],
+            tabs: [],
+        });
+
+        expect(groups.map((group) => group.tileUuid)).toEqual(['a', 'removed']);
+        expect(groups[1]).toMatchObject({
+            title: REMOVED_TILE_TITLE,
+            tileType: null,
+            tabUuid: null,
+        });
+    });
+});
+
+describe('getTileTitle', () => {
+    it('prefers the tile title over the chart name', () => {
+        expect(getTileTitle(chartTile('a', { x: 0, y: 0 }, 'Revenue'))).toBe(
+            'Revenue',
+        );
+        expect(getTileTitle(chartTile('a', { x: 0, y: 0 }))).toBe('Chart a');
+    });
+
+    it('falls back to a type label for tiles without a title', () => {
+        expect(
+            getTileTitle({
+                uuid: 'm',
+                x: 0,
+                y: 0,
+                w: 6,
+                h: 3,
+                tabUuid: undefined,
+                type: DashboardTileTypes.MARKDOWN,
+                properties: { title: '', content: 'hello' },
+            }),
+        ).toBe('Markdown');
+    });
+});

--- a/packages/frontend/src/features/comments/utils/groupCommentsByTile.test.ts
+++ b/packages/frontend/src/features/comments/utils/groupCommentsByTile.test.ts
@@ -9,6 +9,8 @@ import {
     getTileTitle,
     groupCommentsByTile,
     REMOVED_TILE_TITLE,
+    REMOVED_TILES_SECTION_LABEL,
+    sectionGroupsByTab,
 } from './groupCommentsByTile';
 
 const comment = (commentId: string): Comment => ({
@@ -133,5 +135,56 @@ describe('getTileTitle', () => {
                 properties: { title: '', content: 'hello' },
             }),
         ).toBe('Markdown');
+    });
+});
+
+describe('sectionGroupsByTab', () => {
+    const tabs = [
+        { uuid: 'tab-1', name: 'Revenue', order: 0 },
+        { uuid: 'tab-2', name: 'Orders', order: 1 },
+    ];
+
+    it('opens a section per tab in the order the groups arrive', () => {
+        const groups = groupCommentsByTile({
+            commentsByTile: {
+                a: [comment('a1')],
+                b: [comment('b1')],
+                c: [comment('c1')],
+            },
+            tiles: [
+                chartTile('a', { x: 0, y: 0, tabUuid: 'tab-1' }),
+                chartTile('b', { x: 0, y: 3, tabUuid: 'tab-1' }),
+                chartTile('c', { x: 0, y: 0, tabUuid: 'tab-2' }),
+            ],
+            tabs,
+        });
+
+        const sections = sectionGroupsByTab(groups, tabs);
+
+        expect(
+            sections.map((section) => [
+                section.label,
+                section.groups.map((group) => group.tileUuid),
+            ]),
+        ).toEqual([
+            ['Revenue', ['a', 'b']],
+            ['Orders', ['c']],
+        ]);
+    });
+
+    it('puts removed tiles in a trailing section of their own', () => {
+        const groups = groupCommentsByTile({
+            commentsByTile: { gone: [comment('g1')], a: [comment('a1')] },
+            tiles: [chartTile('a', { x: 0, y: 0, tabUuid: 'tab-1' })],
+            tabs,
+        });
+
+        const sections = sectionGroupsByTab(groups, tabs);
+
+        expect(sections.map((section) => section.label)).toEqual([
+            'Revenue',
+            REMOVED_TILES_SECTION_LABEL,
+        ]);
+        expect(sections[1].tabUuid).toBeNull();
     });
 });

--- a/packages/frontend/src/features/comments/utils/groupCommentsByTile.ts
+++ b/packages/frontend/src/features/comments/utils/groupCommentsByTile.ts
@@ -104,3 +104,40 @@ export const groupCommentsByTile = ({
 
 export const countThreads = (groups: TileCommentGroup[]): number =>
     groups.reduce((total, group) => total + group.threads.length, 0);
+
+export type TileCommentSection = {
+    /** null for tiles that are no longer on the dashboard */
+    tabUuid: string | null;
+    label: string;
+    groups: TileCommentGroup[];
+};
+
+export const REMOVED_TILES_SECTION_LABEL = 'No longer on this dashboard';
+
+/**
+ * Splits ordered tile groups into one section per dashboard tab, keeping the
+ * groups' order. Removed tiles get their own trailing section.
+ */
+export const sectionGroupsByTab = (
+    groups: TileCommentGroup[],
+    tabs: DashboardTab[],
+): TileCommentSection[] => {
+    const tabNames = new Map(tabs.map((tab) => [tab.uuid, tab.name]));
+    const sections: TileCommentSection[] = [];
+    for (const group of groups) {
+        const last = sections[sections.length - 1];
+        if (last && last.tabUuid === group.tabUuid) {
+            last.groups.push(group);
+            continue;
+        }
+        sections.push({
+            tabUuid: group.tabUuid,
+            label:
+                group.tabUuid === null
+                    ? REMOVED_TILES_SECTION_LABEL
+                    : (tabNames.get(group.tabUuid) ?? ''),
+            groups: [group],
+        });
+    }
+    return sections;
+};

--- a/packages/frontend/src/features/comments/utils/groupCommentsByTile.ts
+++ b/packages/frontend/src/features/comments/utils/groupCommentsByTile.ts
@@ -1,0 +1,106 @@
+import {
+    assertUnreachable,
+    DashboardTileTypes,
+    type Comment,
+    type DashboardTab,
+    type DashboardTile,
+} from '@lightdash/common';
+
+export type TileCommentGroup = {
+    tileUuid: string;
+    title: string;
+    /** null when the tile is no longer on the dashboard's current version */
+    tileType: DashboardTileTypes | null;
+    tabUuid: string | null;
+    threads: Comment[];
+};
+
+export const REMOVED_TILE_TITLE = 'Tile no longer on this dashboard';
+
+export const getTileTitle = (tile: DashboardTile): string => {
+    switch (tile.type) {
+        case DashboardTileTypes.SAVED_CHART:
+            return (
+                tile.properties.title ||
+                tile.properties.chartName ||
+                'Untitled chart'
+            );
+        case DashboardTileTypes.SQL_CHART:
+            return (
+                tile.properties.title ||
+                tile.properties.chartName ||
+                'Untitled chart'
+            );
+        case DashboardTileTypes.MARKDOWN:
+            return tile.properties.title || 'Markdown';
+        case DashboardTileTypes.LOOM:
+            return tile.properties.title || 'Loom video';
+        case DashboardTileTypes.HEADING:
+            return tile.properties.text || 'Heading';
+        case DashboardTileTypes.DATA_APP:
+            return tile.properties.title || 'Data app';
+        default:
+            return assertUnreachable(tile, 'Unknown dashboard tile type');
+    }
+};
+
+type GroupCommentsByTileArgs = {
+    commentsByTile: Record<string, Comment[]>;
+    tiles: DashboardTile[];
+    tabs: DashboardTab[];
+};
+
+/**
+ * Orders comment threads the way the dashboard reads: tab by tab, then top to
+ * bottom, left to right. Threads on tiles that were removed from the dashboard
+ * are listed last so they are still reachable.
+ */
+export const groupCommentsByTile = ({
+    commentsByTile,
+    tiles,
+    tabs,
+}: GroupCommentsByTileArgs): TileCommentGroup[] => {
+    const tabOrder = new Map(
+        [...tabs]
+            .sort((a, b) => a.order - b.order)
+            .map((tab, index) => [tab.uuid, index] as const),
+    );
+    const tabRank = (tabUuid: string | null | undefined) =>
+        tabUuid ? (tabOrder.get(tabUuid) ?? tabOrder.size) : -1;
+
+    const orderedTiles = [...tiles].sort(
+        (a, b) =>
+            tabRank(a.tabUuid) - tabRank(b.tabUuid) || a.y - b.y || a.x - b.x,
+    );
+
+    const groups: TileCommentGroup[] = [];
+    const seen = new Set<string>();
+    for (const tile of orderedTiles) {
+        const threads = commentsByTile[tile.uuid];
+        if (!threads || threads.length === 0) continue;
+        seen.add(tile.uuid);
+        groups.push({
+            tileUuid: tile.uuid,
+            title: getTileTitle(tile),
+            tileType: tile.type,
+            tabUuid: tile.tabUuid ?? null,
+            threads,
+        });
+    }
+
+    for (const [tileUuid, threads] of Object.entries(commentsByTile)) {
+        if (seen.has(tileUuid) || threads.length === 0) continue;
+        groups.push({
+            tileUuid,
+            title: REMOVED_TILE_TITLE,
+            tileType: null,
+            tabUuid: null,
+            threads,
+        });
+    }
+
+    return groups;
+};
+
+export const countThreads = (groups: TileCommentGroup[]): number =>
+    groups.reduce((total, group) => total + group.threads.length, 0);

--- a/packages/frontend/src/providers/Tracking/types.ts
+++ b/packages/frontend/src/providers/Tracking/types.ts
@@ -60,6 +60,7 @@ type GenericEvent = {
         | EventName.ADD_CUSTOM_DIMENSION_CLICKED
         | EventName.DATE_ZOOM_CLICKED
         | EventName.COMMENTS_CLICKED
+        | EventName.DASHBOARD_COMMENTS_PANEL_OPENED
         | EventName.EMBED_DOWNLOAD_CSV_CLICKED
         | EventName.EMBED_DOWNLOAD_IMAGE_CLICKED
         | EventName.DOWNLOAD_IMAGE_CLICKED

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -131,8 +131,11 @@ strong {
 .ld-mention {
     padding: 0.1em 0.35em;
     border-radius: var(--mantine-radius-sm);
-    background-color: var(--mantine-color-ldGray-1);
-    color: var(--mantine-color-text);
+    background-color: light-dark(
+        var(--mantine-color-blue-0),
+        var(--mantine-color-blue-light)
+    );
+    color: var(--mantine-color-blue-light-color);
     font-weight: 500;
     box-decoration-break: clone;
 }

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -126,3 +126,13 @@ strong {
 .ld-pre-wrap {
     white-space: pre-wrap;
 }
+
+/* An @mention inside a comment, in the editor and once rendered. */
+.ld-mention {
+    padding: 0.1em 0.35em;
+    border-radius: var(--mantine-radius-sm);
+    background-color: var(--mantine-color-ldGray-1);
+    color: var(--mantine-color-text);
+    font-weight: 500;
+    box-decoration-break: clone;
+}

--- a/packages/frontend/src/types/Events.ts
+++ b/packages/frontend/src/types/Events.ts
@@ -159,6 +159,7 @@ export enum EventName {
     ADD_CUSTOM_DIMENSION_CLICKED = 'add_custom_dimension.clicked',
     DATE_ZOOM_CLICKED = 'date_zoom.clicked',
     COMMENTS_CLICKED = 'comments.clicked',
+    DASHBOARD_COMMENTS_PANEL_OPENED = 'dashboard_comments_panel.opened',
     NOTIFICATIONS_COMMENTS_ITEM_CLICKED = 'notifications_comments_item.clicked',
     DASHBOARD_AUTO_REFRESH_UPDATED = 'dashboard_auto_refresh.updated',
 


### PR DESCRIPTION
## Summary

Comments on a dashboard live on individual tiles, and a tile only shows its speech bubble on hover unless it already has a thread. A reviewer who wants to read all the feedback left on a dashboard has to hover over every tile. This adds a dashboard-wide comments panel, in the spirit of the comments sidebar in a shared document.

- **Entry point.** While a dashboard has open threads, the header shows a Comments button with the count inline and a red dot when the user has unread comment notifications for it. Dashboards with no open threads keep the header clean: Comments moves into the header menu, so resolved history stays reachable.
- **Panel.** A right-hand drawer with one list, grouped the way the dashboard reads. On tabbed dashboards each tab is a sticky section header (click it to switch the dashboard to that tab; the active tab reads bold). Each tile is a bordered card whose header shows the tile type and title, and clicking it jumps to the tile, switching tab first if needed and highlighting it. Threads sit inside the tile card.
- **Threads** reuse the existing tile thread component, so replying, resolving, unresolving and deleting work from the panel with the same permissions as the tile popover. Resolved threads fold under the list behind "Show resolved (n)", the same pattern as the popover.
- Threads on tiles that were removed from the dashboard are still listed, last, under "No longer on this dashboard".
- Opening the panel marks the dashboard's unread comment notifications as viewed, as opening a tile popover does for that tile, and fires a `dashboard_comments_panel.opened` tracking event.
- The @mention picker inside the comment editor now uses the app font, border and shadow (it renders outside the Mantine root, so it had none), and mentions render as a light blue pill instead of bare blue text. Stored comment HTML carries an inline style for mentions; rendering swaps that span for the `ld-mention` class, so existing comments pick up the pill too.

No API changes: the panel uses the existing `GET /api/v2/projects/{projectUuid}/dashboards/{dashboardUuid}/comments` endpoint (already fetched by the dashboard provider for open threads, plus one request for resolved threads when the panel opens).

### Seed

Adds `17_dashboard_comments.ts`, which seeds a **Weekly revenue review** dashboard with two tabs, nine tiles (charts, markdown, loom) and a thread on every tile: replies, @mentions, resolved threads, and unread notifications for the demo user. Existing seed dashboards are untouched so nothing that asserts on them changes.

## Screenshots

Header with 8 open threads (red dot: an unread mention):

![header](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/01b-header-zoom.png)

Panel, grouped by tab and tile, replies expanded:

![panel](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/03-panel-replies.png)

Clicking a tile card switched to the Orders tab and scrolled to the tile:

![go to tile](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/04-go-to-tile.png)

Resolved section, dark mode:

![resolved](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/05-panel-resolved.png)
![dark](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/06-panel-dark.png)

A dashboard without open threads: no header button, Comments in the menu, empty state:

![menu](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/07-quiet-menu.png)
![empty](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/07-panel-empty.png)

Mention picker and a rendered mention:

![mentions](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/08-mention-dropdown.png)
![mention pill](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/09-mention-pill.png)
![mention pill dark](https://raw.githubusercontent.com/lightdash/lightdash/assets/dashboard-comments-panel/dashboard-comments-panel/09b-mention-pill-dark.png)

## Who is affected

- **Users without `view:DashboardComments`, or instances with `DISABLE_DASHBOARD_COMMENTS=true`:** nothing changes. The button, menu item and panel are gated on the same check as the tile popovers.
- **Viewers in fullscreen mode:** the button is hidden there, since the drawer portals to `document.body` and would render outside the fullscreen element.
- **Embedded dashboards:** unaffected, they use their own header.
- **Notification behaviour:** opening the panel marks all of this dashboard's unread comment notifications as viewed, where the tile popover only marked that tile's. Deliberate: the panel shows every thread, so opening it is reading them.
- **Mentions:** styling only, no behaviour change. Old comments keep their stored HTML; only the rendering rule changed.

## Testing

- Unit tests for `groupCommentsByTile` (tab/row/column ordering, tiles without threads, removed tiles) and `sectionGroupsByTab` (one section per tab, trailing removed-tiles section).
- Frontend and backend typecheck, oxlint and oxfmt pass on the touched files; `DashboardChartTile.merge.test.tsx` still passes.
- Verified in the browser against the seeded dashboard, light and dark: header button and dot, grouping and sticky tab headers, reply expansion, go to tile across tabs, resolved section, menu entry and empty state on a dashboard without threads, mention picker.

## Follow-ups

- Docs: `explore/dashboards/interact.mdx` should mention the panel next to the tile comments section.
- The drawer overlays the grid rather than reflowing it, like the pre-aggregation audit drawer. An inline side panel that shrinks the grid would let people read a thread and the tile side by side.
- Per-thread unread markers and a "mentions me" filter would help triage on busy dashboards.
- Comment counts on the dashboard tab labels, so a tab with discussion is visible before switching to it.

Closes: PROD-8451
Closes: #24636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyqzQx2gvHAFS7okc8cdyg
