### PR TITLE
refactor(settings): lay out Slack toggles as one Configuration list with rows

### DIFF
--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.module.css
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.module.css
@@ -1,0 +1,4 @@
+.row {
+    padding-block: var(--mantine-spacing-sm);
+    border-top: 1px solid var(--mantine-color-default-border);
+}

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.module.css
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.module.css
@@ -1,4 +1,7 @@
 .row {
     padding-block: var(--mantine-spacing-sm);
+}
+
+.row + .row {
     border-top: 1px solid var(--mantine-color-default-border);
 }

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
@@ -25,10 +25,8 @@ export const SlackSettingRow: FC<Props> = ({
         gap="md"
     >
         <Stack gap="two">
-            <Title order={6} fw={500}>
-                {title}
-            </Title>
-            <Text c="dimmed" fz="sm">
+            <Title order={6}>{title}</Title>
+            <Text c="dimmed" fz="xs">
                 {description}
             </Text>
         </Stack>

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
@@ -31,7 +31,7 @@ export const SlackSettingRow: FC<Props> = ({
             </Text>
         </Stack>
         <Switch
-            className="ld-shrink-0"
+            flex="0 0 auto"
             aria-label={title}
             checked={checked}
             disabled={disabled}

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
@@ -1,13 +1,10 @@
-import { Group, Stack, Switch, Text, Title, Tooltip } from '@mantine/core';
-import { IconHelpCircle } from '@tabler/icons-react';
+import { Group, Stack, Switch, Text, Title } from '@mantine/core';
 import { type FC } from 'react';
-import MantineIcon from '../../common/MantineIcon';
 import classes from './SlackSettingRow.module.css';
 
 type Props = {
     title: string;
     description: string;
-    tooltip: string;
     checked: boolean;
     disabled?: boolean;
     onChange: (checked: boolean) => void;
@@ -16,7 +13,6 @@ type Props = {
 export const SlackSettingRow: FC<Props> = ({
     title,
     description,
-    tooltip,
     checked,
     disabled = false,
     onChange,
@@ -29,14 +25,9 @@ export const SlackSettingRow: FC<Props> = ({
         gap="md"
     >
         <Stack gap="two">
-            <Group gap="two">
-                <Title order={6} fw={500}>
-                    {title}
-                </Title>
-                <Tooltip maw={280} label={tooltip}>
-                    <MantineIcon icon={IconHelpCircle} />
-                </Tooltip>
-            </Group>
+            <Title order={6} fw={500}>
+                {title}
+            </Title>
             <Text c="dimmed" fz="sm">
                 {description}
             </Text>

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/SlackSettingRow.tsx
@@ -1,0 +1,52 @@
+import { Group, Stack, Switch, Text, Title, Tooltip } from '@mantine/core';
+import { IconHelpCircle } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+import classes from './SlackSettingRow.module.css';
+
+type Props = {
+    title: string;
+    description: string;
+    tooltip: string;
+    checked: boolean;
+    disabled?: boolean;
+    onChange: (checked: boolean) => void;
+};
+
+export const SlackSettingRow: FC<Props> = ({
+    title,
+    description,
+    tooltip,
+    checked,
+    disabled = false,
+    onChange,
+}) => (
+    <Group
+        className={classes.row}
+        justify="space-between"
+        align="center"
+        wrap="nowrap"
+        gap="md"
+    >
+        <Stack gap="two">
+            <Group gap="two">
+                <Title order={6} fw={500}>
+                    {title}
+                </Title>
+                <Tooltip maw={280} label={tooltip}>
+                    <MantineIcon icon={IconHelpCircle} />
+                </Tooltip>
+            </Group>
+            <Text c="dimmed" fz="sm">
+                {description}
+            </Text>
+        </Stack>
+        <Switch
+            className="ld-shrink-0"
+            aria-label={title}
+            checked={checked}
+            disabled={disabled}
+            onChange={(event) => onChange(event.currentTarget.checked)}
+        />
+    </Group>
+);

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -50,6 +50,7 @@ import { default as MantineIcon } from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
 import { SlackChannelSelect } from '../../common/SlackChannelSelect';
 import { ProjectSelect } from './ProjectSelect';
+import { SlackSettingRow } from './SlackSettingRow';
 
 const SLACK_INSTALL_URL = `/api/v1/slack/install/`;
 
@@ -301,185 +302,102 @@ const SlackSettingsPanel: FC = () => {
                             <Stack gap="sm">
                                 <Divider mt="sm" />
                                 <Title order={5}>Unfurling</Title>
-                                <Group gap="two">
-                                    <Title order={6} fw={500}>
-                                        Link previews
-                                    </Title>
-                                    <Tooltip
-                                        maw={280}
-                                        label="When enabled, Lightdash posts chart and dashboard previews when links are shared in Slack. Previews are rendered as the user who installed the Slack app, so any queries they trigger are attributed to that user. Disable to stop posting previews."
-                                    >
-                                        <MantineIcon icon={IconHelpCircle} />
-                                    </Tooltip>
-                                </Group>
-                                <Switch
-                                    label="Enable link unfurls"
+                                <SlackSettingRow
+                                    title="Link previews"
+                                    description="Enable link unfurls"
+                                    tooltip="When enabled, Lightdash posts chart and dashboard previews when links are shared in Slack. Previews are rendered as the user who installed the Slack app, so any queries they trigger are attributed to that user. Disable to stop posting previews."
                                     checked={form.values.unfurlsEnabled ?? true}
-                                    onChange={(event) => {
-                                        setFieldValue(
-                                            'unfurlsEnabled',
-                                            event.currentTarget.checked,
-                                        );
-                                    }}
+                                    onChange={(checked) =>
+                                        setFieldValue('unfurlsEnabled', checked)
+                                    }
                                 />
                             </Stack>
                             {isAiCopilotEnabledOrTrial && (
                                 <Stack gap="sm">
                                     <Divider mt="sm" />
                                     <Title order={5}>AI in Slack</Title>
-                                    <Group gap="two">
-                                        <Title order={6} fw={500}>
-                                            AI Agents in Slack
-                                        </Title>
-
-                                        <Tooltip
-                                            maw={280}
-                                            label="Turn this off to stop AI Agents being used from Slack entirely. Agents stay available in Lightdash, and scheduled deliveries, alerts and link previews keep working."
-                                        >
-                                            <MantineIcon
-                                                icon={IconHelpCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-
-                                    <Switch
-                                        label="Allow AI Agents to be used from Slack"
-                                        checked={
-                                            form.values.aiAgentsEnabled ?? true
-                                        }
-                                        onChange={(event) => {
-                                            setFieldValue(
-                                                'aiAgentsEnabled',
-                                                event.currentTarget.checked,
-                                            );
-                                        }}
-                                    />
-
-                                    <Group gap="two">
-                                        <Title order={6} fw={500}>
-                                            AI Agents thread access consent
-                                        </Title>
-
-                                        <Tooltip
-                                            maw={250}
-                                            label="The longer the thread, the more context the AI Agents will have to work with."
-                                        >
-                                            <MantineIcon
-                                                icon={IconHelpCircle}
-                                            />
-                                        </Tooltip>
-                                    </Group>
-
-                                    <Text c="dimmed" fz="xs">
-                                        Allow the AI Agents to access thread
-                                        messages when a user mentions the bot in
-                                        a thread.
-                                    </Text>
-
-                                    <Switch
-                                        label="Allow AI to access thread messages"
-                                        disabled={aiAgentsDisabled}
-                                        checked={
-                                            form.values.aiThreadAccessConsent ??
-                                            false
-                                        }
-                                        onChange={(event) => {
-                                            setFieldValue(
-                                                'aiThreadAccessConsent',
-                                                event.currentTarget.checked,
-                                            );
-                                        }}
-                                    />
-
-                                    <Stack gap="sm">
-                                        <Group gap="two">
-                                            <Title order={6} fw={500}>
-                                                AI Agents OAuth requirement
-                                            </Title>
-
-                                            <Tooltip
-                                                maw={250}
-                                                label="When enabled, users must authenticate with OAuth to use AI Agent features."
-                                            >
-                                                <MantineIcon
-                                                    icon={IconHelpCircle}
-                                                />
-                                            </Tooltip>
-                                        </Group>
-
-                                        <Switch
-                                            label="Require OAuth for AI Agent"
+                                    <Stack gap={0}>
+                                        <SlackSettingRow
+                                            title="AI Agents in Slack"
+                                            description="Allow AI Agents to be used from Slack"
+                                            tooltip="Turn this off to stop AI Agents being used from Slack entirely. Agents stay available in Lightdash, and scheduled deliveries, alerts and link previews keep working."
+                                            checked={
+                                                form.values.aiAgentsEnabled ??
+                                                true
+                                            }
+                                            onChange={(checked) =>
+                                                setFieldValue(
+                                                    'aiAgentsEnabled',
+                                                    checked,
+                                                )
+                                            }
+                                        />
+                                        <SlackSettingRow
+                                            title="AI Agents thread access consent"
+                                            description="Allow the AI Agents to access thread messages when a user mentions the bot in a thread."
+                                            tooltip="The longer the thread, the more context the AI Agents will have to work with."
                                             disabled={aiAgentsDisabled}
-                                            checked={form.values.aiRequireOAuth}
-                                            onChange={(event) => {
+                                            checked={
+                                                form.values
+                                                    .aiThreadAccessConsent ??
+                                                false
+                                            }
+                                            onChange={(checked) =>
+                                                setFieldValue(
+                                                    'aiThreadAccessConsent',
+                                                    checked,
+                                                )
+                                            }
+                                        />
+                                        <SlackSettingRow
+                                            title="AI Agents OAuth requirement"
+                                            description="Require OAuth for AI Agent"
+                                            tooltip="When enabled, users must authenticate with OAuth to use AI Agent features."
+                                            disabled={aiAgentsDisabled}
+                                            checked={
+                                                form.values.aiRequireOAuth ??
+                                                false
+                                            }
+                                            onChange={(checked) =>
                                                 setFieldValue(
                                                     'aiRequireOAuth',
-                                                    event.currentTarget.checked,
-                                                );
-                                            }}
+                                                    checked,
+                                                )
+                                            }
                                         />
-                                    </Stack>
-
-                                    <Stack gap="sm">
-                                        <Group gap="two">
-                                            <Title order={6} fw={500}>
-                                                Links only, no data in Slack
-                                            </Title>
-
-                                            <Tooltip
-                                                maw={300}
-                                                label="When enabled, AI Agents never post query results into Slack: no chart images, no CSV files, and the agent is instructed to keep values out of its reply. Users open the results in Lightdash, where their own permissions apply. For a strict guarantee, also turn off data access on the agent."
-                                            >
-                                                <MantineIcon
-                                                    icon={IconHelpCircle}
-                                                />
-                                            </Tooltip>
-                                        </Group>
-
-                                        <Switch
-                                            label="Reply with links only"
+                                        <SlackSettingRow
+                                            title="Links only, no data in Slack"
+                                            description="Reply with links only"
+                                            tooltip="When enabled, AI Agents never post query results into Slack: no chart images, no CSV files, and the agent is instructed to keep values out of its reply. Users open the results in Lightdash, where their own permissions apply. For a strict guarantee, also turn off data access on the agent."
                                             disabled={aiAgentsDisabled}
-                                            checked={form.values.aiLinksOnly}
-                                            onChange={(event) => {
+                                            checked={
+                                                form.values.aiLinksOnly ?? false
+                                            }
+                                            onChange={(checked) =>
                                                 setFieldValue(
                                                     'aiLinksOnly',
-                                                    event.currentTarget.checked,
-                                                );
-                                            }}
-                                        />
-                                    </Stack>
-
-                                    <Stack gap="sm">
-                                        <Group gap="two">
-                                            <Title order={6} fw={500}>
-                                                Automatic channel linking
-                                            </Title>
-                                            <Tooltip
-                                                maw={280}
-                                                label="Turn this off to stop bot mentions from automatically linking AI Agents to unconfigured Slack channels. Channels must then be added from Lightdash."
-                                            >
-                                                <MantineIcon
-                                                    icon={IconHelpCircle}
-                                                />
-                                            </Tooltip>
-                                        </Group>
-                                        <Switch
-                                            label="Enable automatic channel linking"
-                                            checked={
-                                                !form.values
-                                                    .requireExplicitSlackChannelLinking
+                                                    checked,
+                                                )
                                             }
+                                        />
+                                        <SlackSettingRow
+                                            title="Automatic channel linking"
+                                            description="Enable automatic channel linking"
+                                            tooltip="Turn this off to stop bot mentions from automatically linking AI Agents to unconfigured Slack channels. Channels must then be added from Lightdash."
                                             disabled={
                                                 aiAgentsDisabled ||
                                                 isUpdatingAiOrganizationSettings
                                             }
-                                            onChange={(event) => {
+                                            checked={
+                                                !form.values
+                                                    .requireExplicitSlackChannelLinking
+                                            }
+                                            onChange={(checked) =>
                                                 setFieldValue(
                                                     'requireExplicitSlackChannelLinking',
-                                                    !event.currentTarget
-                                                        .checked,
-                                                );
-                                            }}
+                                                    !checked,
+                                                )
+                                            }
                                         />
                                     </Stack>
 

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -301,100 +301,106 @@ const SlackSettingsPanel: FC = () => {
                             </Group>
                             <Stack gap="sm">
                                 <Divider mt="sm" />
-                                <Title order={5}>Unfurling</Title>
-                                <SlackSettingRow
-                                    title="Link previews"
-                                    description="Post chart and dashboard previews when Lightdash links are shared. Previews run as the user who installed the app."
-                                    checked={form.values.unfurlsEnabled ?? true}
-                                    onChange={(checked) =>
-                                        setFieldValue('unfurlsEnabled', checked)
-                                    }
-                                />
-                            </Stack>
-                            {isAiCopilotEnabledOrTrial && (
-                                <Stack gap="sm">
-                                    <Divider mt="sm" />
-                                    <Title order={5}>AI in Slack</Title>
-                                    <Stack gap={0}>
-                                        <SlackSettingRow
-                                            title="AI Agents in Slack"
-                                            description="Let people talk to AI Agents from Slack. Deliveries, alerts and link previews are unaffected."
-                                            checked={
-                                                form.values.aiAgentsEnabled ??
-                                                true
-                                            }
-                                            onChange={(checked) =>
-                                                setFieldValue(
-                                                    'aiAgentsEnabled',
-                                                    checked,
-                                                )
-                                            }
-                                        />
-                                        <SlackSettingRow
-                                            title="AI Agents thread access consent"
-                                            description="Let agents read earlier messages in a thread when the bot is mentioned there."
-                                            disabled={aiAgentsDisabled}
-                                            checked={
-                                                form.values
-                                                    .aiThreadAccessConsent ??
-                                                false
-                                            }
-                                            onChange={(checked) =>
-                                                setFieldValue(
-                                                    'aiThreadAccessConsent',
-                                                    checked,
-                                                )
-                                            }
-                                        />
-                                        <SlackSettingRow
-                                            title="AI Agents OAuth requirement"
-                                            description="People must sign in with OAuth first, so requests run with their own permissions."
-                                            disabled={aiAgentsDisabled}
-                                            checked={
-                                                form.values.aiRequireOAuth ??
-                                                false
-                                            }
-                                            onChange={(checked) =>
-                                                setFieldValue(
-                                                    'aiRequireOAuth',
-                                                    checked,
-                                                )
-                                            }
-                                        />
-                                        <SlackSettingRow
-                                            title="Links only, no data in Slack"
-                                            description="Never post query results into Slack. People open results in Lightdash, where their permissions apply."
-                                            disabled={aiAgentsDisabled}
-                                            checked={
-                                                form.values.aiLinksOnly ?? false
-                                            }
-                                            onChange={(checked) =>
-                                                setFieldValue(
-                                                    'aiLinksOnly',
-                                                    checked,
-                                                )
-                                            }
-                                        />
-                                        <SlackSettingRow
-                                            title="Automatic channel linking"
-                                            description="Mentioning the bot in a new channel links an agent to it. Turn off to add channels only from Lightdash."
-                                            disabled={
-                                                aiAgentsDisabled ||
-                                                isUpdatingAiOrganizationSettings
-                                            }
-                                            checked={
-                                                !form.values
-                                                    .requireExplicitSlackChannelLinking
-                                            }
-                                            onChange={(checked) =>
-                                                setFieldValue(
-                                                    'requireExplicitSlackChannelLinking',
-                                                    !checked,
-                                                )
-                                            }
-                                        />
-                                    </Stack>
+                                <Title order={5}>Configuration</Title>
+                                <Stack gap={0}>
+                                    <SlackSettingRow
+                                        title="Link previews"
+                                        description="Post chart and dashboard previews when Lightdash links are shared. Previews run as the user who installed the app."
+                                        checked={
+                                            form.values.unfurlsEnabled ?? true
+                                        }
+                                        onChange={(checked) =>
+                                            setFieldValue(
+                                                'unfurlsEnabled',
+                                                checked,
+                                            )
+                                        }
+                                    />
+                                    {isAiCopilotEnabledOrTrial && (
+                                        <>
+                                            <SlackSettingRow
+                                                title="AI Agents in Slack"
+                                                description="Let people talk to AI Agents from Slack. Deliveries, alerts and link previews are unaffected."
+                                                checked={
+                                                    form.values
+                                                        .aiAgentsEnabled ?? true
+                                                }
+                                                onChange={(checked) =>
+                                                    setFieldValue(
+                                                        'aiAgentsEnabled',
+                                                        checked,
+                                                    )
+                                                }
+                                            />
+                                            <SlackSettingRow
+                                                title="AI Agents thread access consent"
+                                                description="Let agents read earlier messages in a thread when the bot is mentioned there."
+                                                disabled={aiAgentsDisabled}
+                                                checked={
+                                                    form.values
+                                                        .aiThreadAccessConsent ??
+                                                    false
+                                                }
+                                                onChange={(checked) =>
+                                                    setFieldValue(
+                                                        'aiThreadAccessConsent',
+                                                        checked,
+                                                    )
+                                                }
+                                            />
+                                            <SlackSettingRow
+                                                title="AI Agents OAuth requirement"
+                                                description="People must sign in with OAuth first, so requests run with their own permissions."
+                                                disabled={aiAgentsDisabled}
+                                                checked={
+                                                    form.values
+                                                        .aiRequireOAuth ?? false
+                                                }
+                                                onChange={(checked) =>
+                                                    setFieldValue(
+                                                        'aiRequireOAuth',
+                                                        checked,
+                                                    )
+                                                }
+                                            />
+                                            <SlackSettingRow
+                                                title="Links only, no data in Slack"
+                                                description="Never post query results into Slack. People open results in Lightdash, where their permissions apply."
+                                                disabled={aiAgentsDisabled}
+                                                checked={
+                                                    form.values.aiLinksOnly ??
+                                                    false
+                                                }
+                                                onChange={(checked) =>
+                                                    setFieldValue(
+                                                        'aiLinksOnly',
+                                                        checked,
+                                                    )
+                                                }
+                                            />
+                                            <SlackSettingRow
+                                                title="Automatic channel linking"
+                                                description="Mentioning the bot in a new channel links an agent to it. Turn off to add channels only from Lightdash."
+                                                disabled={
+                                                    aiAgentsDisabled ||
+                                                    isUpdatingAiOrganizationSettings
+                                                }
+                                                checked={
+                                                    !form.values
+                                                        .requireExplicitSlackChannelLinking
+                                                }
+                                                onChange={(checked) =>
+                                                    setFieldValue(
+                                                        'requireExplicitSlackChannelLinking',
+                                                        !checked,
+                                                    )
+                                                }
+                                            />
+                                        </>
+                                    )}
+                                </Stack>
 
+                                {isAiCopilotEnabledOrTrial && (
                                     <Stack gap="xs">
                                         <Group gap="xs">
                                             <Title order={6} fw={500}>
@@ -513,8 +519,8 @@ const SlackSettingsPanel: FC = () => {
                                             </Stack>
                                         )}
                                     </Stack>
-                                </Stack>
-                            )}
+                                )}
+                            </Stack>
                         </Stack>
                         <Stack align="end" mt="xl">
                             <Group gap="sm">

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -304,8 +304,7 @@ const SlackSettingsPanel: FC = () => {
                                 <Title order={5}>Unfurling</Title>
                                 <SlackSettingRow
                                     title="Link previews"
-                                    description="Enable link unfurls"
-                                    tooltip="When enabled, Lightdash posts chart and dashboard previews when links are shared in Slack. Previews are rendered as the user who installed the Slack app, so any queries they trigger are attributed to that user. Disable to stop posting previews."
+                                    description="Post chart and dashboard previews when Lightdash links are shared in Slack. Previews run as the user who installed the Slack app, so their queries are attributed to that user."
                                     checked={form.values.unfurlsEnabled ?? true}
                                     onChange={(checked) =>
                                         setFieldValue('unfurlsEnabled', checked)
@@ -319,8 +318,7 @@ const SlackSettingsPanel: FC = () => {
                                     <Stack gap={0}>
                                         <SlackSettingRow
                                             title="AI Agents in Slack"
-                                            description="Allow AI Agents to be used from Slack"
-                                            tooltip="Turn this off to stop AI Agents being used from Slack entirely. Agents stay available in Lightdash, and scheduled deliveries, alerts and link previews keep working."
+                                            description="Let people use AI Agents from Slack. Turning this off keeps agents available in Lightdash; scheduled deliveries, alerts and link previews keep working."
                                             checked={
                                                 form.values.aiAgentsEnabled ??
                                                 true
@@ -334,8 +332,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="AI Agents thread access consent"
-                                            description="Allow the AI Agents to access thread messages when a user mentions the bot in a thread."
-                                            tooltip="The longer the thread, the more context the AI Agents will have to work with."
+                                            description="Let AI Agents read earlier messages in a thread when someone mentions the bot there, so they have the conversation as context."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values
@@ -351,8 +348,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="AI Agents OAuth requirement"
-                                            description="Require OAuth for AI Agent"
-                                            tooltip="When enabled, users must authenticate with OAuth to use AI Agent features."
+                                            description="People must sign in to Lightdash with OAuth before using AI Agents from Slack, so their requests run with their own permissions."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values.aiRequireOAuth ??
@@ -367,8 +363,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="Links only, no data in Slack"
-                                            description="Reply with links only"
-                                            tooltip="When enabled, AI Agents never post query results into Slack: no chart images, no CSV files, and the agent is instructed to keep values out of its reply. Users open the results in Lightdash, where their own permissions apply. For a strict guarantee, also turn off data access on the agent."
+                                            description="AI Agents never post query results into Slack: no chart images, CSV files or values in the reply. People open results in Lightdash, where their own permissions apply. For a strict guarantee, also turn off data access on the agent."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values.aiLinksOnly ?? false
@@ -382,8 +377,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="Automatic channel linking"
-                                            description="Enable automatic channel linking"
-                                            tooltip="Turn this off to stop bot mentions from automatically linking AI Agents to unconfigured Slack channels. Channels must then be added from Lightdash."
+                                            description="Mentioning the bot in a channel with no agent yet links an agent to it automatically. Turn this off to add channels only from Lightdash."
                                             disabled={
                                                 aiAgentsDisabled ||
                                                 isUpdatingAiOrganizationSettings

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -10,7 +10,6 @@ import {
     Badge,
     Box,
     Button,
-    Divider,
     Flex,
     Group,
     Loader,
@@ -299,8 +298,7 @@ const SlackSettingsPanel: FC = () => {
                                     }
                                 />
                             </Group>
-                            <Stack gap="sm">
-                                <Divider mt="sm" />
+                            <Stack gap="sm" mt="sm">
                                 <Title order={5}>Configuration</Title>
                                 <Stack gap={0}>
                                     <SlackSettingRow

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -304,7 +304,7 @@ const SlackSettingsPanel: FC = () => {
                                 <Title order={5}>Unfurling</Title>
                                 <SlackSettingRow
                                     title="Link previews"
-                                    description="Post chart and dashboard previews when Lightdash links are shared in Slack. Previews run as the user who installed the Slack app, so their queries are attributed to that user."
+                                    description="Post chart and dashboard previews when Lightdash links are shared. Previews run as the user who installed the app."
                                     checked={form.values.unfurlsEnabled ?? true}
                                     onChange={(checked) =>
                                         setFieldValue('unfurlsEnabled', checked)
@@ -318,7 +318,7 @@ const SlackSettingsPanel: FC = () => {
                                     <Stack gap={0}>
                                         <SlackSettingRow
                                             title="AI Agents in Slack"
-                                            description="Let people use AI Agents from Slack. Turning this off keeps agents available in Lightdash; scheduled deliveries, alerts and link previews keep working."
+                                            description="Let people talk to AI Agents from Slack. Deliveries, alerts and link previews are unaffected."
                                             checked={
                                                 form.values.aiAgentsEnabled ??
                                                 true
@@ -332,7 +332,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="AI Agents thread access consent"
-                                            description="Let AI Agents read earlier messages in a thread when someone mentions the bot there, so they have the conversation as context."
+                                            description="Let agents read earlier messages in a thread when the bot is mentioned there."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values
@@ -348,7 +348,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="AI Agents OAuth requirement"
-                                            description="People must sign in to Lightdash with OAuth before using AI Agents from Slack, so their requests run with their own permissions."
+                                            description="People must sign in with OAuth first, so requests run with their own permissions."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values.aiRequireOAuth ??
@@ -363,7 +363,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="Links only, no data in Slack"
-                                            description="AI Agents never post query results into Slack: no chart images, CSV files or values in the reply. People open results in Lightdash, where their own permissions apply. For a strict guarantee, also turn off data access on the agent."
+                                            description="Never post query results into Slack. People open results in Lightdash, where their permissions apply."
                                             disabled={aiAgentsDisabled}
                                             checked={
                                                 form.values.aiLinksOnly ?? false
@@ -377,7 +377,7 @@ const SlackSettingsPanel: FC = () => {
                                         />
                                         <SlackSettingRow
                                             title="Automatic channel linking"
-                                            description="Mentioning the bot in a channel with no agent yet links an agent to it automatically. Turn this off to add channels only from Lightdash."
+                                            description="Mentioning the bot in a new channel links an agent to it. Turn off to add channels only from Lightdash."
                                             disabled={
                                                 aiAgentsDisabled ||
                                                 isUpdatingAiOrganizationSettings

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -320,7 +320,7 @@ const SlackSettingsPanel: FC = () => {
                                         <>
                                             <SlackSettingRow
                                                 title="AI Agents in Slack"
-                                                description="Let people talk to AI Agents from Slack. Deliveries, alerts and link previews are unaffected."
+                                                description="Let people talk to AI Agents from Slack."
                                                 checked={
                                                     form.values
                                                         .aiAgentsEnabled ?? true
@@ -365,7 +365,7 @@ const SlackSettingsPanel: FC = () => {
                                             />
                                             <SlackSettingRow
                                                 title="Links only, no data in Slack"
-                                                description="Never post query results into Slack. People open results in Lightdash, where their permissions apply."
+                                                description="Never post query results into Slack. People open results in Lightdash."
                                                 disabled={aiAgentsDisabled}
                                                 checked={
                                                     form.values.aiLinksOnly ??
@@ -380,7 +380,7 @@ const SlackSettingsPanel: FC = () => {
                                             />
                                             <SlackSettingRow
                                                 title="Automatic channel linking"
-                                                description="Mentioning the bot in a new channel links an agent to it. Turn off to add channels only from Lightdash."
+                                                description="Mentioning the bot in a new channel links an agent to it."
                                                 disabled={
                                                     aiAgentsDisabled ||
                                                     isUpdatingAiOrganizationSettings


### PR DESCRIPTION
The Slack integration card split its toggles across two headed sections and stacked each toggle's heading, help icon, description and switch vertically, so the six switches read as a wall of text, the on/off state was hard to scan, and most descriptions just restated their titles while the real explanation hid in a tooltip. All toggles now sit under one Configuration heading as rows with a short description on the left and the switch on the right, separated by hairlines; the tooltips are gone and their content became the descriptions.

<img width="1312" height="1316" alt="CleanShot 2026-09-11 at 16 20 52@2x" src="https://github.com/user-attachments/assets/515d100e-9927-4962-aed2-435820979839" />


Relates: PROD-11110