### PR TITLE
feat(chart-registry): promote the chart library explainer to an info callout

### DIFF
--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibrarySection.tsx
@@ -1,6 +1,7 @@
 import { FeatureFlags } from '@lightdash/common';
 import { Group, Paper, SimpleGrid, Stack, Text } from '@mantine/core';
 import { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
 import EmptyStateLoader from '../../../components/common/EmptyStateLoader';
 import InlineErrorState from '../../../components/common/InlineErrorState';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
@@ -97,11 +98,11 @@ const ChartTypeLibrarySection: FC<Props> = ({
                 </Group>
             )}
 
-            <Text fz="sm" c="dimmed">
+            <Callout variant="info">
                 These chart types are available to add to your instance. Once
                 installed, they can be used by anyone building charts in your
                 organization.
-            </Text>
+            </Callout>
 
             {registryQuery.isInitialLoading ? (
                 <EmptyStateLoader title="Loading chart type library…" />


### PR DESCRIPTION
The chart type library's intro line ("These chart types are available to add to your instance. Once installed, they can be used by anyone building charts in your organization.") rendered as small dimmed text and was easy to miss — but it's the one sentence that tells an admin the install is instance-wide. It's now the house info `Callout` (blue tint + info icon), copy unchanged.

Stacked on #29070 (both touch adjacent lines of `ChartTypeLibrarySection.tsx`); merge that first and this retargets to main automatically.

Relates: GLITCH-714