### PR TITLE
fix(cli): validate data apps with model selection

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -656,6 +656,85 @@ describe('validation', () => {
         ]);
     });
 
+    it.each([
+        {
+            scenario: 'accepts valid references to selected models',
+            compiledExplores: [explore],
+            expectedErrors: [],
+        },
+        {
+            scenario: 'reports removed fields in selected models',
+            compiledExplores: [exploreWithoutDimension],
+            expectedErrors: [
+                expect.objectContaining({
+                    source: ValidationSourceType.DataApp,
+                    errorType: ValidationErrorType.Dimension,
+                    modelName: explore.name,
+                    fieldName: 'table.dimension',
+                }),
+            ],
+        },
+        {
+            scenario:
+                'reports unselected models even when they exist in the cache',
+            compiledExplores: [{ ...explore, name: 'selected_explore' }],
+            expectedErrors: [
+                expect.objectContaining({
+                    source: ValidationSourceType.DataApp,
+                    errorType: ValidationErrorType.Model,
+                    modelName: explore.name,
+                }),
+            ],
+        },
+    ])(
+        '$scenario for data apps',
+        async ({ compiledExplores, expectedErrors }) => {
+            appModel.findAppsForValidation.mockResolvedValueOnce([
+                {
+                    app_id: 'app-uuid',
+                    name: 'App using a selected model',
+                    data_references: {
+                        references: [
+                            {
+                                kind: 'query',
+                                explore: explore.name,
+                                dimensions: ['table.dimension'],
+                                metrics: [],
+                                dimensionFilterFields: [],
+                                metricFilterFields: [],
+                                sortFields: [],
+                                parameterKeys: [],
+                                localFields: [],
+                                unresolved: [],
+                                location: {
+                                    path: 'src/App.tsx',
+                                    line: 10,
+                                    column: 5,
+                                },
+                            },
+                        ],
+                        parseErrors: [],
+                        stats: {
+                            callSites: 1,
+                            fullyResolved: 1,
+                            partiallyResolved: 0,
+                            unresolved: 0,
+                        },
+                    },
+                },
+            ]);
+
+            const errors = await validationService.generateValidation(
+                'projectUuid',
+                compiledExplores,
+                new Set([ValidationTarget.APPS]),
+            );
+
+            expect(errors).toEqual(expectedErrors);
+            expect(projectModel.findExploresFromCache).not.toHaveBeenCalled();
+        },
+    );
+
     it('reveals only owned personal data app validations to non-admins', async () => {
         appModel.listAppsByProject.mockResolvedValueOnce([
             {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,22 @@ Commands:
 
 eg: `ligthdash test` Runs `dbt test`
 
+## Project validation
+
+`lightdash validate` checks existing project content against locally compiled
+models. Data apps are included by default, or use `--only apps` to check only
+their stored data references:
+
+```shell
+lightdash validate --profiles-dir ../profiles/ --select path:models/marts --only apps
+```
+
+With `--select`, `--models`, `--exclude`, or `--selector`, data apps are checked
+against the compiled selection. App references to models outside that selection
+fail validation, as do broken references within it. The command exits non-zero
+on errors. It does not fall back to a full-project compile or require additional
+warehouse access for app validation.
+
 ## AI agents as code
 
 AI-agent project configuration can be downloaded into

--- a/packages/cli/src/handlers/validate.test.ts
+++ b/packages/cli/src/handlers/validate.test.ts
@@ -89,7 +89,7 @@ const brokenChartError = {
     lastUpdatedAt: new Date('2026-08-06T15:30:00Z'),
 };
 
-describe('validateHandler warehouse column validation', () => {
+describe('validateHandler', () => {
     let errorOutput: string[];
     let validationResults: unknown[] = [];
 
@@ -217,48 +217,59 @@ describe('validateHandler warehouse column validation', () => {
         expect(skipWarnings()).toEqual([]);
     });
 
-    test('skips data app validation when dbt selection produces a partial semantic layer', async () => {
+    test.each([
+        { select: ['orders'] },
+        { models: ['orders'] },
+        { exclude: ['customers'] },
+        { selector: 'marts' },
+    ])('validates data apps with model selection %j', async (selection) => {
+        const only = [ValidationTarget.CHARTS, ValidationTarget.APPS];
         await validateHandler({
             ...baseOptions,
-            only: [ValidationTarget.CHARTS, ValidationTarget.APPS],
-            select: ['orders'],
+            ...selection,
+            only,
         });
 
-        const validationRequest = vi
-            .mocked(lightdashApi)
-            .mock.calls.find(
-                ([request]) =>
-                    request.method === 'POST' &&
-                    request.url.endsWith('/validate'),
-            );
-        expect(validationRequest).toBeDefined();
-        expect(JSON.parse(String(validationRequest![0].body))).toEqual(
+        expect(compile).toHaveBeenCalledTimes(1);
+        expect(compile).toHaveBeenCalledWith(
+            expect.objectContaining(selection),
+        );
+        expect(lightdashApi).toHaveBeenCalledWith(
             expect.objectContaining({
-                validationTargets: [ValidationTarget.CHARTS],
+                method: 'POST',
+                url: `/api/v1/projects/${baseOptions.project}/validate`,
+                body: JSON.stringify({ explores: [], validationTargets: only }),
             }),
         );
-        expect(
-            errorOutput.some((line) =>
-                line.includes('Skipping data app validation'),
-            ),
-        ).toBe(true);
     });
 
-    test('rejects apps-only validation against a partial semantic layer', async () => {
-        await expect(
-            validateHandler({
+    test.each([
+        { only: [] },
+        { only: Object.values(ValidationTarget) },
+        { only: [ValidationTarget.APPS] },
+    ])(
+        'preserves validation targets %j with model selection',
+        async ({ only }) => {
+            await validateHandler({
                 ...baseOptions,
-                only: [ValidationTarget.APPS],
+                only,
                 select: ['orders'],
-            }),
-        ).rejects.toThrow(
-            'Data app validation requires a full project compile',
-        );
+            });
 
-        expect(compile).not.toHaveBeenCalled();
-    });
+            expect(lightdashApi).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: 'POST',
+                    url: `/api/v1/projects/${baseOptions.project}/validate`,
+                    body: JSON.stringify({
+                        explores: [],
+                        validationTargets: only,
+                    }),
+                }),
+            );
+        },
+    );
 
-    test('prints the latest data app version author and date', async () => {
+    test('fails selected apps-only validation and prints the latest version author and date', async () => {
         vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
         vi.mocked(lightdashApi).mockImplementation(async ({ method, url }) => {
             if (method === 'POST' && url.endsWith('/validate')) {
@@ -293,9 +304,12 @@ describe('validateHandler warehouse column validation', () => {
         await validateHandler({
             ...baseOptions,
             only: [ValidationTarget.APPS],
+            select: ['orders'],
         });
 
+        expect(process.exit).toHaveBeenCalledWith(1);
         const output = errorOutput.join('\n');
+        expect(output).toContain('Dimension does not exist');
         expect(output).toContain('Ada Lovelace');
         expect(output).toContain('2026-08-06');
     });

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -215,42 +215,7 @@ export const validateHandler = async (
             projectUuid,
         );
 
-    let validationTargets = options.only ? [...options.only] : [];
-    const hasPartialModelSelection =
-        Boolean(options.select?.length) ||
-        Boolean(options.models?.length) ||
-        Boolean(options.exclude?.length) ||
-        Boolean(options.selector);
-    const includesDataAppValidation =
-        validationTargets.length === 0 ||
-        validationTargets.includes(ValidationTarget.APPS);
-
-    if (hasPartialModelSelection && includesDataAppValidation) {
-        if (
-            validationTargets.length === 1 &&
-            validationTargets[0] === ValidationTarget.APPS
-        ) {
-            throw new ParameterError(
-                'Data app validation requires a full project compile. Remove the dbt model selection flags to use --only apps.',
-            );
-        }
-
-        validationTargets =
-            validationTargets.length === 0
-                ? [
-                      ValidationTarget.TABLES,
-                      ValidationTarget.CHARTS,
-                      ValidationTarget.DASHBOARDS,
-                  ]
-                : validationTargets.filter(
-                      (target) => target !== ValidationTarget.APPS,
-                  );
-        console.error(
-            styles.warning(
-                '> Skipping data app validation because dbt model selection flags produce a partial semantic layer',
-            ),
-        );
-    }
+    const validationTargets = options.only ? [...options.only] : [];
 
     await LightdashAnalytics.track({
         event: 'validate.started',


### PR DESCRIPTION
Closes #28968
[PROD-11145](https://linear.app/lightdash/issue/PROD-11145/cli-lightdash-validate-select-skips-data-app-validation-support)

### Description:

```diff
 lightdash validate --select path:models/marts
- Skip data apps; reject --only apps with model selection
+ Validate data app references against the compiled selection
```

- Support `--select`, `--models`, `--exclude`, and `--selector`, including `--only apps`.
- Report missing models and broken fields through the existing validation errors and non-zero exit status, without a separate selection warning.
- Preserve the selected compile scope; app validation does not trigger a full-project compile or require additional warehouse access.

Validation:
- `pnpm -F @lightdash/cli test src/handlers/validate.test.ts` — 21 passed.
- `pnpm -F backend test src/services/ValidationService/ValidationService.test.ts` — 48 passed, including selected models, removed fields, and unselected models present in the server cache.
- CLI/backend typechecks, targeted Oxlint/Oxfmt, `git diff --check`, and repository commit hooks passed.
- Local F1 project at `localhost:3000`, using the checkout-backed `ld` alias: `ld validate --profiles-dir ./profiles/ --project-dir ./dbt --select path:models/marts --only apps` passed. Adding `--exclude fct_teammate_battles` produced exactly two app errors and exited 1.
- Live runs stored validation job/results only; no app or model changes were deployed. The customer's restricted warehouse service account was not tested; dynamic reference coverage retains the existing static validator's limits.

### Risk assessment:

- [ ] This is a high-risk change

Low risk: reuses the existing backend validator and authorization, with no API, schema, or migration changes. CI runs using model selection can now fail on app errors that were previously skipped.
