### PR TITLE
feat(dashboards): reserve direct deletion for full access

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -43,6 +43,7 @@ import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import {
     SpacePermissionService,
     type AccessTarget,
+    type SpaceAccessContextForCasl,
 } from '../SpaceService/SpacePermissionService';
 import { DashboardService } from './DashboardService';
 import {
@@ -72,6 +73,8 @@ const dashboardModel = {
     update: vi.fn(async () => dashboard),
 
     permanentDelete: vi.fn(async () => dashboard),
+
+    softDelete: vi.fn(async () => dashboard),
 
     addVersion: vi.fn(async () => dashboard),
 
@@ -171,7 +174,10 @@ const contentVerificationModel = {
     unverify: vi.fn(async () => undefined),
 };
 
-const spaceContexts = {
+const spaceContexts: Record<
+    string,
+    Omit<SpaceAccessContextForCasl, 'admins'>
+> = {
     [space.space_uuid]: {
         organizationUuid: space.organization_uuid,
         projectUuid: publicSpace.projectUuid,
@@ -233,7 +239,9 @@ describe('DashboardService', () => {
         pinnedListModel: {} as PinnedListModel,
         schedulerModel: schedulerModel as unknown as SchedulerModel,
         searchModel: searchModel as unknown as SearchModel,
-        schedulerService: {} as SchedulerService,
+        schedulerService: {
+            softDeleteByDashboardUuid: vi.fn(),
+        } as unknown as SchedulerService,
         savedChartModel: savedChartModel as unknown as SavedChartModel,
         savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
         savedChartService: {} as SavedChartService, // Mock for test
@@ -978,6 +986,88 @@ describe('DashboardService', () => {
             }),
         );
     });
+
+    describe.each(['delete', 'softDelete'] as const)(
+        '%s with direct dashboard access',
+        (method) => {
+            test.each([
+                {
+                    directRole: SpaceMemberRole.EDITOR,
+                    spaceRole: null,
+                    allowed: false,
+                },
+                {
+                    directRole: SpaceMemberRole.VIEWER,
+                    spaceRole: null,
+                    allowed: false,
+                },
+                {
+                    directRole: SpaceMemberRole.ADMIN,
+                    spaceRole: null,
+                    allowed: true,
+                },
+                {
+                    directRole: SpaceMemberRole.EDITOR,
+                    spaceRole: SpaceMemberRole.EDITOR,
+                    allowed: true,
+                },
+                {
+                    directRole: SpaceMemberRole.EDITOR,
+                    spaceRole: SpaceMemberRole.VIEWER,
+                    allowed: false,
+                },
+            ])(
+                'direct $directRole and space $spaceRole: allowed=$allowed',
+                async ({ directRole, spaceRole, allowed }) => {
+                    const editor = {
+                        ...user,
+                        role: OrganizationMemberRole.EDITOR,
+                        ability: defineUserAbility(
+                            { ...user, role: OrganizationMemberRole.EDITOR },
+                            [],
+                        ),
+                    };
+                    const accessRow = {
+                        userUuid: user.userUuid,
+                        hasDirectAccess: true,
+                        projectRole: undefined,
+                        inheritedRole: undefined,
+                        inheritedFrom: undefined,
+                    };
+                    spacePermissionService.resolveAccess.mockResolvedValueOnce({
+                        organizationUuid: dashboard.organizationUuid,
+                        projectUuid: dashboard.projectUuid,
+                        inheritsFromOrgOrProject: false,
+                        directOnly: spaceRole === null,
+                        access: [
+                            {
+                                ...accessRow,
+                                role: directRole,
+                                grantedVia: 'dashboard' as const,
+                            },
+                            ...(spaceRole
+                                ? [{ ...accessRow, role: spaceRole }]
+                                : []),
+                        ],
+                    });
+
+                    const result = service[method](editor, dashboardUuid);
+
+                    if (allowed) {
+                        await expect(result).resolves.toBeUndefined();
+                    } else {
+                        await expect(result).rejects.toThrow(ForbiddenError);
+                        expect(
+                            dashboardModel.permanentDelete,
+                        ).not.toHaveBeenCalled();
+                        expect(
+                            dashboardModel.softDelete,
+                        ).not.toHaveBeenCalled();
+                    }
+                },
+            );
+        },
+    );
     test('should not see dashboard from other organizations', async () => {
         const anotherUser = {
             ...user,

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -22,6 +22,7 @@ import {
     ExportContentRequest,
     ForbiddenError,
     generateSlug,
+    getDashboardDeleteAccess,
     getItemId,
     getSchedulerResourceTypeAndId,
     hasChartsInDashboard,
@@ -2873,7 +2874,7 @@ export class DashboardService
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
-                        access,
+                        access: getDashboardDeleteAccess(access),
                         metadata: { dashboardUuid: dashboardToDelete.uuid },
                     }),
                 )
@@ -2994,7 +2995,7 @@ export class DashboardService
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
                         inheritsFromOrgOrProject,
-                        access,
+                        access: getDashboardDeleteAccess(access),
                         metadata: { dashboardUuid: dashboard.uuid },
                     }),
                 )

--- a/packages/common/src/authorization/getDashboardDeleteAccess.test.ts
+++ b/packages/common/src/authorization/getDashboardDeleteAccess.test.ts
@@ -1,0 +1,156 @@
+import { Ability, AbilityBuilder, subject } from '@casl/ability';
+import { ProjectMemberRole } from '../types/projectMemberRole';
+import { SpaceMemberRole, type SpaceAccess } from '../types/space';
+import { getDashboardDeleteAccess } from './getDashboardDeleteAccess';
+import { projectMemberAbilities } from './projectMemberAbility';
+import { buildAbilityFromScopes } from './scopeAbilityBuilder';
+import { type MemberAbility } from './types';
+
+const context = {
+    organizationUuid: 'org',
+    projectUuid: 'project',
+    userUuid: 'user',
+};
+
+const editorGrant: Pick<SpaceAccess, 'userUuid' | 'role' | 'grantedVia'> = {
+    userUuid: context.userUuid,
+    role: SpaceMemberRole.EDITOR,
+    grantedVia: 'dashboard',
+};
+
+const buildAbility = (scopes?: string[]) => {
+    const builder = new AbilityBuilder<MemberAbility>(Ability);
+    if (scopes) {
+        buildAbilityFromScopes(
+            {
+                projectUuid: context.projectUuid,
+                userUuid: context.userUuid,
+                scopes,
+                isEnterprise: true,
+            },
+            builder,
+        );
+    } else {
+        projectMemberAbilities.editor(
+            { ...context, role: ProjectMemberRole.EDITOR },
+            builder,
+        );
+    }
+    return builder.build();
+};
+
+describe.each([
+    { name: 'built-in editor', scopes: undefined },
+    { name: 'custom space manager', scopes: ['manage:Dashboard@space'] },
+])('$name dashboard deletion', ({ scopes }) => {
+    const ability = buildAbility(scopes);
+
+    test.each([
+        { name: 'direct editor', access: [editorGrant], allowed: false },
+        {
+            name: 'direct full access',
+            access: [{ ...editorGrant, role: SpaceMemberRole.ADMIN }],
+            allowed: true,
+        },
+        {
+            name: 'space editor',
+            access: [{ ...editorGrant, grantedVia: undefined }],
+            allowed: true,
+        },
+        {
+            name: 'direct editor plus space viewer',
+            access: [
+                editorGrant,
+                {
+                    ...editorGrant,
+                    grantedVia: undefined,
+                    role: SpaceMemberRole.VIEWER,
+                },
+            ],
+            allowed: false,
+        },
+        {
+            name: 'direct viewer plus space editor',
+            access: [
+                { ...editorGrant, role: SpaceMemberRole.VIEWER },
+                { ...editorGrant, grantedVia: undefined },
+            ],
+            allowed: true,
+        },
+        {
+            name: 'direct user editor plus group admin',
+            access: [
+                editorGrant,
+                { ...editorGrant, role: SpaceMemberRole.ADMIN },
+            ],
+            allowed: true,
+        },
+        { name: 'no access (including flag off)', access: [], allowed: false },
+        {
+            name: 'another user full access',
+            access: [
+                {
+                    ...editorGrant,
+                    userUuid: 'other',
+                    role: SpaceMemberRole.ADMIN,
+                },
+            ],
+            allowed: false,
+        },
+    ])('$name: allowed=$allowed', ({ access, allowed }) => {
+        expect(
+            ability.can(
+                'delete',
+                subject('Dashboard', {
+                    ...context,
+                    inheritsFromOrgOrProject: false,
+                    access: getDashboardDeleteAccess(access),
+                }),
+            ),
+        ).toBe(allowed);
+    });
+
+    it('keeps editing authorized by the original grant', () => {
+        const access = [editorGrant];
+        getDashboardDeleteAccess(access);
+        expect(
+            ability.can('update', subject('Dashboard', { ...context, access })),
+        ).toBe(true);
+        expect(access).toEqual([editorGrant]);
+    });
+});
+
+it('preserves unconditional custom-role deletion rights', () => {
+    expect(
+        buildAbility(['manage:Dashboard']).can(
+            'delete',
+            subject('Dashboard', {
+                ...context,
+                access: getDashboardDeleteAccess([editorGrant]),
+            }),
+        ),
+    ).toBe(true);
+});
+
+it('does not supply missing project capabilities to full access', () => {
+    expect(
+        buildAbility(['view:Dashboard']).can(
+            'delete',
+            subject('Dashboard', {
+                ...context,
+                access: getDashboardDeleteAccess([
+                    { ...editorGrant, role: SpaceMemberRole.ADMIN },
+                ]),
+            }),
+        ),
+    ).toBe(false);
+});
+
+it('preserves grants sourced from other content types', () => {
+    const access: Pick<SpaceAccess, 'role' | 'grantedVia'>[] = [
+        { role: SpaceMemberRole.EDITOR, grantedVia: 'saved_chart' },
+        { role: SpaceMemberRole.EDITOR, grantedVia: 'sql_chart' },
+        { role: SpaceMemberRole.EDITOR, grantedVia: 'app' },
+    ];
+    expect(getDashboardDeleteAccess(access)).toEqual(access);
+});

--- a/packages/common/src/authorization/getDashboardDeleteAccess.ts
+++ b/packages/common/src/authorization/getDashboardDeleteAccess.ts
@@ -1,0 +1,12 @@
+import { SpaceMemberRole, type SpaceAccess } from '../types/space';
+
+/** Keep inherited rights intact; only Full access grants dashboard deletion. */
+export const getDashboardDeleteAccess = <
+    T extends Pick<SpaceAccess, 'role' | 'grantedVia'>,
+>(
+    access: readonly T[],
+): T[] =>
+    access.filter(
+        ({ role, grantedVia }) =>
+            grantedVia !== 'dashboard' || role === SpaceMemberRole.ADMIN,
+    );

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -47,6 +47,7 @@ export { getPermissionsFromAbilityRules } from './authorization/abilityPermissio
 export * from './authorization/buildAccountHelpers';
 export { collapseAbilityRules } from './authorization/collapseAbilityRules';
 export { canMutateVerifiedContent } from './authorization/canMutateVerifiedContent';
+export { getDashboardDeleteAccess } from './authorization/getDashboardDeleteAccess';
 export {
     defineUserAbility,
     getUserAbilityBuilder,

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     DirectAccessResourceType,
     canMutateVerifiedContent,
+    getDashboardDeleteAccess,
     ContentReviewContentType,
     ContentType,
     ResourceViewItemType,
@@ -312,6 +313,15 @@ const DashboardHeader = memo(
                 },
                 dashboard.verification,
                 user.data.userUuid,
+            );
+        const userCanDeleteDashboard =
+            userCanManageDashboard &&
+            user.data?.ability.can(
+                'delete',
+                subject('Dashboard', {
+                    ...dashboard,
+                    access: getDashboardDeleteAccess(dashboard.access ?? []),
+                }),
             );
         const userCanRefreshPreAggregates =
             user.data?.ability.can(
@@ -1110,7 +1120,7 @@ const DashboardHeader = memo(
                                         </>
                                     )}
 
-                                    {userCanManageDashboard && (
+                                    {userCanDeleteDashboard && (
                                         <>
                                             <Menu.Divider />
                                             <Menu.Item

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -4,6 +4,7 @@ import {
     ChartSourceType,
     ContentReviewContentType,
     DirectAccessResourceType,
+    getDashboardDeleteAccess,
     isResourceViewDataAppItem,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
@@ -236,6 +237,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const isFavorited = favoritesContext?.isFavorited(item.data.uuid) ?? false;
 
     let userCanManage = false;
+    let userCanDelete = false;
     switch (item.type) {
         case ResourceViewItemType.CHART: {
             const userAccess = spaces.find(
@@ -299,6 +301,22 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                             ...(userAccess ? [userAccess] : []),
                             ...grantAccess,
                         ],
+                    }),
+                ) === true;
+            userCanDelete =
+                user.data?.ability?.can(
+                    'delete',
+                    subject('Dashboard', {
+                        ...item.data,
+                        projectUuid,
+                        organizationUuid,
+                        access: getDashboardDeleteAccess([
+                            ...(userAccess ? [userAccess] : []),
+                            ...grantAccess.map((access) => ({
+                                ...access,
+                                grantedVia: 'dashboard' as const,
+                            })),
+                        ]),
                     }),
                 ) === true;
             break;
@@ -805,35 +823,37 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 </Menu.Item>
                             )}
 
-                            {allowDelete && (
-                                <>
-                                    <Menu.Divider />
+                            {allowDelete &&
+                                (item.type !== ResourceViewItemType.DASHBOARD ||
+                                    userCanDelete) && (
+                                    <>
+                                        <Menu.Divider />
 
-                                    <Menu.Item
-                                        component="button"
-                                        role="menuitem"
-                                        color="red"
-                                        leftSection={
-                                            <MantineIcon
-                                                icon={IconTrash}
-                                                size={18}
-                                            />
-                                        }
-                                        onClick={() => {
-                                            onAction({
-                                                type: ResourceViewItemAction.DELETE,
-                                                item,
-                                            });
-                                        }}
-                                    >
-                                        Delete{' '}
-                                        {item.type ===
-                                        ResourceViewItemType.DATA_APP
-                                            ? 'data app'
-                                            : item.type}
-                                    </Menu.Item>
-                                </>
-                            )}
+                                        <Menu.Item
+                                            component="button"
+                                            role="menuitem"
+                                            color="red"
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconTrash}
+                                                    size={18}
+                                                />
+                                            }
+                                            onClick={() => {
+                                                onAction({
+                                                    type: ResourceViewItemAction.DELETE,
+                                                    item,
+                                                });
+                                            }}
+                                        >
+                                            Delete{' '}
+                                            {item.type ===
+                                            ResourceViewItemType.DATA_APP
+                                                ? 'data app'
+                                                : item.type}
+                                        </Menu.Item>
+                                    </>
+                                )}
                         </>
                     )}
                 </Menu.Dropdown>

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
@@ -397,6 +397,15 @@ const DirectAccessModal: FC<DirectAccessModalProps> = ({
                 }
             >
                 <Stack gap="md" className={classes.content}>
+                    {resource.resourceType ===
+                        DirectAccessResourceType.DASHBOARD && (
+                        <Text fz="sm" c="dimmed">
+                            Can edit allows changes to dashboard contents. Full
+                            access also allows deleting the dashboard and
+                            managing sharing. Permissions from other roles still
+                            apply.
+                        </Text>
+                    )}
                     {isUnavailable ? (
                         <Callout variant="info" title="Sharing isn't available">
                             <Text fz="sm">


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/SPK-2067

## Summary

Direct dashboard Can edit grants allow dashboard maintenance without authorizing deletion of the dashboard itself. Full access retains deletion and sharing management, subject to existing project capabilities and content protections.

## How it works

A shared deletion-access filter excludes non-admin direct dashboard grants while preserving independent inherited access. Dashboard deletion, soft deletion, and the dashboard/list menus use this filter. Editing still uses the original access rows, including for adding and removing tiles. The sharing dialog explains the distinction.

```text
Direct Can edit   → edit dashboard contents
Direct Full access → edit + delete + manage sharing
Other qualifying permissions → retain deletion rights
```

## Regression analysis

- Existing direct editors lose deletion only when no other permission authorizes it. This is an intentional permission change.
- Space-editor rights, additive user/group and custom-role permissions, and project capability ceilings retain their existing behavior.
- Other content types, verified/Git-backed protections, and separate trash-management/restore permissions are unchanged.
- Bulk deletion uses the same service checks and reports unauthorized items as skipped. No migration or scope vocabulary change is needed.

## Test plan

- Before: a real direct Editor deleted a private dashboard with HTTP 200; four new service regression cases failed.
- After: Editor GET/PATCH return 200 and DELETE returns 403. User/group Full access and inherited space Editor deletion succeed.
- Exercised hard and soft deletion on the local API; confirmed soft deletion in Postgres and restored local configuration afterward.
- Mixed bulk deletion deletes the Full-access item and skips the Editor-only item.
- Chrome DevTools: dashboard and Shared with me menus omit Delete for Editor and show it for Full access; sharing copy verified.
- Common authorization and role parity: 44 passed, one pre-existing skipped test. Backend service/access/verification suites: 183 passed. Direct-access modal: 18 passed.
- Common, backend, and frontend typechecks and lint pass; changed-file formatting and diff checks pass.
