### PR TITLE
feat(ai-reviews): calm down the issues board card

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewAssigneeMenu.tsx
@@ -24,6 +24,8 @@ type Props = {
     className?: string;
     /** Compact avatar + name row (e.g. the issue rail) instead of avatar only. */
     withName?: boolean;
+    /** Avatar size for the avatar-only trigger. */
+    avatarSize?: number;
 };
 
 export const ReviewAssigneeMenu: FC<Props> = ({
@@ -32,6 +34,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
     assignedToUserUuid,
     className,
     withName = false,
+    avatarSize = 26,
 }) => {
     // Source the candidate list from the same hook the project users & groups
     // table uses, so anyone who can access the project is assignable — not just
@@ -87,7 +90,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                 {assignee ? (
                                     <LightdashUserAvatar
                                         name={assigneeName ?? undefined}
-                                        size={withName ? 18 : 'sm'}
+                                        size={withName ? 18 : avatarSize}
                                         radius="xl"
                                         userUuid={assignee.userUuid}
                                         avatarUrl={assignee.avatarUrl}
@@ -95,7 +98,7 @@ export const ReviewAssigneeMenu: FC<Props> = ({
                                     />
                                 ) : (
                                     <LightdashUserAvatar
-                                        size={withName ? 18 : 'sm'}
+                                        size={withName ? 18 : avatarSize}
                                         radius="xl"
                                         variant="light"
                                         color="gray"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -14,8 +14,7 @@
         box-shadow 120ms ease;
     overflow: hidden;
 }
-.card:has(.cardBody:hover),
-.card:has(.cardFooter:hover) {
+.card:has(.cardBody:hover) {
     border-color: var(--mantine-color-indigo-4);
     box-shadow: 0 4px 14px rgba(80, 60, 180, 0.1);
 }
@@ -38,39 +37,6 @@
    so the tour spotlight always lands on something. The "Example" badge marks
    them — don't dim the card, the tour spotlights it. */
 .cardExample .cardBody {
-    cursor: default;
-}
-/* The sample card's action is disabled but should still read as the real
-   footer, not greyed out — the tour spotlights it. */
-.cardExample .startFooter:disabled {
-    opacity: 1;
-    cursor: default;
-}
-.cardFooter {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-sm);
-    border-top: 1px solid var(--mantine-color-default-border);
-    background: light-dark(
-        var(--mantine-color-gray-0),
-        var(--mantine-color-dark-6)
-    );
-    color: var(--mantine-color-ldGray-7);
-    text-decoration: none;
-    transition: background 100ms ease;
-}
-.cardFooter:hover {
-    background: var(--mantine-color-default-hover);
-}
-/* Start/Retry action as a footer row, same shape as the workspace row so
-   every card action lives in one place. */
-.startFooter {
-    width: 100%;
-    font: inherit;
-    color: var(--mantine-color-text);
-}
-.startFooter:disabled {
     cursor: default;
 }
 .assigneeUnassigned {
@@ -221,4 +187,35 @@
 .cardTitle {
     font-size: 13px;
     line-height: 1.4;
+}
+/* Inline card actions (workspace link, start/retry) share the metadata row. */
+.inlineAction {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    color: var(--mantine-color-ldGray-7);
+    text-decoration: none;
+    transition: color 120ms ease;
+}
+.inlineAction:hover {
+    color: var(--mantine-color-text);
+}
+.inlineAction:disabled {
+    cursor: default;
+}
+.cardAction {
+    font-size: 11px;
+    font-weight: 500;
+}
+/* Nothing in flight: the primary action waits for hover so idle cards stay
+   quiet. Selected cards keep it visible so keyboard users can reach it. */
+.hoverAction {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+.card:hover .hoverAction,
+.cardSelected .hoverAction,
+.hoverAction:focus-visible {
+    opacity: 1;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -40,15 +40,11 @@
 .cardExample .cardBody {
     cursor: default;
 }
-/* The sample card's action is disabled, but Mantine's disabled colours (grey
-   text on grey) clashed with the filled background this class forces, which read
-   as broken in dark mode. Keep it looking like the real button. */
-.cardExample .startAction,
-.cardExample .startAction:disabled {
+/* The sample card's action is disabled but should still read as the real
+   footer, not greyed out — the tour spotlights it. */
+.cardExample .startFooter:disabled {
     opacity: 1;
-    background: var(--mantine-color-indigo-filled);
-    color: var(--mantine-color-white);
-    border-color: transparent;
+    cursor: default;
 }
 .cardFooter {
     display: flex;
@@ -67,23 +63,15 @@
 .cardFooter:hover {
     background: var(--mantine-color-default-hover);
 }
-.startAction {
-    position: absolute;
-    top: var(--mantine-spacing-xs);
-    right: var(--mantine-spacing-xs);
-    opacity: 0;
-    transition:
-        opacity 120ms ease,
-        transform 120ms cubic-bezier(0.23, 1, 0.32, 1);
-    background: var(--mantine-color-indigo-filled);
-    box-shadow: var(--mantine-shadow-sm);
+/* Start/Retry action as a footer row, same shape as the workspace row so
+   every card action lives in one place. */
+.startFooter {
+    width: 100%;
+    font: inherit;
+    color: var(--mantine-color-text);
 }
-.card:hover .startAction,
-.cardSelected .startAction {
-    opacity: 1;
-}
-.startAction:active {
-    transform: scale(0.96);
+.startFooter:disabled {
+    cursor: default;
 }
 .assigneeUnassigned {
     opacity: 0.4;
@@ -211,5 +199,26 @@
     }
 }
 .assigneeTrigger {
+    display: inline-flex;
+    align-items: center;
     cursor: pointer;
+}
+/* Unset priority is the common case; keep the control reachable on hover
+   without every card announcing "No priority". */
+.priorityNone {
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+.card:hover .priorityNone {
+    opacity: 1;
+}
+/* One step below the title so title, category, timestamp read as three levels. */
+.categoryLabel {
+    color: var(--mantine-color-ldGray-6);
+}
+/* Between the xs and sm steps: 12px felt small for the card's lead line, 14px
+   outweighed the rest of the card. */
+.cardTitle {
+    font-size: 13px;
+    line-height: 1.4;
 }

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.tsx
@@ -644,10 +644,10 @@ export const ReviewKanbanBoard: FC<Props> = ({
                                             bg={`${lane.color}.5`}
                                             style={{ borderRadius: 3 }}
                                         />
-                                        <Text fz="sm" fw={600}>
+                                        <Text fz="xs" fw={600}>
                                             {lane.label}
                                         </Text>
-                                        <Badge size="sm">{all.length}</Badge>
+                                        <Badge size="xs">{all.length}</Badge>
                                     </Group>
                                     <DroppableLane
                                         laneId={lane.id}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -2,12 +2,11 @@ import { type AiAgentReviewItemSummary } from '@lightdash/common';
 import {
     Badge,
     Box,
-    Button,
-    Code,
     Group,
     Stack,
     Text,
     Tooltip,
+    UnstyledButton,
 } from '@mantine/core';
 import {
     IconArrowUpRight,
@@ -112,7 +111,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                     }
                 }}
             >
-                <Stack gap={8}>
+                <Stack gap={10}>
                     <Group
                         justify="space-between"
                         align="flex-start"
@@ -128,21 +127,28 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     Example
                                 </Badge>
                             )}
-                            <Text fz="sm" fw={500} lineClamp={2}>
+                            <Text
+                                fw={500}
+                                c="ldGray.9"
+                                lineClamp={2}
+                                className={styles.cardTitle}
+                            >
                                 {title}
                             </Text>
-                            {targetAnchor && (
-                                <Code
-                                    fz="xs"
-                                    c="dimmed"
-                                    w="fit-content"
-                                    maw="100%"
-                                >
-                                    {targetAnchor}
-                                </Code>
-                            )}
                         </Stack>
                         <Group gap={8} wrap="nowrap" align="center">
+                            {!isExample && (
+                                <ReviewPriorityMenu
+                                    fingerprint={item.fingerprint}
+                                    priority={item.priority}
+                                    variant="bars"
+                                    className={
+                                        item.priority === 'none'
+                                            ? styles.priorityNone
+                                            : undefined
+                                    }
+                                />
+                            )}
                             <Tooltip
                                 position="top"
                                 label={`First seen ${formatReviewDate(
@@ -151,7 +157,11 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                     item.lastSeenAt,
                                 )}`}
                             >
-                                <Text fz="xs" c="dimmed" className="ld-nowrap">
+                                <Text
+                                    fz="xs"
+                                    c="ldGray.5"
+                                    className="ld-nowrap"
+                                >
                                     {formatRelativeReviewDate(item.lastSeenAt)}
                                 </Text>
                             </Tooltip>
@@ -164,7 +174,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                         justify="space-between"
                         align="center"
                     >
-                        <Group gap={6} wrap="wrap">
+                        <Group gap="sm" wrap="wrap">
                             <CategoryBadge
                                 color={
                                     reviewRootCauseColors[item.primaryRootCause]
@@ -172,13 +182,10 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                 label={
                                     reviewRootCauseLabels[item.primaryRootCause]
                                 }
+                                bordered={false}
+                                tooltip={targetAnchor ?? undefined}
+                                className={styles.categoryLabel}
                             />
-                            {!isExample && (
-                                <ReviewPriorityMenu
-                                    fingerprint={item.fingerprint}
-                                    priority={item.priority}
-                                />
-                            )}
                         </Group>
 
                         {!isExample && (
@@ -190,6 +197,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                 }
                                 fingerprint={item.fingerprint}
                                 assignedToUserUuid={item.assignedToUserUuid}
+                                avatarSize={18}
                                 className={
                                     item.assignedToUserUuid
                                         ? undefined
@@ -250,50 +258,46 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                     </Box>
                 ))}
 
-            {startKind !== null &&
-                (isExample ? (
-                    <Button
-                        data-tour="reviews-pr"
-                        size="compact-xs"
-                        disabled
-                        leftSection={<MantineIcon icon={IconBolt} size={12} />}
-                        className={styles.startAction}
-                    >
-                        Start fix
-                    </Button>
-                ) : (
-                    <Button
-                        size="compact-xs"
-                        leftSection={
-                            <MantineIcon
-                                icon={isRetry ? IconRefresh : IconBolt}
-                                size={12}
-                            />
+            {startKind !== null && (
+                <UnstyledButton
+                    data-tour={isExample ? 'reviews-pr' : undefined}
+                    disabled={isExample || createWriteback.isLoading}
+                    className={`${styles.cardFooter} ${styles.startFooter}`}
+                    onPointerDown={(e: React.PointerEvent) =>
+                        e.stopPropagation()
+                    }
+                    onClick={(e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        if (isExample) return;
+                        updateStatus.mutate({
+                            fingerprint: item.fingerprint,
+                            body: {
+                                status: 'in_progress',
+                                dismissedReason: null,
+                            },
+                        });
+                        if (startKind === 'modal') {
+                            setPreviewOpen(true);
+                        } else {
+                            createWriteback.mutate(item.fingerprint);
                         }
-                        loading={createWriteback.isLoading}
-                        className={styles.startAction}
-                        onPointerDown={(e: React.PointerEvent) =>
-                            e.stopPropagation()
-                        }
-                        onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            updateStatus.mutate({
-                                fingerprint: item.fingerprint,
-                                body: {
-                                    status: 'in_progress',
-                                    dismissedReason: null,
-                                },
-                            });
-                            if (startKind === 'modal') {
-                                setPreviewOpen(true);
-                            } else {
-                                createWriteback.mutate(item.fingerprint);
-                            }
-                        }}
-                    >
-                        {isRetry ? 'Retry fix' : 'Start fix'}
-                    </Button>
-                ))}
+                    }}
+                >
+                    <Group gap={6} align="center">
+                        <MantineIcon
+                            icon={isRetry ? IconRefresh : IconBolt}
+                            size={13}
+                        />
+                        <Text fz="xs" c="ldGray.7">
+                            {createWriteback.isLoading
+                                ? 'Starting…'
+                                : isRetry
+                                  ? 'Retry fix'
+                                  : 'Start fix'}
+                        </Text>
+                    </Group>
+                </UnstyledButton>
+            )}
 
             {startKind === 'modal' && (
                 <ProjectContextWritebackModal

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -1,19 +1,6 @@
 import { type AiAgentReviewItemSummary } from '@lightdash/common';
-import {
-    Badge,
-    Box,
-    Group,
-    Stack,
-    Text,
-    Tooltip,
-    UnstyledButton,
-} from '@mantine/core';
-import {
-    IconArrowUpRight,
-    IconBolt,
-    IconLayoutColumns,
-    IconRefresh,
-} from '@tabler/icons-react';
+import { Badge, Box, Button, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { IconBolt, IconLayoutColumns, IconRefresh } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import { Link } from 'react-router';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
@@ -188,116 +175,130 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                             />
                         </Group>
 
-                        {!isExample && (
-                            <ReviewAssigneeMenu
-                                projectUuid={
-                                    item.projectUuid ??
-                                    item.latestFinding?.projectUuid ??
-                                    null
-                                }
-                                fingerprint={item.fingerprint}
-                                assignedToUserUuid={item.assignedToUserUuid}
-                                avatarSize={18}
-                                className={
-                                    item.assignedToUserUuid
-                                        ? undefined
-                                        : styles.assigneeUnassigned
-                                }
-                            />
-                        )}
+                        <Group gap={10} wrap="nowrap" align="center">
+                            {activityLabel && (
+                                <Group gap={6} wrap="nowrap" align="center">
+                                    {isAgentRunning ? (
+                                        <AiAgentIcon size={13} animated />
+                                    ) : (
+                                        <Box
+                                            pos="relative"
+                                            w={6}
+                                            h={6}
+                                            bg="indigo.5"
+                                            className={styles.pulse}
+                                            style={{ borderRadius: '50%' }}
+                                        />
+                                    )}
+                                    <Text fz="xs" c="ldGray.6">
+                                        {activityLabel}
+                                    </Text>
+                                </Group>
+                            )}
+                            {hasWorkspace &&
+                                !activityLabel &&
+                                (isExample ? (
+                                    <Box
+                                        data-tour="reviews-workspace"
+                                        className={styles.inlineAction}
+                                    >
+                                        <MantineIcon
+                                            icon={IconLayoutColumns}
+                                            size={13}
+                                        />
+                                        <Text fz="xs">Workspace</Text>
+                                    </Box>
+                                ) : (
+                                    <Tooltip
+                                        label="Open workspace"
+                                        openDelay={300}
+                                    >
+                                        <Box
+                                            component={Link}
+                                            to={workspaceHref}
+                                            onClick={(
+                                                e: React.MouseEvent<HTMLAnchorElement>,
+                                            ) => e.stopPropagation()}
+                                            className={styles.inlineAction}
+                                        >
+                                            <MantineIcon
+                                                icon={IconLayoutColumns}
+                                                size={13}
+                                            />
+                                            <Text fz="xs">Workspace</Text>
+                                        </Box>
+                                    </Tooltip>
+                                ))}
+                            {startKind !== null && (
+                                <Button
+                                    data-tour={
+                                        isExample ? 'reviews-pr' : undefined
+                                    }
+                                    variant="light"
+                                    color="gray"
+                                    size="compact-xs"
+                                    h={20}
+                                    px={6}
+                                    disabled={isExample}
+                                    loading={createWriteback.isLoading}
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={
+                                                isRetry ? IconRefresh : IconBolt
+                                            }
+                                            size={12}
+                                        />
+                                    }
+                                    className={
+                                        isRetry || isExample
+                                            ? styles.cardAction
+                                            : `${styles.cardAction} ${styles.hoverAction}`
+                                    }
+                                    onPointerDown={(e: React.PointerEvent) =>
+                                        e.stopPropagation()
+                                    }
+                                    onClick={(e: React.MouseEvent) => {
+                                        e.stopPropagation();
+                                        updateStatus.mutate({
+                                            fingerprint: item.fingerprint,
+                                            body: {
+                                                status: 'in_progress',
+                                                dismissedReason: null,
+                                            },
+                                        });
+                                        if (startKind === 'modal') {
+                                            setPreviewOpen(true);
+                                        } else {
+                                            createWriteback.mutate(
+                                                item.fingerprint,
+                                            );
+                                        }
+                                    }}
+                                >
+                                    {isRetry ? 'Retry fix' : 'Start fix'}
+                                </Button>
+                            )}
+                            {!isExample && (
+                                <ReviewAssigneeMenu
+                                    projectUuid={
+                                        item.projectUuid ??
+                                        item.latestFinding?.projectUuid ??
+                                        null
+                                    }
+                                    fingerprint={item.fingerprint}
+                                    assignedToUserUuid={item.assignedToUserUuid}
+                                    avatarSize={18}
+                                    className={
+                                        item.assignedToUserUuid
+                                            ? undefined
+                                            : styles.assigneeUnassigned
+                                    }
+                                />
+                            )}
+                        </Group>
                     </Group>
                 </Stack>
             </Box>
-
-            {hasWorkspace &&
-                (activityLabel ? (
-                    <Box className={styles.cardFooter}>
-                        <Group gap={6} align="center">
-                            {isAgentRunning ? (
-                                <AiAgentIcon size={14} animated />
-                            ) : (
-                                <Box
-                                    pos="relative"
-                                    w={7}
-                                    h={7}
-                                    bg="indigo.5"
-                                    className={styles.pulse}
-                                    style={{ borderRadius: '50%' }}
-                                />
-                            )}
-                            <Text fz="xs" c="dimmed">
-                                {activityLabel}
-                            </Text>
-                        </Group>
-                    </Box>
-                ) : isExample ? (
-                    <Box
-                        data-tour="reviews-workspace"
-                        className={styles.cardFooter}
-                    >
-                        <Group gap={6} align="center">
-                            <MantineIcon icon={IconLayoutColumns} size={13} />
-                            <Text fz="xs">Open workspace</Text>
-                        </Group>
-                        <MantineIcon icon={IconArrowUpRight} size={14} />
-                    </Box>
-                ) : (
-                    <Box
-                        component={Link}
-                        to={workspaceHref}
-                        onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
-                            e.stopPropagation()
-                        }
-                        className={styles.cardFooter}
-                    >
-                        <Group gap={6} align="center">
-                            <MantineIcon icon={IconLayoutColumns} size={13} />
-                            <Text fz="xs">Open workspace</Text>
-                        </Group>
-                        <MantineIcon icon={IconArrowUpRight} size={14} />
-                    </Box>
-                ))}
-
-            {startKind !== null && (
-                <UnstyledButton
-                    data-tour={isExample ? 'reviews-pr' : undefined}
-                    disabled={isExample || createWriteback.isLoading}
-                    className={`${styles.cardFooter} ${styles.startFooter}`}
-                    onPointerDown={(e: React.PointerEvent) =>
-                        e.stopPropagation()
-                    }
-                    onClick={(e: React.MouseEvent) => {
-                        e.stopPropagation();
-                        if (isExample) return;
-                        updateStatus.mutate({
-                            fingerprint: item.fingerprint,
-                            body: {
-                                status: 'in_progress',
-                                dismissedReason: null,
-                            },
-                        });
-                        if (startKind === 'modal') {
-                            setPreviewOpen(true);
-                        } else {
-                            createWriteback.mutate(item.fingerprint);
-                        }
-                    }}
-                >
-                    <Group gap={6} align="center">
-                        <MantineIcon
-                            icon={isRetry ? IconRefresh : IconBolt}
-                            size={13}
-                        />
-                        <Text fz="xs" c="ldGray.7">
-                            {createWriteback.isLoading
-                                ? 'Starting…'
-                                : isRetry
-                                  ? 'Retry fix'
-                                  : 'Start fix'}
-                        </Text>
-                    </Group>
-                </UnstyledButton>
-            )}
 
             {startKind === 'modal' && (
                 <ProjectContextWritebackModal

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityBars.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityBars.module.css
@@ -1,0 +1,16 @@
+.bars {
+    display: block;
+    flex-shrink: 0;
+    color: var(--mantine-color-ldGray-5);
+}
+/* Urgent shares three bars with high; a darker ink keeps it readable without color. */
+.urgent {
+    color: var(--mantine-color-ldGray-9);
+}
+.filled {
+    fill: currentColor;
+}
+.empty {
+    fill: currentColor;
+    opacity: 0.22;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityBars.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityBars.tsx
@@ -1,0 +1,46 @@
+import { type AiAgentReviewItemPriority } from '@lightdash/common';
+import { Box } from '@mantine/core';
+import { type FC } from 'react';
+import styles from './ReviewPriorityBars.module.css';
+
+const FILLED_BARS: Record<AiAgentReviewItemPriority, number> = {
+    none: 0,
+    low: 1,
+    medium: 2,
+    high: 3,
+    urgent: 3,
+};
+
+type Props = {
+    priority: AiAgentReviewItemPriority;
+};
+
+// Signal-strength glyph: one bar per level; urgent fills all three in darker ink.
+export const ReviewPriorityBars: FC<Props> = ({ priority }) => {
+    const filled = FILLED_BARS[priority];
+
+    return (
+        <Box
+            component="svg"
+            className={`${styles.bars} ${
+                priority === 'urgent' ? styles.urgent : ''
+            }`}
+            width={10}
+            height={9}
+            viewBox="0 0 10 9"
+            aria-hidden
+        >
+            {[0, 1, 2].map((index) => (
+                <rect
+                    key={index}
+                    x={index * 4}
+                    y={6 - index * 3}
+                    width={2}
+                    height={3 + index * 3}
+                    rx={0.5}
+                    className={index < filled ? styles.filled : styles.empty}
+                />
+            ))}
+        </Box>
+    );
+};

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPriorityMenu.tsx
@@ -1,5 +1,5 @@
 import { type AiAgentReviewItemPriority } from '@lightdash/common';
-import { Menu, UnstyledButton } from '@mantine/core';
+import { Group, Menu, Tooltip, UnstyledButton } from '@mantine/core';
 import { type FC } from 'react';
 import { CategoryBadge } from '../../../../../components/common/CategoryBadge';
 import { useUpdateAiAgentReviewItemPriority } from '../../hooks/useAiAgentAdmin';
@@ -7,10 +7,13 @@ import {
     reviewPriorityColors,
     reviewPriorityLabels,
 } from './reviewItemDetails';
+import { ReviewPriorityBars } from './ReviewPriorityBars';
 
 type Props = {
     fingerprint: string;
     priority: AiAgentReviewItemPriority;
+    /** `badge` = dot + label; `bars` = compact signal-strength glyph (board cards). */
+    variant?: 'badge' | 'bars';
     /** Render as a bare dot + label (no chip) — e.g. in the issue rail. */
     bordered?: boolean;
     /** Extra class for the badge — e.g. rail typography overrides. */
@@ -28,6 +31,7 @@ const priorities: AiAgentReviewItemPriority[] = [
 export const ReviewPriorityMenu: FC<Props> = ({
     fingerprint,
     priority,
+    variant = 'badge',
     bordered = true,
     className,
 }) => {
@@ -37,16 +41,29 @@ export const ReviewPriorityMenu: FC<Props> = ({
         <Menu width={160} position="bottom-start">
             <Menu.Target>
                 <UnstyledButton
-                    aria-label="Change priority"
+                    display="inline-flex"
+                    aria-label={`Priority: ${reviewPriorityLabels[priority]}`}
+                    className={variant === 'bars' ? className : undefined}
                     onClick={(event) => event.stopPropagation()}
                     onPointerDown={(event) => event.stopPropagation()}
                 >
-                    <CategoryBadge
-                        color={reviewPriorityColors[priority]}
-                        label={reviewPriorityLabels[priority]}
-                        bordered={bordered}
-                        className={className}
-                    />
+                    {variant === 'bars' ? (
+                        <Tooltip
+                            label={reviewPriorityLabels[priority]}
+                            openDelay={300}
+                        >
+                            <Group>
+                                <ReviewPriorityBars priority={priority} />
+                            </Group>
+                        </Tooltip>
+                    ) : (
+                        <CategoryBadge
+                            color={reviewPriorityColors[priority]}
+                            label={reviewPriorityLabels[priority]}
+                            bordered={bordered}
+                            className={className}
+                        />
+                    )}
                 </UnstyledButton>
             </Menu.Target>
             <Menu.Dropdown
@@ -65,6 +82,9 @@ export const ReviewPriorityMenu: FC<Props> = ({
                                 fingerprint,
                                 priority: nextPriority,
                             })
+                        }
+                        leftSection={
+                            <ReviewPriorityBars priority={nextPriority} />
                         }
                     >
                         {reviewPriorityLabels[nextPriority]}


### PR DESCRIPTION
## Summary

The AI reviews board card carried too much at equal weight: a bordered category chip, a bordered priority chip sitting a few pixels lower than it, a grey code block for the explore/field reference, a 26px avatar, and a "Start fix" button that floated over the title on hover. Cards with a workspace also grew a footer row, so lane rhythm broke every few cards.

This reworks the card so the issue title leads, everything else steps back, and every card is exactly two rows.

## Changes

- **Two-row card.** Row one: title, priority glyph, age. Row two: category on the left; actions and assignee on the right. Footer rows and their styles are removed.
- **Priority** is a three-bar glyph (1 low, 2 medium, 3 high, urgent in darker ink) next to the timestamp, so "how hot" and "how old" read together. Unset priority is hidden until hover. The menu items carry the same glyph.
- **Category** is a bare dot + label, one ink step below the title. The explore/field reference lives in its tooltip instead of a code block on every card.
- **Actions live in row two.** "Workspace" is a small link with the columns glyph; live states ("Writing fix…", "Building…", "Compiling…") sit in the same slot. **Start fix** is a light button that appears on hover, selection, or keyboard focus, so idle cards stay quiet. **Retry fix** uses the same button but stays visible, since a failed attempt should be noticed.
- **Scale**: title 13px, avatar 18px, lane headers and count pills a step smaller, so card and lane read at one scale. The title size is off the theme's 12/14 steps on purpose and says so in the stylesheet.
- **Alignment fix**: the priority control is a menu trigger wrapped in an inline button, which inherited the row's line height and sat ~5px below the category chip. Both triggers are inline-flex now.

`ReviewAssigneeMenu` gains an `avatarSize` prop (default unchanged). `ReviewPriorityMenu` gains a `variant` prop; the existing badge rendering stays the default, so the issue rail and thread sidebar are unaffected.

## Before / after

| Before | After |
| --- | --- |
| ![board before](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/board-before.png) | ![board after](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/board-after.png) |
| ![lane before](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/lane-before.png) | ![lane after](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/lane-after.png) |

Hovering a card reveals Start fix; Retry fix stays visible:

![start fix on hover](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/lane-after-hover-button.png)

Category tooltip carrying the field reference:

![lane after hover](https://raw.githubusercontent.com/lightdash/lightdash/assets/issues-board-card-polish/img/lane-after-hover.png)

## Regression analysis

- The onboarding tour anchors `reviews-pr` and `reviews-workspace` on the example card; both anchors moved into row two, the Start action is still a disabled `<button>`, and `ReviewKanbanBoard.test.tsx` passes (3/3).
- Lint, format, and typecheck are clean on the touched files.
- Verified visually in Storybook against a full fixture (24 issues across all lanes, root causes, priorities, and remediation states) in light mode. Dark mode uses the same `ldGray` tokens, which invert per scheme, but was not screenshot-verified.
- Every control in row two already stopped pointer propagation (they sit on a dnd-kit sortable), so moving them next to the assignee menu adds no new drag conflicts.
- No behaviour change to status, assignee, priority, or writeback mutations; only where the controls render.

No ticket exists for this work; confirmed with the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJVtP5eJ5DU2sDYEF3RJVS
