### PR TITLE
fix(dashboards): open the chart page from the tile hover pill

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.test.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.test.tsx
@@ -1,0 +1,69 @@
+import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import TileBase from './index';
+
+vi.mock('../../../providers/Dashboard/useDashboardContext', () => ({
+    default: vi.fn((selector) =>
+        selector({ hasTileComments: () => false, dashboard: undefined }),
+    ),
+}));
+
+const hiddenTitleTile: Dashboard['tiles'][number] = {
+    uuid: 'tile-1',
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 2,
+    w: 2,
+    tabUuid: undefined,
+    properties: {
+        savedChartUuid: 'chart-1',
+        title: 'Revenue',
+        hideTitle: true,
+    },
+};
+
+const CHART_HREF = '/projects/jaffle-shop/saved/revenue/';
+
+const renderTile = (
+    props: Partial<{ isEditMode: boolean; minimal: boolean }> = {},
+) =>
+    renderWithProviders(
+        <TileBase
+            tile={hiddenTitleTile}
+            title="Revenue"
+            titleHref={CHART_HREF}
+            isEditMode={props.isEditMode ?? false}
+            minimal={props.minimal ?? false}
+            lockHeaderVisibility
+            onEdit={vi.fn()}
+            onDelete={vi.fn()}
+        >
+            <div>chart</div>
+        </TileBase>,
+    );
+
+describe('TileBase chart page link', () => {
+    it('offers the chart page from the hover pill when the title is hidden', () => {
+        renderTile();
+
+        const viewChart = screen.getByRole('link', { name: 'View chart' });
+        expect(viewChart).toHaveAttribute('href', CHART_HREF);
+        expect(viewChart).toHaveAttribute('target', '_blank');
+    });
+
+    it('does not offer the chart page while editing the dashboard', () => {
+        renderTile({ isEditMode: true });
+
+        expect(screen.queryByRole('link', { name: 'View chart' })).toBeNull();
+        expect(screen.getByTestId('tile-icon-more')).toBeInTheDocument();
+    });
+
+    it('does not offer the chart page in minimal mode', () => {
+        renderTile({ minimal: true });
+
+        expect(screen.queryByRole('link', { name: 'View chart' })).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -22,6 +22,7 @@ import {
     IconCircleCheckFilled,
     IconDots,
     IconEdit,
+    IconExternalLink,
     IconGripVertical,
     IconLink,
     IconTrash,
@@ -100,11 +101,14 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
     const copyTileLink = useCopyTileLink(tile);
     const canCopyTileLink = !minimal && copyTileLink !== null;
+    // The title is the only link to the chart page and hidden titles have
+    // none, so the pill carries one in view mode.
+    const canViewChart = !minimal && !isEditMode && !!titleHref;
 
     const hasMenuContent = isEditMode || !!extraMenuItems || canCopyTileLink;
     const isVerified = verification !== null && verification !== undefined;
     const hasHeaderContent =
-        hasMenuContent || isVerified || hasNonMenuHeaderContent;
+        hasMenuContent || isVerified || hasNonMenuHeaderContent || canViewChart;
 
     return (
         <div ref={containerRef} className={styles.tileWrapper}>
@@ -157,6 +161,21 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                                         color: 'var(--mantine-color-green-6)',
                                     }}
                                 />
+                            </Tooltip>
+                        )}
+
+                        {canViewChart && (
+                            <Tooltip label="View chart">
+                                <ActionIcon
+                                    component="a"
+                                    size="sm"
+                                    href={titleHref}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    aria-label="View chart"
+                                >
+                                    <MantineIcon icon={IconExternalLink} />
+                                </ActionIcon>
                             </Tooltip>
                         )}
 


### PR DESCRIPTION
## Summary

A tile's title is the only link from a dashboard to a chart's own page. Tiles with a hidden title, which is common for big value charts, had none, and "Edit chart" now opens the in-dashboard editor instead of the chart page. Everything that lives only on the chart page was several clicks away for those tiles.

- The tile's hover pill now carries a "View chart" icon in view mode, next to the menu trigger. It opens the chart page in a new tab, the same way the title link does, so it is one click from the tile.
- It applies to every tile with a chart page link, so SQL chart tiles get it too. It is not shown while editing the dashboard, where the other navigation actions are also disabled, or in minimal mode.

<img width="300" height="90" alt="image" src="https://github.com/user-attachments/assets/ff4cc843-90ab-46b0-93bc-69b62d47cbfd" />

Stacked on #29063.

## Test plan

- [x] `TileBase/index.test.tsx`: link target and new-tab attributes on a hidden-title tile, absent in dashboard edit mode and in minimal mode
- [x] Frontend typecheck and lint
- [x] Manual run on a local dashboard: the icon appears in the pill on hover and opens the chart page

Closes: #29057


Replaces #29066, which GitHub marked as merged into its old stack parent when the stack was reordered.
