### PR TITLE
fix(embed): let chart embed tokens read and cancel their queries

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -9273,3 +9273,153 @@ describe('DuckDB source queries on the worker', () => {
         expect(model.getDuckdbExecution).not.toHaveBeenCalled();
     });
 });
+
+describe('chart embed token query history access', () => {
+    const buildChartEmbedAccount = (explores: string[]) =>
+        fromJwt({
+            decodedToken: {
+                user: { externalId: 'external-user-123' },
+                content: { type: 'chart', contentId: 'source-chart-uuid' },
+            },
+            embed: {
+                projectUuid,
+                organization: {
+                    organizationUuid: projectSummary.organizationUuid,
+                    name: 'Test Organization',
+                    createdAt: new Date('2024-01-01'),
+                },
+                encodedSecret: 'test-encoded-secret',
+                dashboardUuids: [],
+                allowAllDashboards: false,
+                chartUuids: ['source-chart-uuid'],
+                allowAllCharts: true,
+                allowAllApps: false,
+                appUuids: [],
+                createdAt: '2024-01-01',
+                user: null,
+            },
+            source: 'test-jwt-token',
+            content: {
+                type: 'chart',
+                dashboardUuid: undefined,
+                chartUuids: ['source-chart-uuid'],
+                explores,
+            },
+            userAttributes: { userAttributes: {}, intrinsicUserAttributes: {} },
+        });
+
+    const buildFixture = (explores: string[]) => {
+        const account = buildChartEmbedAccount(explores);
+        const history: QueryHistory = {
+            queryUuid: 'source-query-uuid',
+            projectUuid,
+            organizationUuid: projectSummary.organizationUuid,
+            context: QueryExecutionContext.CHART,
+            status: QueryHistoryStatus.READY,
+            requestParameters: { chartUuid: 'source-chart-uuid' },
+            metricQuery: metricQueryMock,
+            fields: validExplore.tables.a.dimensions,
+            columns: expectedColumns,
+            resultsFileName: 'results.jsonl',
+            resultsExpiresAt: new Date(Date.now() + 60_000),
+            totalRowCount: 1,
+            defaultPageSize: 10,
+            createdAt: new Date(),
+            createdBy: account.user.id,
+            createdByUserUuid: account.user.id,
+            createdByAccount: null,
+            createdByActorType: account.authentication.type,
+            warehouseQueryId: null,
+            warehouseQueryMetadata: null,
+            compiledSql: 'select 1',
+            usedParameters: null,
+            warehouseExecutionTimeMs: null,
+            error: null,
+            erroredAt: null,
+            cacheKey: 'cache-key',
+            pivotConfiguration: null,
+            pivotValuesColumns: null,
+            pivotTotalColumnCount: null,
+            resultsCreatedAt: new Date(),
+            resultsUpdatedAt: new Date(),
+            originalColumns: expectedColumns,
+            preAggregateCompiledSql: null,
+            preAggregateExecution: null,
+            preAggregateFallbackReason: null,
+            processingStartedAt: null,
+        };
+        const service = getMockedAsyncQueryService(lightdashConfigMock);
+        service.queryHistoryModel.get = vi.fn().mockResolvedValue(history);
+        service.exportsStorageClient = {
+            isEnabled: () => true,
+        } as FileStorageClient;
+        (service as AnyType).schedulerClient = {
+            downloadAsyncQueryResults: vi.fn(async () => ({
+                jobId: 'export-job-uuid',
+            })),
+        };
+        vi.spyOn(
+            service as unknown as {
+                downloadAsyncQueryResultsAsFormattedFile: () => Promise<{
+                    fileUrl: string;
+                    truncated: boolean;
+                }>;
+            },
+            'downloadAsyncQueryResultsAsFormattedFile',
+        ).mockResolvedValue({ fileUrl: 'export.csv', truncated: false });
+        return { account, service };
+    };
+
+    const operations = ['stream', 'cancel', 'schedule', 'download'] as const;
+
+    const run = (
+        service: AsyncQueryService,
+        account: Account,
+        operation: (typeof operations)[number],
+    ) => {
+        const args = { account, projectUuid, queryUuid: 'source-query-uuid' };
+        switch (operation) {
+            case 'stream':
+                return service.getResultsStream(args);
+            case 'cancel':
+                return service.cancelAsyncQuery(args);
+            case 'schedule':
+                return service.scheduleDownloadAsyncQueryResults({
+                    ...args,
+                    type: DownloadFileType.CSV,
+                });
+            case 'download':
+                return service.download({
+                    ...args,
+                    type: DownloadFileType.CSV,
+                    accessMode:
+                        PersistentDownloadFileAccessMode.AUTHENTICATED_CREATOR,
+                });
+            default:
+                return assertUnreachable(operation, 'Unknown query operation');
+        }
+    };
+
+    it.each(operations)(
+        'allows a chart token scoped to the query explore through %s',
+        async (operation) => {
+            const { account, service } = buildFixture([validExplore.name]);
+            await run(service, account, operation);
+            expect(service.queryHistoryModel.get).toHaveBeenCalledWith(
+                'source-query-uuid',
+                projectUuid,
+                account,
+            );
+        },
+    );
+
+    it.each(operations)(
+        'refuses a chart token scoped to another explore through %s',
+        async (operation) => {
+            const { account, service } = buildFixture(['other_explore']);
+            await expect(run(service, account, operation)).rejects.toThrow(
+                ForbiddenError,
+            );
+        },
+    );
+});

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1103,24 +1103,16 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { queryUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
             account,
+        );
+        this.assertCanViewQueryHistory(
+            account,
+            projectUuid,
+            organizationUuid,
+            queryHistory,
         );
 
         const previousStatus = queryHistory.status;
@@ -1403,7 +1395,24 @@ export class AsyncQueryService extends ProjectService {
         queryHistory: QueryHistory,
     ): Promise<void> {
         await this.assertAnalyticsProjectAccess(account, project);
-        const { organizationUuid } = project;
+        await this.assertQueryHistoryReadAccess(
+            account,
+            projectUuid,
+            project.organizationUuid,
+            queryHistory,
+        );
+    }
+
+    /**
+     * Chart embed tokens only hold a project grant scoped to their explores,
+     * so a bare project check refuses them; fall back to the query's explore.
+     */
+    private assertCanViewQueryHistory(
+        account: Account,
+        projectUuid: string,
+        organizationUuid: string,
+        queryHistory: QueryHistory,
+    ): void {
         const { queryUuid } = queryHistory;
         const auditedAbility = this.createAuditedAbility(account);
         const canViewProject = auditedAbility.can(
@@ -1440,7 +1449,20 @@ export class AsyncQueryService extends ProjectService {
         if (isForbidden) {
             throw new ForbiddenError();
         }
+    }
 
+    private async assertQueryHistoryReadAccess(
+        account: Account,
+        projectUuid: string,
+        organizationUuid: string,
+        queryHistory: QueryHistory,
+    ): Promise<void> {
+        this.assertCanViewQueryHistory(
+            account,
+            projectUuid,
+            organizationUuid,
+            queryHistory,
+        );
         await this.assertSavedChartQuerySourceAccess(
             account,
             projectUuid,
@@ -1738,30 +1760,16 @@ export class AsyncQueryService extends ProjectService {
 
         const project = await this.projectModel.getSummary(projectUuid);
         await this.assertAnalyticsProjectAccess(account, project);
-        const { organizationUuid } = project;
-
-        const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { queryUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
 
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
             account,
         );
-        await this.assertSavedChartQuerySourceAccess(
+        await this.assertQueryHistoryReadAccess(
             account,
             projectUuid,
+            project.organizationUuid,
             queryHistory,
         );
 
@@ -1870,30 +1878,15 @@ export class AsyncQueryService extends ProjectService {
 
         const { organizationUuid } = account.organization;
 
-        const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid: payload.projectUuid,
-                    metadata: {
-                        queryUuid: payload.queryUuid,
-                    },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const queryHistory = await this.queryHistoryModel.get(
             payload.queryUuid,
             payload.projectUuid,
             account,
         );
-        await this.assertSavedChartQuerySourceAccess(
+        await this.assertQueryHistoryReadAccess(
             account,
             payload.projectUuid,
+            project.organizationUuid,
             queryHistory,
         );
 
@@ -2076,28 +2069,15 @@ export class AsyncQueryService extends ProjectService {
         }
         const { organizationUuid } = project;
 
-        const auditedAbility = this.createAuditedAbility(account);
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { queryUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
             account,
         );
-        await this.assertSavedChartQuerySourceAccess(
+        await this.assertQueryHistoryReadAccess(
             account,
             projectUuid,
+            organizationUuid,
             queryHistory,
         );
 


### PR DESCRIPTION
## Summary

Standalone chart embeds could submit a query and poll it, but reading the rows through the results stream endpoint, cancelling the query, and exporting it all returned 403 for `type: 'chart'` embed JWTs. Dashboard tokens worked on the same chart.

Chart tokens only hold a `view Project` grant conditioned on `exploreNames: { $all: content.explores }`. Those four paths checked `view Project` against a subject with no explore names and had no fallback, so the condition never matched. The results poll already handled this in `throwIfCannotReadQueryHistory` by falling back to a `view Explore` check for the query's explore.

This PR reuses that check across `getResultsStream`, `cancelAsyncQuery`, `scheduleDownloadAsyncQueryResults`, and `downloadAsyncQueryResults`. The internal analytics guard and the saved chart source access check keep their current order. #28904 fixed the same mismatch for the project details endpoint only.

## Verification

- Reproduced on `main` against the seeded project with a chart-type token: submit 200, poll ready, results stream 403, cancel 403. A dashboard-type token on the same chart returned 200 on both.
- After the change the chart-type token gets 200 with rows on the results stream and 200 on cancel.
- Added regression tests that run a chart-type JWT account through stream, cancel, schedule, and download: allowed when the token's explores cover the query's explore, refused when they do not.
- `pnpm -F backend test src/services/AsyncQueryService/AsyncQueryService.test.ts` (184 passed), `pnpm -F backend typecheck`, backend lint and format on the changed files.

Closes: #29072
