### PR TITLE
refactor(frontend): replace global ld-* utility classes with flex props and CSS modules

### DIFF
--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -64,8 +64,7 @@ When creating/updating components:
 1. **Best**: No custom styles (use theme defaults and variants)
 2. **Theme extension**: For repeated patterns, add a variant or rule in `src/theme/components/<Component>.module.css` (registered in `src/theme/components/index.ts`)
 3. **Component props**: Simple overrides (1-3 props like `mt="xl" w={240}`)
-4. **Utility class**: a single layout rule Mantine has no prop for (`ld-shrink-0`, `ld-grow`, `ld-self-center`, `ld-pointer`, `ld-nowrap`, `ld-pre-wrap`, `ld-overflow-hidden`, `ld-scroll-y` in `src/styles/global.css`)
-5. **CSS modules**: Complex styling or more than 3 props
+4. **CSS modules**: Complex styling, more than 3 props, or a single rule Mantine has no prop for (`align-self`, `overflow`, `cursor`, `white-space`) as a role-named class in the file's module. `flex-shrink`/`flex-grow` are the `flex` style prop. No global utility classes.
 
 ### NEVER Use
 

--- a/packages/frontend/CLAUDE.md
+++ b/packages/frontend/CLAUDE.md
@@ -7,9 +7,8 @@ the [Frontend Style Guide](../../.cursor/rules/frontend.mdc). Key points:
 -   **Prefer Mantine components over raw HTML elements** - `Box` instead of `<div>`, `Text` instead of `<p>`/`<span>` for copy, `Group`/`Stack` for flex layouts. This applies even when mirroring existing code that uses raw elements - older files predate the rule and are not a licence to copy the pattern
 -   **Styling hierarchy**:
     1. Inline-style component props (≤3 simple layout props like `mt`, `p`, `w`)
-    2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available)
-    3. For a single layout rule Mantine has no prop for (`flex-shrink`, `align-self`, `overflow`, `cursor`, `white-space`), use the `ld-*` utility classes in `src/styles/global.css` (`ld-shrink-0`, `ld-grow`, `ld-self-center`, `ld-pointer`, `ld-nowrap`, ...) instead of a one-line module or an inline `style`
-    4. Theme extensions for reusable styles
+    2. CSS modules (default choice when more than 3 inline-style props are needed or when component props aren't available). This includes single rules Mantine has no prop for (`align-self`, `overflow`, `cursor`, `white-space`): add a role-named class (`.scrollableBody`, `.clickableRow`) to the file's module. `flex-shrink: 0` and `flex-grow: 1` are the `flex` style prop (`flex="0 0 auto"`, `flex={1}`). No global utility classes.
+    3. Theme extensions for reusable styles
 -   **NEVER use** `styles`(v8) or `sx`(v6) props or `style`(v6/v8)
 -   **Colors**: Prefer default component colors (auto-theme switching). For custom colors, use `ldGray.X` and `ldDark.X`, not standard `gray.X`
 -   **Prop changes** - `spacing` → `gap`, `noWrap` → `wrap="nowrap"`, `sx` → `style` (v6)

--- a/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.module.css
@@ -16,3 +16,7 @@
         background-color: var(--mantine-color-ldGray-1);
     }
 }
+
+.skeletonBody {
+    overflow: hidden;
+}

--- a/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/LoadingSkeletonOverlay.tsx
@@ -83,8 +83,8 @@ const LoadingSkeletonOverlay = ({
             gap="sm"
             style={{ zIndex: 1 }}
         >
-            {hasTitle && <Box h={28} className="ld-shrink-0" />}
-            <Box flex={1} mih={0} className="ld-overflow-hidden">
+            {hasTitle && <Box h={28} flex="0 0 auto" />}
+            <Box flex={1} mih={0} className={styles.skeletonBody}>
                 {chartKind ? (
                     getSkeletonByChartKind(chartKind)
                 ) : (

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.module.css
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.module.css
@@ -1,0 +1,3 @@
+.dimensionTypeSelect {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomSqlDimensionModal.tsx
@@ -45,6 +45,7 @@ import { useEditorTheme } from '../../../hooks/useEditorTheme';
 import { useCustomDimensionsAceEditorCompleter } from '../../../hooks/useExplorerAceEditorCompleter';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import classes from './CustomSqlDimensionModal.module.css';
 
 type FormValues = {
     customDimensionLabel: string;
@@ -274,7 +275,7 @@ export const CustomSqlDimensionModal: FC<{
                             data-tour-suggest="Order size"
                         />
                         <Select
-                            className="ld-self-start"
+                            className={classes.dimensionTypeSelect}
                             label="Dimension Type"
                             data={Object.values(DimensionType).map((type) => ({
                                 value: type,

--- a/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/SelectedFieldsSection.tsx
@@ -319,7 +319,7 @@ const SelectedFieldRow: FC<RowProps> = memo(({ row, onDeselect }) => {
             </HoverCard>
             {isDashboardMetric && (
                 <Tooltip label="Only available in this dashboard">
-                    <Badge size="xs" radius="sm" px={4} className="ld-shrink-0">
+                    <Badge size="xs" radius="sm" px={4} flex="0 0 auto">
                         =
                     </Badge>
                 </Tooltip>

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.module.css
@@ -9,3 +9,7 @@
 .detailPreviewDropdown {
     overflow: auto;
 }
+
+.nodeIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -395,7 +395,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     <MantineIcon
                         icon={alertIcon}
                         color={color}
-                        className="ld-shrink-0"
+                        className={styles.nodeIcon}
                     />
                 </Tooltip>
             );
@@ -474,7 +474,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         transitionProps={ITEM_DETAIL_PREVIEW_TRANSITION_PROPS}
                     >
                         <HoverCard.Target>
-                            <Text truncate fz="sm" className="ld-grow">
+                            <Text truncate fz="sm" flex={1}>
                                 <Highlight
                                     component="span"
                                     highlight={searchQuery || ''}
@@ -510,12 +510,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     </HoverCard>
                     {isDashboardMetric && (
                         <Tooltip label="Only available in this dashboard">
-                            <Badge
-                                size="xs"
-                                radius="sm"
-                                px={4}
-                                className="ld-shrink-0"
-                            >
+                            <Badge size="xs" radius="sm" px={4} flex="0 0 auto">
                                 =
                             </Badge>
                         </Tooltip>
@@ -529,7 +524,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <MantineIcon
                                 icon={IconHierarchyOff}
                                 color="dimmed"
-                                className="ld-shrink-0"
+                                className={styles.nodeIcon}
                             />
                         </Tooltip>
                     )}
@@ -544,7 +539,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <ActionIcon onClick={handleFilterClick}>
                                 <MantineIcon
                                     icon={IconFilter}
-                                    className="ld-shrink-0"
+                                    className={styles.nodeIcon}
                                 />
                             </ActionIcon>
                         </Tooltip>
@@ -554,7 +549,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <ActionIcon onClick={handleDeleteClick}>
                                 <MantineIcon
                                     icon={IconTrash}
-                                    className="ld-shrink-0"
+                                    className={styles.nodeIcon}
                                 />
                             </ActionIcon>
                         </Tooltip>
@@ -564,7 +559,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                             <MantineIcon
                                 icon={IconAlertTriangle}
                                 color="yellow.9"
-                                className="ld-shrink-0"
+                                className={styles.nodeIcon}
                             />
                         </Tooltip>
                     ) : null}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.module.css
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.module.css
@@ -1,0 +1,7 @@
+.row {
+    overflow: hidden;
+}
+
+.rowIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualMissingField.tsx
@@ -3,6 +3,7 @@ import { IconAlertTriangle, IconTrash } from '@tabler/icons-react';
 import { memo, useCallback, type FC } from 'react';
 import MantineIcon from '../../../../common/MantineIcon';
 import type { MissingFieldItem } from './types';
+import classes from './VirtualMissingField.module.css';
 
 interface VirtualMissingFieldProps {
     item: MissingFieldItem;
@@ -29,12 +30,12 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
             my="xs"
             gap="xs"
             wrap="nowrap"
-            className="ld-overflow-hidden"
+            className={classes.row}
         >
             <MantineIcon
                 icon={IconAlertTriangle}
                 color="yellow.9"
-                className="ld-shrink-0"
+                className={classes.rowIcon}
             />
 
             <Text truncate size="sm" flex={1} miw={0}>
@@ -51,10 +52,10 @@ const VirtualMissingFieldComponent: FC<VirtualMissingFieldProps> = ({
             >
                 <ActionIcon
                     variant="transparent"
-                    className="ld-shrink-0"
+                    flex="0 0 auto"
                     onClick={handleClick}
                 >
-                    <MantineIcon icon={IconTrash} className="ld-shrink-0" />
+                    <MantineIcon icon={IconTrash} className={classes.rowIcon} />
                 </ActionIcon>
             </Tooltip>
         </Group>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.module.css
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.module.css
@@ -53,3 +53,7 @@
         animation-delay: 12s;
     }
 }
+
+.errorMessage {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -183,7 +183,7 @@ export const ExploreErrorState = ({
         title="Error loading results"
         description={
             <Fragment>
-                <Text className="ld-pre-wrap">
+                <Text className={classes.errorMessage}>
                     {errorDetail?.message ||
                         'There was an error loading the results'}
                 </Text>

--- a/packages/frontend/src/components/Explorer/WriteBackModal/WriteBackModal.module.css
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/WriteBackModal.module.css
@@ -1,0 +1,3 @@
+.previewPane {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/WriteBackModal/index.tsx
@@ -42,6 +42,7 @@ import {
     useWriteBackCustomMetrics,
 } from './hooks';
 import { convertToDbt, getItemId, getItemLabel, match } from './utils';
+import classes from './WriteBackModal.module.css';
 import { BIN_ORDERING_WRITE_BACK_WARNING } from './writeBackSupport';
 
 const prDisabledMessage =
@@ -466,7 +467,7 @@ const MultipleItemsModalContent = ({
                             {BIN_ORDERING_WRITE_BACK_WARNING}
                         </Callout>
                     ) : null}
-                    <Paper h="100%" className="ld-scroll-y">
+                    <Paper h="100%" className={classes.previewPane}>
                         <CodeBlock
                             code={
                                 previewError ||

--- a/packages/frontend/src/components/LightdashVisualization/LightdashVisualization.module.css
+++ b/packages/frontend/src/components/LightdashVisualization/LightdashVisualization.module.css
@@ -1,0 +1,3 @@
+.errorMessage {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -24,6 +24,7 @@ import SimpleSankey from '../SimpleSankey';
 import SimpleStatistic from '../SimpleStatistic';
 import SimpleTable from '../SimpleTable';
 import SimpleTreemap from '../SimpleTreemap';
+import classes from './LightdashVisualization.module.css';
 import { useVisualizationContext } from './useVisualizationContext';
 
 // Lazy load SimpleMap to avoid bundling Leaflet in the main chunk
@@ -136,7 +137,7 @@ const LightdashVisualization = memo(
                             title="Unable to load visualization"
                             description={
                                 <Fragment>
-                                    <Text className="ld-pre-wrap">
+                                    <Text className={classes.errorMessage}>
                                         {apiErrorDetail.message || ''}
                                     </Text>
                                     {apiErrorDetail.data.documentationUrl && (

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
@@ -78,7 +78,7 @@ const PreAggregateTopToolbar: FC<Props> = ({
                     <ActionIcon
                         size="sm"
                         onClick={resetFilters}
-                        className="ld-shrink-0"
+                        flex="0 0 auto"
                     >
                         <MantineIcon icon={IconFilterOff} />
                     </ActionIcon>

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.module.css
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.module.css
@@ -1,0 +1,3 @@
+.managePalettesLink {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
+++ b/packages/frontend/src/components/ProjectAppearance/ProjectAppearance.tsx
@@ -21,6 +21,7 @@ import Callout from '../common/Callout';
 import MantineIcon from '../common/MantineIcon';
 import { PalettePicker } from '../common/PalettePicker/PalettePicker';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
+import classes from './ProjectAppearance.module.css';
 
 type Props = { projectUuid: string };
 
@@ -100,7 +101,7 @@ const ProjectAppearance: FC<Props> = ({ projectUuid }) => {
                             leftSection={
                                 <MantineIcon icon={IconExternalLink} />
                             }
-                            className="ld-self-end"
+                            className={classes.managePalettesLink}
                         >
                             Manage organization palettes
                         </Button>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -411,7 +411,7 @@ const DatabricksForm: FC<{
                                             gap="xs"
                                         >
                                             <TextInput
-                                                className="ld-grow"
+                                                flex={1}
                                                 size="xs"
                                                 {...form.getInputProps(
                                                     `warehouse.compute.${index}.name`,
@@ -420,7 +420,7 @@ const DatabricksForm: FC<{
                                                 required
                                             />
                                             <TextInput
-                                                className="ld-grow"
+                                                flex={1}
                                                 size="xs"
                                                 {...form.getInputProps(
                                                     `warehouse.compute.${index}.httpPath`,

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.module.css
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.module.css
@@ -1,0 +1,3 @@
+.sortableHeader {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
+++ b/packages/frontend/src/components/ProjectParameters/ProjectParameters.tsx
@@ -25,6 +25,7 @@ import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import { SettingsCard } from '../common/Settings/SettingsCard';
 import { DEFAULT_PAGE_SIZE } from '../common/Table/constants';
+import classes from './ProjectParameters.module.css';
 
 interface ProjectParametersProps {
     projectUuid: string;
@@ -204,7 +205,7 @@ const ProjectParameters: FC<ProjectParametersProps> = ({ projectUuid }) => {
                     <Table.Thead>
                         <Table.Tr>
                             <Table.Th
-                                className="ld-pointer"
+                                className={classes.sortableHeader}
                                 onClick={() => handleSort('name')}
                             >
                                 <Group gap="xs">

--- a/packages/frontend/src/components/RefreshDbtButton/RefreshDbtButton.module.css
+++ b/packages/frontend/src/components/RefreshDbtButton/RefreshDbtButton.module.css
@@ -1,0 +1,3 @@
+.popoverTarget {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/RefreshDbtButton/index.tsx
+++ b/packages/frontend/src/components/RefreshDbtButton/index.tsx
@@ -25,6 +25,7 @@ import useTracking from '../../providers/Tracking/useTracking';
 import { EventName } from '../../types/Events';
 import MantineIcon from '../common/MantineIcon';
 import { useIsGitProject } from '../Explorer/WriteBackModal/hooks';
+import classes from './RefreshDbtButton.module.css';
 
 type RefreshMode = 'dbt' | 'dbt-and-content';
 
@@ -154,7 +155,7 @@ const RefreshDbtButton: FC<{
         return (
             <Popover withArrow width={300}>
                 <Popover.Target>
-                    <Box className="ld-pointer">
+                    <Box className={classes.popoverTarget}>
                         <Button
                             size="xs"
                             variant="outline"

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.module.css
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.module.css
@@ -1,0 +1,3 @@
+.descriptionInput {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
+++ b/packages/frontend/src/components/SavedDashboards/AddTilesToDashboardModal.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../hooks/useSpaces';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
+import classes from './AddTilesToDashboardModal.module.css';
 
 interface AddTilesToDashboardModalProps {
     isOpen: boolean;
@@ -367,7 +368,7 @@ const AddTilesToDashboardModal: FC<AddTilesToDashboardModalProps> = ({
                             placeholder="A few words to give your team some context"
                             autosize
                             maxRows={3}
-                            className="ld-scroll-y"
+                            className={classes.descriptionInput}
                             {...form.getInputProps('dashboardDescription')}
                         />
                         {!isLoadingSpaces && !showNewSpaceInput ? (

--- a/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/LogsTopToolbar.tsx
@@ -88,12 +88,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                                 setSearch={setSearch}
                             />
 
-                            <Divider
-                                orientation="vertical"
-                                w={1}
-                                h={20}
-                                className="ld-self-center"
-                            />
+                            <Divider orientation="vertical" w={1} h={20} />
                         </>
                     )}
 
@@ -108,12 +103,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                             >
                                 {selectedScheduler.name}
                             </Pill>
-                            <Divider
-                                orientation="vertical"
-                                w={1}
-                                h={20}
-                                className="ld-self-center"
-                            />
+                            <Divider orientation="vertical" w={1} h={20} />
                         </>
                     )}
 
@@ -145,7 +135,7 @@ export const LogsTopToolbar: FC<LogsTopToolbarProps> = memo(
                         <ActionIcon
                             size="sm"
                             onClick={resetFilters}
-                            className="ld-shrink-0"
+                            flex="0 0 auto"
                         >
                             <MantineIcon icon={IconTrash} />
                         </ActionIcon>

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.module.css
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.module.css
@@ -1,0 +1,3 @@
+.timestampCell {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
+++ b/packages/frontend/src/components/SchedulersView/RunDetailsModal.tsx
@@ -33,6 +33,7 @@ import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
+import classes from './RunDetailsModal.module.css';
 import {
     formatTaskName,
     formatTime,
@@ -143,7 +144,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     started
                 </Text>
-                <Text fz="xs" className="ld-nowrap">
+                <Text fz="xs" className={classes.timestampCell}>
                     {startedAt ? formatTimeOnly(startedAt) : '-'}
                 </Text>
             </Stack>
@@ -151,7 +152,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     {endLabel}
                 </Text>
-                <Text fz="xs" className="ld-nowrap">
+                <Text fz="xs" className={classes.timestampCell}>
                     {completedAt ? formatTimeOnly(completedAt) : '-'}
                 </Text>
             </Stack>
@@ -159,7 +160,7 @@ const JobTimingInfo: FC<{
                 <Text fz="xs" c="dimmed">
                     duration
                 </Text>
-                <Text fz="xs" className="ld-nowrap">
+                <Text fz="xs" className={classes.timestampCell}>
                     {startedAt && completedAt
                         ? formatDuration(startedAt, completedAt)
                         : '-'}

--- a/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulerTopToolbar.tsx
@@ -82,24 +82,14 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                 <Group gap="xs" wrap="nowrap" flex={1} miw={0}>
                     <SearchFilter search={search} setSearch={setSearch} />
 
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
 
                     <ResourceTypeFilter
                         selectedResourceType={selectedResourceType}
                         setSelectedResourceType={setSelectedResourceType}
                     />
 
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
 
                     <FormatFilter
                         selectedFormats={selectedFormats}
@@ -126,7 +116,7 @@ export const SchedulerTopToolbar: FC<SchedulerTopToolbarProps> = memo(
                     />
                 </Group>
 
-                <Group gap="sm" wrap="nowrap" className="ld-shrink-0">
+                <Group gap="sm" wrap="nowrap" flex="0 0 auto">
                     {hasSelection && onBulkReassign && !hideBulkReassign && (
                         <>
                             <Text size="sm" c="dimmed">

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.module.css
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.module.css
@@ -1,0 +1,3 @@
+.statusFilterBadge {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
+++ b/packages/frontend/src/components/SchedulersView/SchedulersTable.tsx
@@ -56,6 +56,7 @@ import {
 } from '../common/ContentTable';
 import MantineIcon from '../common/MantineIcon';
 import ReassignSchedulerOwnerModal from './ReassignSchedulerOwnerModal';
+import classes from './SchedulersTable.module.css';
 import SchedulersViewActionMenu from './SchedulersViewActionMenu';
 import { SchedulersViewTab } from './SchedulersViewConstants';
 import {
@@ -478,7 +479,7 @@ const SchedulersTable: FC<SchedulersTableProps> = ({
                                         size="xs"
                                     />
                                 }
-                                className="ld-pointer"
+                                className={classes.statusFilterBadge}
                                 onClick={() => {
                                     setSearchParams({
                                         tab: SchedulersViewTab.RUN_HISTORY,

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.module.css
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.module.css
@@ -1,0 +1,3 @@
+.addParamButton {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionExamplesPanel.tsx
@@ -33,6 +33,7 @@ import { useSaveConnectionSample } from '../../../features/externalConnections/h
 import { useTestConnection } from '../../../features/externalConnections/hooks/useTestConnection';
 import { ConfirmDeleteButton } from '../../common/ConfirmDeleteButton';
 import MantineIcon from '../../common/MantineIcon';
+import classes from './ConnectionExamplesPanel.module.css';
 
 const MAX_SAMPLE_PREVIEW_CHARS = 200;
 
@@ -357,7 +358,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                     <TextInput
                         label="Path"
                         placeholder="/v1/endpoint"
-                        className="ld-grow"
+                        flex={1}
                         onPaste={handlePathPaste}
                         {...form.getInputProps('path')}
                     />
@@ -406,7 +407,7 @@ export const ConnectionExamplesPanel: FC<Props> = ({
                         variant="subtle"
                         size="compact-sm"
                         leftSection={<MantineIcon icon={IconPlus} />}
-                        className="ld-self-start"
+                        className={classes.addParamButton}
                         onClick={() =>
                             form.insertListItem('queryParams', {
                                 uuid: uuidv4(),

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/ConnectionsTable.tsx
@@ -177,7 +177,7 @@ export const ConnectionsTable: FC<Props> = ({
     setConnectionToViewUsage,
 }) => {
     return (
-        <Paper className="ld-overflow-hidden">
+        <Paper className={tableStyles.paper}>
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 ta="left"

--- a/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
+++ b/packages/frontend/src/components/Settings/DataAppConnectionsPanel/WizardTestStep.tsx
@@ -134,7 +134,7 @@ export const WizardTestStep: FC<Props> = ({
                     label="Path"
                     description="Relative to the base URL"
                     placeholder="/v1/endpoint"
-                    className="ld-grow"
+                    flex={1}
                     value={path}
                     onChange={(e) => setPath(e.currentTarget.value)}
                 />

--- a/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
+++ b/packages/frontend/src/components/Settings/SemanticLayerConnectionPanel/index.tsx
@@ -157,7 +157,7 @@ const TokenAddedCard: FC<{
                     fz="sm"
                     fw={500}
                     onClick={onReplace}
-                    className="ld-shrink-0"
+                    flex="0 0 auto"
                 >
                     Replace
                 </Anchor>

--- a/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.module.css
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/SettingsUsageAnalytics.module.css
@@ -1,0 +1,3 @@
+.linkCard {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -3,6 +3,7 @@ import { IconLayoutDashboard } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../common/MantineIcon';
+import classes from './SettingsUsageAnalytics.module.css';
 
 interface ProjectUserAccessProps {
     projectUuid: string;
@@ -16,7 +17,7 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
             <Card
                 component={Link}
                 shadow="sm"
-                className="ld-pointer"
+                className={classes.linkCard}
                 to={`/projects/${projectUuid}/user-activity`}
             >
                 <Group>

--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -277,7 +277,7 @@ export const TokensTable = () => {
 
     return (
         <>
-            <Paper className="ld-overflow-hidden">
+            <Paper className={tableStyles.paper}>
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.module.css
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.module.css
@@ -7,3 +7,7 @@
 .colorInputs {
     border-right: 1px solid var(--mantine-color-ldGray-2);
 }
+
+.toggleColorsButton {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
@@ -158,7 +158,7 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
                         <MantineIcon icon={IconChevronDown} size="xs" />
                     }
                     fullWidth
-                    className="ld-self-end"
+                    className={classes.toggleColorsButton}
                 >
                     {showAllColors ? 'Show fewer colors' : 'Show all colors'}
                 </Button>

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/GithubSettingsPanel.module.css
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/GithubSettingsPanel.module.css
@@ -1,0 +1,3 @@
+.repositoryList {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../common/GithubIntegration/hooks/useGithubIntegration';
 import MantineIcon from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
+import classes from './GithubSettingsPanel.module.css';
 
 const GITHUB_INSTALL_URL = `/api/v1/github/install`;
 
@@ -96,7 +97,7 @@ const GithubSettingsPanel: FC = () => {
                             Your GitHub integration has access to the following
                             repositories ({data.length}):
                         </Text>
-                        <Box mah={200} className="ld-scroll-y">
+                        <Box mah={200} className={classes.repositoryList}>
                             <Text
                                 component="ul"
                                 fz="xs"

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CredentialsTable.tsx
@@ -95,7 +95,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     setWarehouseCredentialsToBeDeleted,
 }) => {
     return (
-        <Paper className="ld-overflow-hidden">
+        <Paper className={tableStyles.paper}>
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
             >

--- a/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OAuthClientsPanel/OAuthClientsTable.tsx
@@ -115,7 +115,7 @@ export const OAuthClientsTable: FC<{
     clients: OAuthClientSummary[];
 }> = ({ clients }) => {
     return (
-        <Paper className="ld-overflow-hidden">
+        <Paper className={tableStyles.paper}>
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
             >

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/CredentialsTable.tsx
@@ -67,7 +67,7 @@ export const CredentialsTable: FC<CredentialsTableProps> = ({
     setWarehouseCredentialsToBeDeleted,
 }) => {
     return (
-        <Paper className="ld-overflow-hidden">
+        <Paper className={tableStyles.paper}>
             <Table
                 className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 ta="left"

--- a/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ProjectManagementPanel/index.tsx
@@ -652,12 +652,7 @@ const ProjectManagementPanel: FC = () => {
                         />
                     </Tooltip>
 
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
 
                     <SegmentedControl
                         size="xs"
@@ -720,12 +715,7 @@ const ProjectManagementPanel: FC = () => {
                         ]}
                     />
 
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
 
                     {/* Warehouse filter */}
                     <Popover width={220} position="bottom-start">
@@ -922,7 +912,7 @@ const ProjectManagementPanel: FC = () => {
                     )}
                 </Group>
 
-                <Group gap="sm" wrap="nowrap" className="ld-shrink-0">
+                <Group gap="sm" wrap="nowrap" flex="0 0 auto">
                     {hasActiveFilters && (
                         <Tooltip label="Clear all filters">
                             <ActionIcon size="sm" onClick={resetAllFilters}>

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.module.css
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.module.css
@@ -1,0 +1,3 @@
+.addButton {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
+++ b/packages/frontend/src/components/UserSettings/UserAttributesPanel/UserAttributeModal.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../../hooks/useUserAttributes';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
+import classes from './UserAttributeModal.module.css';
 
 type UserAttributeFormValues = {
     name: string;
@@ -312,7 +313,7 @@ const UserAttributeModal: FC<{
                             <Button
                                 size="xs"
                                 variant="default"
-                                className="ld-self-start"
+                                className={classes.addButton}
                                 leftSection={
                                     <MantineIcon icon={IconUserPlus} />
                                 }
@@ -402,7 +403,7 @@ const UserAttributeModal: FC<{
                                 <Button
                                     size="xs"
                                     variant="default"
-                                    className="ld-self-start"
+                                    className={classes.addButton}
                                     leftSection={
                                         <MantineIcon icon={IconUsersPlus} />
                                     }

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.module.css
@@ -1,3 +1,7 @@
 .panelStack {
     border-radius: var(--mantine-radius-sm);
 }
+
+.positionLabel {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -435,7 +435,7 @@ export const ReferenceLine: FC<ReferenceLineProps> = ({
                             }}
                         />
                         <Group wrap="nowrap" flex="1" gap="sm">
-                            <Config.Label className="ld-nowrap">
+                            <Config.Label className={classes.positionLabel}>
                                 Position
                             </Config.Label>
                             <SegmentedControl

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.module.css
@@ -31,3 +31,7 @@
     pointer-events: none;
     font-family: monospace;
 }
+
+.helpIcon {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipConfig.tsx
@@ -278,7 +278,7 @@ export const TooltipConfig: FC<Props> = ({ fields }) => {
                         size="md"
                         display="inline"
                         color="ldGray.5"
-                        className="ld-pointer"
+                        className={styles.helpIcon}
                     />
                 </Tooltip>
                 <Switch

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -79,7 +79,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
     return (
         <Box>
             <Group justify="space-between">
-                <Group gap="two" ref={ref} className="ld-grow">
+                <Group gap="two" ref={ref} flex={1}>
                     {isGrouped && (
                         <GrabIcon
                             dragHandleProps={dragHandleProps}
@@ -120,7 +120,7 @@ const SingleSeriesConfiguration: FC<Props> = ({
                         />
                     )}
                     {!isSingle && isGrouped && (
-                        <Box className="ld-grow">
+                        <Box flex={1}>
                             <EditableText
                                 disabled={series.hidden}
                                 defaultValue={seriesValue}

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapFieldConfiguration.tsx
@@ -78,8 +78,8 @@ const MapFieldConfiguration: FC<MapFieldConfigurationProps> = ({ fieldId }) => {
     const isVisible = isFieldVisible(fieldId);
 
     return (
-        <Group gap="xs" wrap="nowrap" className="ld-grow">
-            <Box className="ld-grow">
+        <Group gap="xs" wrap="nowrap" flex={1}>
+            <Box flex={1}>
                 <MapFieldConfigurationInput
                     fieldId={fieldId}
                     defaultLabel={defaultLabel}

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/GroupItem.tsx
@@ -99,7 +99,7 @@ export const GroupItem = forwardRef<
                             onColorChange(defaultLabel, newColor)
                         }
                     />
-                    <Box className="ld-grow">
+                    <Box flex={1}>
                         <EditableText
                             placeholder={defaultLabel}
                             value={label}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ColumnConfiguration.tsx
@@ -136,8 +136,8 @@ const ColumnConfiguration: FC<ColumnConfigurationProps> = ({
     };
 
     return (
-        <Group gap="xs" wrap="nowrap" className="ld-grow">
-            <Box className="ld-grow">
+        <Group gap="xs" wrap="nowrap" flex={1}>
+            <Box flex={1}>
                 <ColumnConfigurationInput
                     fieldId={fieldId}
                     chartConfig={visualizationConfig.chartConfig}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.module.css
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.module.css
@@ -54,3 +54,7 @@
 :global([data-mantine-color-scheme='dark']) .zapIndicator[data-settled] svg {
     color: var(--mantine-color-ldDark-6) !important;
 }
+
+.draftsBadge {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -492,7 +492,7 @@ const DashboardHeader = memo(
                                 color="blue"
                                 variant="dot"
                                 size="sm"
-                                className="ld-pointer"
+                                className={headerClasses.draftsBadge}
                             >
                                 {dashboard.draftsAwaitingReview} draft
                                 {dashboard.draftsAwaitingReview === 1

--- a/packages/frontend/src/components/common/FieldSelect/FieldSelect.module.css
+++ b/packages/frontend/src/components/common/FieldSelect/FieldSelect.module.css
@@ -1,3 +1,7 @@
 .separatorLabel {
     font-weight: 600;
 }
+
+.optionIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/common/FieldSelect/index.tsx
+++ b/packages/frontend/src/components/common/FieldSelect/index.tsx
@@ -322,7 +322,10 @@ const FieldSelectComponent = <T extends Item = Item>({
                     openDelay={500}
                 >
                     <Group wrap="nowrap" gap={rest.size} maw="100%">
-                        <FieldIcon className="ld-shrink-0" item={fieldItem} />
+                        <FieldIcon
+                            className={classes.optionIcon}
+                            item={fieldItem}
+                        />
                         <Text
                             span
                             fz="xs"

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.module.css
@@ -1,0 +1,3 @@
+.weekPrefix {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -18,6 +18,7 @@ import { NumberInput } from '../../NumberInput';
 import useFiltersContext from '../useFiltersContext';
 import { getFirstDayOfWeek } from '../utils/filterDateUtils';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
+import classes from './DateFilterInputs.module.css';
 import {
     getInvalidDateFilterValue,
     parseFilterDateValue,
@@ -146,7 +147,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 if (coarseTimeFrame) {
                     return coarseTimeFrame === TimeFrames.WEEK ? (
                         <Flex align="center" gap="xs" w="100%">
-                            <Text c="dimmed" className="ld-nowrap" size="xs">
+                            <Text
+                                c="dimmed"
+                                className={classes.weekPrefix}
+                                size="xs"
+                            >
                                 week commencing
                             </Text>
 
@@ -177,7 +182,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                             <Flex align="center" gap="xs" w="100%">
                                 <Text
                                     c="dimmed"
-                                    className="ld-nowrap"
+                                    className={classes.weekPrefix}
                                     size="xs"
                                 >
                                     week commencing

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -288,7 +288,7 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
     }, [andRootFilterGroupItems, orRootFilterGroups]);
 
     return (
-        <Stack gap="xs" pos="relative" m="sm" className="ld-grow">
+        <Stack gap="xs" pos="relative" m="sm" flex={1}>
             {totalFilterRules.length >= 1 &&
                 (showSimplifiedForm ? (
                     <SimplifiedFilterGroupForm

--- a/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.module.css
+++ b/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.module.css
@@ -1,0 +1,3 @@
+.formattedJson {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
+++ b/packages/frontend/src/components/common/JsonViewer/JsonCellViewer.tsx
@@ -16,6 +16,7 @@ import { useRjvTheme } from '../../../hooks/useRjvTheme';
 import { CopyActionIcon } from '../CopyActionIcon';
 import MantineIcon from '../MantineIcon';
 import MantineModal from '../MantineModal';
+import classes from './JsonCellViewer.module.css';
 import { type JsonCellValue } from './utils';
 
 type Props = {
@@ -160,7 +161,7 @@ export const JsonCellModal: FC<ModalProps> = ({ value, opened, onClose }) => {
                                 component="pre"
                                 fz="xs"
                                 m={0}
-                                className="ld-pre-wrap"
+                                className={classes.formattedJson}
                             >
                                 {formattedJson}
                             </Box>

--- a/packages/frontend/src/components/common/PolymorphicPaperButton.module.css
+++ b/packages/frontend/src/components/common/PolymorphicPaperButton.module.css
@@ -1,0 +1,3 @@
+.root {
+    cursor: pointer;
+}

--- a/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
+++ b/packages/frontend/src/components/common/PolymorphicPaperButton.tsx
@@ -5,6 +5,7 @@ import {
 } from '@mantine/core';
 import { clsx } from 'clsx';
 import { forwardRef, type Ref } from 'react';
+import classes from './PolymorphicPaperButton.module.css';
 
 /**
  * A polymorphic component that renders a paper button.
@@ -19,7 +20,7 @@ export const PolymorphicPaperButton = createPolymorphicComponent<
             <Paper
                 ref={ref}
                 {...props}
-                className={clsx('ld-pointer', className)}
+                className={clsx(classes.root, className)}
             />
         ),
     ),

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -825,7 +825,6 @@ const InfiniteResourceTable = ({
                                         w={1}
                                         h={20}
                                         color="#DEE2E6"
-                                        className="ld-self-center"
                                     />
                                     <ContentTypeFilter
                                         value={selectedContentType}
@@ -864,7 +863,6 @@ const InfiniteResourceTable = ({
                                         w={1}
                                         h={20}
                                         color="#DEE2E6"
-                                        className="ld-self-center"
                                     />
                                     <Box w={220}>
                                         <UserSelect

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.module.css
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.module.css
@@ -11,3 +11,7 @@
         var(--mantine-color-dark-5)
     );
 }
+
+.pagination {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalContent.tsx
@@ -167,7 +167,7 @@ const UserAccessAuditList: FC<UserAccessAuditListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    className="ld-self-end"
+                    className={classes.pagination}
                 />
             )}
         </Stack>

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.module.css
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.module.css
@@ -27,3 +27,7 @@
         var(--mantine-color-dark-5)
     );
 }
+
+.pagination {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
@@ -224,7 +224,7 @@ export const UserAccessList: FC<UserAccessListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    className="ld-self-end"
+                    className={classes.pagination}
                 />
             )}
         </Stack>
@@ -345,7 +345,7 @@ export const GroupsAccessList: FC<GroupAccessListProps> = ({
                     hasPreviousPage={page > 1}
                     onNextPage={handleNextPage}
                     onPreviousPage={handlePreviousPage}
-                    className="ld-self-end"
+                    className={classes.pagination}
                 />
             )}
         </Stack>

--- a/packages/frontend/src/components/common/Tree/TreeItem.module.css
+++ b/packages/frontend/src/components/common/Tree/TreeItem.module.css
@@ -36,3 +36,7 @@
         visibility: hidden;
     }
 }
+
+.itemIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/components/common/Tree/TreeItem.tsx
+++ b/packages/frontend/src/components/common/Tree/TreeItem.tsx
@@ -101,14 +101,14 @@ const TreeItem: React.FC<Props> = ({
                 color="ldGray.7"
                 size="lg"
                 stroke={1.5}
-                className="ld-shrink-0"
+                className={classes.itemIcon}
             />
 
             <Highlight
                 truncate="end"
                 fz={rem(13)}
                 fw={500}
-                className="ld-grow"
+                flex={1}
                 highlight={matchHighlights}
                 highlightStyles={{
                     backgroundColor: 'transparent',
@@ -123,7 +123,7 @@ const TreeItem: React.FC<Props> = ({
                     icon={IconCheck}
                     size="lg"
                     color="blue.6"
-                    className="ld-shrink-0"
+                    className={classes.itemIcon}
                 />
             )}
         </Paper>

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/AiSearchBox.tsx
@@ -185,7 +185,7 @@ const AiSearchBoxInner: FC<Props> = ({
         aiRouterConfigQuery.isLoading
     ) {
         return (
-            <Paper className="ld-overflow-hidden" p="md">
+            <Paper className={styles.loadingCard} p="md">
                 <Group wrap="nowrap" align="center">
                     <Skeleton circle height={38} width={38} />
                     <Skeleton height={36} flex={1} />

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.module.css
@@ -39,3 +39,7 @@
     border-top-right-radius: var(--mantine-radius-sm);
     overflow: hidden;
 }
+
+.comboboxFooter {
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/SearchDropdown.tsx
@@ -194,7 +194,7 @@ export const SearchDropdown: FC<Props> = ({
                     </ScrollArea.Autosize>
                 </Combobox.Options>
                 {footer && (
-                    <Combobox.Footer p={0} className="ld-overflow-hidden">
+                    <Combobox.Footer p={0} className={styles.comboboxFooter}>
                         {footer}
                     </Combobox.Footer>
                 )}

--- a/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
+++ b/packages/frontend/src/ee/components/Home/AiSearchBox/aiSearchBox.module.css
@@ -108,3 +108,7 @@
         margin-right: 4px !important;
     }
 }
+
+.loadingCard {
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminAgentsTable.tsx
@@ -575,12 +575,7 @@ const AiAgentAdminAgentsTable = () => {
                             placeholder="Search agents"
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={
@@ -589,12 +584,7 @@ const AiAgentAdminAgentsTable = () => {
                             tooltipLabel="Filter agents by project"
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <Switch
                             size="xs"
                             label="Hide preview projects"
@@ -608,12 +598,7 @@ const AiAgentAdminAgentsTable = () => {
 
                         {hasActiveFilters && (
                             <>
-                                <Divider
-                                    orientation="vertical"
-                                    w={1}
-                                    h={20}
-                                    className="ld-self-center"
-                                />
+                                <Divider orientation="vertical" w={1} h={20} />
                                 <Button
                                     variant="subtle"
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminEvalsTable.tsx
@@ -362,35 +362,20 @@ const AiAgentAdminEvalsTable = ({
                             setSearch={setSearch}
                             placeholder="Search evals by title"
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={setSelectedProjectUuids}
                             hidePreviewProjects={hidePreviewProjects}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
                             hidePreviewProjects={hidePreviewProjects}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <Switch
                             size="xs"
                             label="Hide preview projects"
@@ -403,12 +388,7 @@ const AiAgentAdminEvalsTable = ({
                         />
                         {hasActiveFilters && (
                             <>
-                                <Divider
-                                    orientation="vertical"
-                                    w={1}
-                                    h={20}
-                                    className="ld-self-center"
-                                />
+                                <Divider orientation="vertical" w={1} h={20} />
                                 <Button
                                     variant="subtle"
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/AiAgentAdminTopToolbar.tsx
@@ -93,68 +93,38 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
                             debounceMs={300}
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <ProjectsFilter
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={setSelectedProjectUuids}
                             hidePreviewProjects={hidePreviewProjects}
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
                             hidePreviewProjects={hidePreviewProjects}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <UsersFilter
                             selectedUserUuids={selectedUserUuids}
                             setSelectedUserUuids={setSelectedUserUuids}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <FeedbackFilter
                             selectedFeedback={selectedFeedback}
                             setSelectedFeedback={setSelectedFeedback}
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <SourceFilter
                             selectedSource={selectedSource}
                             setSelectedSource={setSelectedSource}
                         />
 
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <Switch
                             size="xs"
                             label="Hide preview projects"
@@ -168,12 +138,7 @@ export const AiAgentAdminTopToolbar: FC<AiAgentAdminTopToolbarProps> = memo(
 
                         {hasActiveFilters && onClearFilters && (
                             <>
-                                <Divider
-                                    orientation="vertical"
-                                    w={1}
-                                    h={20}
-                                    className="ld-self-center"
-                                />
+                                <Divider orientation="vertical" w={1} h={20} />
                                 <Button
                                     variant="subtle"
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/EvalPreviewSidebar.tsx
@@ -154,7 +154,7 @@ export const EvalPreviewSidebar: FC<EvalPreviewSidebarProps> = ({
                                     c="ldGray.5"
                                     w={20}
                                     ta="right"
-                                    className="ld-shrink-0"
+                                    flex="0 0 auto"
                                 >
                                     {index + 1}
                                 </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/McpActivityTopToolbar.tsx
@@ -63,23 +63,13 @@ export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
                             selectedProjectUuids={selectedProjectUuids}
                             setSelectedProjectUuids={setSelectedProjectUuids}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <AgentsFilter
                             selectedAgentUuids={selectedAgentUuids}
                             setSelectedAgentUuids={setSelectedAgentUuids}
                             selectedProjectUuids={selectedProjectUuids}
                         />
-                        <Divider
-                            orientation="vertical"
-                            w={1}
-                            h={20}
-                            className="ld-self-center"
-                        />
+                        <Divider orientation="vertical" w={1} h={20} />
                         <SegmentedControl
                             size="xs"
                             value={selectedStatus}
@@ -97,12 +87,7 @@ export const McpActivityTopToolbar: FC<McpActivityTopToolbarProps> = memo(
 
                         {hasActiveFilters && onClearFilters && (
                             <>
-                                <Divider
-                                    orientation="vertical"
-                                    w={1}
-                                    h={20}
-                                    className="ld-self-center"
-                                />
+                                <Divider orientation="vertical" w={1} h={20} />
                                 <Button
                                     variant="subtle"
                                     size="xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.module.css
@@ -1,0 +1,3 @@
+.diffPanel {
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ProjectContextDiffPreview.tsx
@@ -9,6 +9,7 @@ import {
     PIERRE_HIGHLIGHTER_OPTIONS,
     PIERRE_POOL_OPTIONS,
 } from './pierreDiffConfig';
+import classes from './ProjectContextDiffPreview.module.css';
 
 type ProjectContextDiffPreviewProps = {
     fileName: string;
@@ -43,7 +44,7 @@ export const ProjectContextDiffPreview: FC<ProjectContextDiffPreviewProps> = ({
             poolOptions={PIERRE_POOL_OPTIONS}
             highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
         >
-            <Paper shadow="sm" radius="md" className="ld-overflow-hidden">
+            <Paper shadow="sm" radius="md" className={classes.diffPanel}>
                 <Virtualizer style={viewportStyle}>
                     <MultiFileDiff
                         oldFile={{ name: fileName, contents: before }}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanBoard.module.css
@@ -219,3 +219,7 @@
 .hoverAction:focus-visible {
     opacity: 1;
 }
+
+.lastSeen {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewKanbanCard.tsx
@@ -147,7 +147,7 @@ export const ReviewKanbanCard: FC<Props> = ({ item, isSelected, onSelect }) => {
                                 <Text
                                     fz="xs"
                                     c="ldGray.5"
-                                    className="ld-nowrap"
+                                    className={styles.lastSeen}
                                 >
                                     {formatRelativeReviewDate(item.lastSeenAt)}
                                 </Text>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.module.css
@@ -1,0 +1,3 @@
+.diffPanel {
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ReviewPrDiffContent.tsx
@@ -17,6 +17,7 @@ import {
     PIERRE_HIGHLIGHTER_OPTIONS,
     PIERRE_POOL_OPTIONS,
 } from './pierreDiffConfig';
+import classes from './ReviewPrDiffContent.module.css';
 
 type Props = {
     diff: AiAgentReviewItemPrDiff | undefined;
@@ -65,7 +66,7 @@ export const ReviewPrDiffContent: FC<Props> = ({
                     <Paper
                         key={file.path}
                         radius="md"
-                        className="ld-overflow-hidden"
+                        className={classes.diffPanel}
                     >
                         <Virtualizer style={viewportStyle}>
                             <MultiFileDiff

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.module.css
@@ -77,3 +77,7 @@
         width: 100%;
     }
 }
+
+.scrollableBody {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Admin/ThreadPreviewSidebar.tsx
@@ -280,7 +280,10 @@ export const ThreadPreviewSidebar: FC<ThreadPreviewSidebarProps> = ({
             <Divider />
 
             {threadData && (
-                <Box mah="calc(100vh - 150px)" className="ld-scroll-y">
+                <Box
+                    mah="calc(100vh - 150px)"
+                    className={styles.scrollableBody}
+                >
                     {selectedReviewItem ? (
                         <>
                             <Stack p="md" gap="md">

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.module.css
@@ -1,0 +1,3 @@
+.markdownViewer {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeDocumentModal.tsx
@@ -35,6 +35,7 @@ import {
     useAiAgentDocumentContent,
     useUpdateAiAgentDocumentContent,
 } from '../hooks/useAiAgentDocuments';
+import classes from './AiAgentKnowledgeDocumentModal.module.css';
 
 const MARKDOWN_REMARK_PLUGINS = [remarkFrontmatter];
 
@@ -194,7 +195,7 @@ const LoadedDocumentModal = ({
                     <Box
                         data-color-mode={colorScheme}
                         h="100%"
-                        className="ld-scroll-y"
+                        className={classes.markdownViewer}
                     >
                         <MDEditor.Markdown
                             source={form.values.content}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.module.css
@@ -18,3 +18,7 @@
         animation: none;
     }
 }
+
+.fileIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentKnowledgeFilesSection.tsx
@@ -485,7 +485,9 @@ export const AiAgentKnowledgeFilesSection = ({
                                                                     IconFileText
                                                                 }
                                                                 color="dimmed"
-                                                                className="ld-shrink-0"
+                                                                className={
+                                                                    styles.fileIcon
+                                                                }
                                                             />
                                                             <Stack
                                                                 gap={2}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.module.css
@@ -1,0 +1,3 @@
+.serverCard {
+    overflow: hidden;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentMcpServersInput.tsx
@@ -69,6 +69,7 @@ import {
     MCP_TOOL_TOKEN_WARNING_THRESHOLD,
 } from '../utils/mcpToolTokenEstimates';
 import { AgentSettingsSubsection } from './AgentSettingsSubsection';
+import classes from './AiAgentMcpServersInput.module.css';
 import { AiAgentMcpServerToolsPanel } from './AiAgentMcpServerToolsPanel';
 import { AiMcpServerIcon } from './AiMcpServerIcon';
 import { GithubMcpConnectModal } from './GithubMcpConnectModal';
@@ -1541,7 +1542,7 @@ export const AiAgentMcpServersInput = ({
                                         key={mcpServer.uuid}
                                         radius="md"
                                         p={0}
-                                        className="ld-overflow-hidden"
+                                        className={classes.serverCard}
                                     >
                                         <Group
                                             justify="space-between"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatDisplay.tsx
@@ -195,9 +195,9 @@ export const AgentChatDisplay: FC<PropsWithChildren<Props>> = ({
                     px={ChatElementsUtils.centeredElementProps.px}
                     pb="md"
                     gap="xl"
-                    className="ld-grow"
+                    flex={1}
                 >
-                    <Stack flex={1} className="ld-grow">
+                    <Stack flex={1}>
                         {visibleMessages.map((message, i, xs) => (
                             <Fragment key={`${message.role}-${message.uuid}`}>
                                 {message.role === 'user' &&

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -355,7 +355,7 @@ export const AiVisualizationRenderer: FC<Props> = ({
                     </Box>
 
                     {displayDetails ? (
-                        <Stack gap="xs" className="ld-shrink-0">
+                        <Stack gap="xs" flex="0 0 auto">
                             <Flex align="center" justify="flex-start">
                                 <Button
                                     size="compact-xs"

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.module.css
@@ -11,3 +11,7 @@
     border: 1px solid var(--mantine-color-default-border);
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
 }
+
+.versionLabel {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/DataAppVersionPill.tsx
@@ -21,7 +21,7 @@ export const DataAppVersionPill: FC<Props> = ({
     restore,
 }) => (
     <Group gap="xs" wrap="nowrap" className={classes.pill}>
-        <Text size="xs" fw={500} className="ld-nowrap">
+        <Text size="xs" fw={500} className={classes.versionLabel}>
             Viewing v{version}
         </Text>
         <Button

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/StreamRecoveryAlert.tsx
@@ -28,7 +28,7 @@ export const StreamRecoveryAlert = () => {
                     aria-label="Connection lost. Reconnecting"
                     color="yellow.7"
                     size={14}
-                    className="ld-shrink-0"
+                    flex="0 0 auto"
                 />
                 <Group gap={6} wrap="nowrap" flex={1} miw={0}>
                     <Text

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.module.css
@@ -1,0 +1,3 @@
+.assessmentText {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalAssessmentDisplay.tsx
@@ -4,6 +4,7 @@ import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useAiAgentEvaluationRunResults } from '../../hooks/useAiAgentEvaluations';
 import { ToolCallPaper } from '../ChatElements/ToolCalls/ToolCallPaper';
+import classes from './EvalAssessmentDisplay.module.css';
 import { getAssessmentConfig } from './utils';
 
 type EvalAssessmentDisplayProps = {
@@ -83,7 +84,11 @@ export const EvalAssessmentDisplay: FC<EvalAssessmentDisplayProps> = ({
                     }
                 >
                     {assessment.reason && (
-                        <Text size="xs" className="ld-pre-wrap" mt="xs">
+                        <Text
+                            size="xs"
+                            className={classes.assessmentText}
+                            mt="xs"
+                        >
                             {assessment.reason}
                         </Text>
                     )}
@@ -92,7 +97,11 @@ export const EvalAssessmentDisplay: FC<EvalAssessmentDisplayProps> = ({
                             <Text size="xs" fw={600} c="dimmed">
                                 Expected Response
                             </Text>
-                            <Text size="xs" className="ld-pre-wrap" fs="italic">
+                            <Text
+                                size="xs"
+                                className={classes.assessmentText}
+                                fs="italic"
+                            >
                                 {expectedResponse}
                             </Text>
                         </Stack>

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.module.css
@@ -1,0 +1,3 @@
+.clickableCard {
+    cursor: pointer;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalPromptThreadReference.tsx
@@ -13,6 +13,7 @@ import { type FC } from 'react';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import { useEvalSectionContext } from '../../hooks/useEvalSectionContext';
 import { useAiAgentThread } from '../../hooks/useProjectAiAgents';
+import classes from './EvalPromptThreadReference.module.css';
 
 type Props = {
     projectUuid: string;
@@ -78,7 +79,11 @@ export const EvalPromptThreadReference: FC<Props> = ({
     );
 
     return (
-        <Card p="sm" className="ld-pointer" onClick={handleOpenThread}>
+        <Card
+            p="sm"
+            className={classes.clickableCard}
+            onClick={handleOpenThread}
+        >
             <Stack gap="xs">
                 <Group justify="space-between" align="flex-start">
                     <Group gap="xs" flex={1} align="flex-start">

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.module.css
@@ -13,3 +13,7 @@
 .threadPanel {
     max-height: 100%;
 }
+
+.breadcrumbLink {
+    cursor: pointer;
+}

--- a/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/Evals/EvalSectionLayout.tsx
@@ -136,7 +136,7 @@ export const EvalSectionLayout: FC<EvalSectionLayoutProps> = ({ children }) => {
                 key="evaluation"
                 size="lg"
                 onClick={handleNavigateToEvaluation}
-                className="ld-pointer"
+                className={styles.breadcrumbLink}
                 td="none"
                 fw={500}
             >

--- a/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/PinnedContextCard/PinnedReviewEntityCard.tsx
@@ -117,7 +117,7 @@ const ReviewFindingRow: FC<{
             icon={IconSearch}
             right={
                 item.findingCount > 1 ? (
-                    <Text fz="xs" fw={600} c="dimmed" className="ld-shrink-0">
+                    <Text fz="xs" fw={600} c="dimmed" flex="0 0 auto">
                         {item.findingCount}×
                     </Text>
                 ) : undefined

--- a/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
+++ b/packages/frontend/src/ee/features/contentReview/components/RequestReviewModal.tsx
@@ -205,11 +205,7 @@ const RequestReviewModal: FC<Props> = ({
                                 {contentName}
                             </Text>
                             <MantineIcon icon={IconArrowRight} color="dimmed" />
-                            <Group
-                                gap={4}
-                                wrap="nowrap"
-                                className="ld-shrink-0"
-                            >
+                            <Group gap={4} wrap="nowrap" flex="0 0 auto">
                                 <MantineIcon icon={IconFolder} color="dimmed" />
                                 <Text fz="sm" fw={500}>
                                     {targetSpace?.name ?? 'Shared space'}

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.module.css
@@ -26,3 +26,7 @@
 .inlineToggle:hover {
     text-decoration: underline;
 }
+
+.noteText {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
+++ b/packages/frontend/src/ee/features/contentReview/pages/ContentReviewRequestPage.tsx
@@ -253,7 +253,7 @@ const WaitingCard: FC<{
                     variant="default"
                     loading={isCancelling}
                     onClick={() => cancel(request.uuid)}
-                    className="ld-shrink-0"
+                    flex="0 0 auto"
                 >
                     Cancel request
                 </Button>
@@ -390,7 +390,7 @@ const ThreadMessage: FC<
             <LightdashUserAvatar size={28} userUuid={user.userUuid} fz="xs">
                 {getUserInitials(user)}
             </LightdashUserAvatar>
-            <Stack gap="sm" className="ld-grow">
+            <Stack gap="sm" flex={1}>
                 <Group gap={6} wrap="wrap">
                     <Text fz="sm" fw={500}>
                         {getUserFullName(user)}
@@ -441,7 +441,7 @@ const RequestMessage: FC<{
             date={request.createdAt}
         >
             {request.requestNote && (
-                <Text fz="sm" className="ld-pre-wrap">
+                <Text fz="sm" className={classes.noteText}>
                     {request.requestNote}
                 </Text>
             )}
@@ -476,7 +476,7 @@ const OutcomeMessage: FC<{ request: ContentReviewRequestDetail }> = ({
 }) => {
     if (request.reviewedAt === null) return null;
     const note = request.reviewNote && (
-        <Text fz="sm" className="ld-pre-wrap">
+        <Text fz="sm" className={classes.noteText}>
             {request.reviewNote}
         </Text>
     );
@@ -666,7 +666,7 @@ export const ContentReviewRequestDetailView: FC<{
                         variant={isReviewing ? 'filled' : 'default'}
                         size="xs"
                         leftSection={<MantineIcon icon={IconExternalLink} />}
-                        className="ld-shrink-0"
+                        flex="0 0 auto"
                     >
                         Open {getContentTypeNoun(request.contentType)}
                     </Button>

--- a/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
+++ b/packages/frontend/src/ee/features/customRoles/CustomRolesTable.tsx
@@ -132,7 +132,7 @@ export const CustomRolesTable: FC<TableProps> = ({
 
     return (
         <>
-            <Paper className="ld-overflow-hidden">
+            <Paper className={tableStyles.paper}>
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
+++ b/packages/frontend/src/ee/features/customRoles/components/ScopeSelector/ScopeSelector.tsx
@@ -170,7 +170,7 @@ const ScopePanel: FC<{
 
     return (
         <Stack gap="md" h="100%" w="100%">
-            <Group justify="space-between" className="ld-shrink-0">
+            <Group justify="space-between" flex="0 0 auto">
                 <Title order={5}>{group.groupName}</Title>
                 <Group gap="xs">
                     <Text size="xs" fw={500}>
@@ -494,7 +494,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
 
     return (
         <Stack gap="sm" h="100%">
-            <Stack gap="sm" className="ld-shrink-0">
+            <Stack gap="sm" flex="0 0 auto">
                 <Group justify="space-between">
                     <Stack gap="two">
                         <Title order={5}>Permissions</Title>
@@ -556,7 +556,7 @@ export const ScopeSelector: FC<ScopeSelectorProps> = ({
             </Stack>
 
             {filteredScopes.length === 0 ? (
-                <Paper p="xl" className="ld-shrink-0">
+                <Paper p="xl" flex="0 0 auto">
                     <Text ta="center" fz="sm">
                         No permissions found matching your search.
                     </Text>

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardFilterBar.tsx
@@ -117,7 +117,7 @@ const EmbedDashboardFilterBar: FC<Props> = ({
                 )}
             </Group>
 
-            <Group gap="xs" wrap="nowrap" className="ld-shrink-0">
+            <Group gap="xs" wrap="nowrap" flex="0 0 auto">
                 {dashboard.canDateZoom && (
                     <Box
                         className={embedContractClass('ld-dashboard-date-zoom')}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -807,3 +807,7 @@
         var(--mantine-color-ldGray-9)
     );
 }
+
+.targetIcon {
+    flex-shrink: 0;
+}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1057,7 +1057,7 @@ const DetailSidebar: FC<{
                     <TargetIcon
                         size={16}
                         color="var(--mantine-color-dimmed)"
-                        className="ld-shrink-0"
+                        className={classes.targetIcon}
                     />
                     <TruncatedText maxWidth={260} fz="sm" fw={600}>
                         {action.targetName}
@@ -1894,7 +1894,7 @@ const ActionRow: FC<{
                     <TargetIcon
                         size={14}
                         color="var(--mantine-color-dimmed)"
-                        className="ld-shrink-0"
+                        className={classes.targetIcon}
                     />
                     <TruncatedText maxWidth={220} fz="xs" fw={500}>
                         {action.targetName}

--- a/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/ee/features/scim/components/ScimAccessTokensPanel/TokensTable.tsx
@@ -117,7 +117,7 @@ export const TokensTable = () => {
 
     return (
         <>
-            <Paper className="ld-overflow-hidden">
+            <Paper className={tableStyles.paper}>
                 <Table
                     className={`${tableStyles.root} ${tableStyles.alignLastTdRight}`}
                 >

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.module.css
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.module.css
@@ -23,3 +23,11 @@
         background-color: var(--mantine-color-dark-7);
     }
 }
+
+.agentInstruction {
+    white-space: pre-wrap;
+}
+
+.agentDescription {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AiAgentNewThreadPage.tsx
@@ -413,7 +413,9 @@ const AiAgentNewThreadPage: FC = () => {
                                         >
                                             <Text
                                                 size="sm"
-                                                className="ld-pre-wrap"
+                                                className={
+                                                    styles.agentInstruction
+                                                }
                                             >
                                                 {agent.instruction}
                                             </Text>
@@ -428,7 +430,7 @@ const AiAgentNewThreadPage: FC = () => {
                                 c="dimmed"
                                 ta="center"
                                 maw={600}
-                                className="ld-pre-wrap"
+                                className={styles.agentDescription}
                                 data-tour-scope="view:AiAgent"
                                 data-tour-result="1"
                                 data-tour-label="Read the agent description"

--- a/packages/frontend/src/features/apps/AppInspector.module.css
+++ b/packages/frontend/src/features/apps/AppInspector.module.css
@@ -215,3 +215,7 @@
         border-left: 1px solid var(--mantine-color-ldDark-4);
     }
 }
+
+.rawJsonToggle {
+    cursor: pointer;
+}

--- a/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
+++ b/packages/frontend/src/features/apps/ExternalRequestInspector.tsx
@@ -178,7 +178,7 @@ const ExternalRequestRow: FC<{ request: ExternalRequestEvent }> = ({
                             <Group
                                 gap={4}
                                 onClick={() => setJsonExpanded((v) => !v)}
-                                className="ld-pointer"
+                                className={classes.rawJsonToggle}
                             >
                                 <ActionIcon size="xs">
                                     {jsonExpanded ? (

--- a/packages/frontend/src/features/apps/QueryInspector.tsx
+++ b/packages/frontend/src/features/apps/QueryInspector.tsx
@@ -261,7 +261,7 @@ const QueryRow: FC<{
                             <Group
                                 gap={4}
                                 onClick={() => setJsonExpanded((v) => !v)}
-                                className="ld-pointer"
+                                className={classes.rawJsonToggle}
                             >
                                 <ActionIcon size="xs">
                                     {jsonExpanded ? (

--- a/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
+++ b/packages/frontend/src/features/chartTypes/components/ChartTypeLibraryCard.tsx
@@ -86,7 +86,7 @@ const ChartTypeLibraryCard: FC<Props> = ({ item, onClick }) => {
                     <Text fz={13} fw={600} truncate="end">
                         {item.name}
                     </Text>
-                    <Group gap={4} wrap="nowrap" className="ld-shrink-0">
+                    <Group gap={4} wrap="nowrap" flex="0 0 auto">
                         {item.channel === 'beta' && <ChartTypeBetaBadge />}
                         <OfficialChartTypeBadge />
                     </Group>

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.module.css
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.module.css
@@ -22,3 +22,7 @@
 .row[data-active='true']:hover {
     background-color: var(--mantine-color-default-hover);
 }
+
+.diffPanel {
+    overflow: hidden;
+}

--- a/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
+++ b/packages/frontend/src/features/contentAsCode/components/ContentReviewPage.tsx
@@ -292,7 +292,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
 
     return (
         <Group align="flex-start" gap="md" wrap="nowrap">
-            <Stack w={280} gap="sm" className="ld-shrink-0">
+            <Stack w={280} gap="sm" flex="0 0 auto">
                 <ScrollArea.Autosize mah="72vh">
                     <Stack gap="md">
                         {openDrafts.length > 0 && (
@@ -376,11 +376,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                                     </Anchor>
                                 </Group>
                             </Stack>
-                            <Group
-                                gap="xs"
-                                wrap="nowrap"
-                                className="ld-shrink-0"
-                            >
+                            <Group gap="xs" wrap="nowrap" flex="0 0 auto">
                                 {active.prUrl ? (
                                     <Button
                                         component="a"
@@ -507,7 +503,7 @@ const ContentReviewPage: FC<ContentReviewPageProps> = ({ projectUuid }) => {
                             poolOptions={PIERRE_POOL_OPTIONS}
                             highlighterOptions={PIERRE_HIGHLIGHTER_OPTIONS}
                         >
-                            <Paper radius="md" className="ld-overflow-hidden">
+                            <Paper radius="md" className={classes.diffPanel}>
                                 <Virtualizer
                                     key={active.uuid}
                                     style={viewportStyle}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -604,7 +604,7 @@ const FilterConfiguration: FC<Props> = ({
             </Tabs>
 
             <Flex gap="sm">
-                <Box className="ld-grow" />
+                <Box flex={1} />
 
                 {!isTemporary &&
                     isFilterModified &&

--- a/packages/frontend/src/features/dashboardTabs/DeleteTabModal.module.css
+++ b/packages/frontend/src/features/dashboardTabs/DeleteTabModal.module.css
@@ -1,0 +1,3 @@
+.schedulerList {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
+++ b/packages/frontend/src/features/dashboardTabs/DeleteTabModal.tsx
@@ -23,6 +23,7 @@ import MantineModal from '../../components/common/MantineModal';
 import { useDashboardSchedulers } from '../../features/scheduler/hooks/useDashboardSchedulers';
 import useToaster from '../../hooks/toaster/useToaster';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
+import classes from './DeleteTabModal.module.css';
 
 type DeleteProps = ModalProps & {
     tab: DashboardTab;
@@ -256,7 +257,7 @@ export const TabDeleteModal: FC<DeleteProps> = ({
                             <Box
                                 ref={scrollContainerRef}
                                 mah={150}
-                                className="ld-scroll-y"
+                                className={classes.schedulerList}
                                 onScroll={onScroll}
                             >
                                 <List size="sm">

--- a/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
+++ b/packages/frontend/src/features/dataAppActivity/components/DataAppActivityTopToolbar.tsx
@@ -141,12 +141,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         searchValue={projectSearch}
                         onSearchChange={setProjectSearch}
                     />
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
                     <FilterFacet
                         label="Users"
                         icon={IconUser}
@@ -158,12 +153,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         searchValue={userSearch}
                         onSearchChange={setUserSearch}
                     />
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
                     <FilterFacet
                         label="Models"
                         icon={IconSparkles}
@@ -172,12 +162,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                         options={modelOptions}
                         tooltipLabel="Filter activity by the model that built it"
                     />
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
                     <SegmentedControl
                         size="xs"
                         value={selectedPeriod}
@@ -191,12 +176,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                             value: period,
                         }))}
                     />
-                    <Divider
-                        orientation="vertical"
-                        w={1}
-                        h={20}
-                        className="ld-self-center"
-                    />
+                    <Divider orientation="vertical" w={1} h={20} />
                     <SegmentedControl
                         size="xs"
                         value={selectedKind}
@@ -210,12 +190,7 @@ export const DataAppActivityTopToolbar: FC<DataAppActivityTopToolbarProps> = ({
                     />
                     {hasActiveFilters && (
                         <>
-                            <Divider
-                                orientation="vertical"
-                                w={1}
-                                h={20}
-                                className="ld-self-center"
-                            />
+                            <Divider orientation="vertical" w={1} h={20} />
                             <Button
                                 variant="subtle"
                                 size="xs"

--- a/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
+++ b/packages/frontend/src/features/directAccess/components/DirectAccessModal.tsx
@@ -132,7 +132,7 @@ const AssignmentRow: FC<AssignmentRowProps> = ({
                 </Stack>
             </Group>
 
-            <Group gap="xs" wrap="nowrap" className="ld-shrink-0">
+            <Group gap="xs" wrap="nowrap" flex="0 0 auto">
                 <Select
                     size="xs"
                     w={120}
@@ -258,7 +258,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
             <Select
                 size="xs"
                 w={120}
-                className="ld-shrink-0"
+                flex="0 0 auto"
                 aria-label="Role for new assignment"
                 data={ROLE_OPTIONS}
                 value={selectedRole}
@@ -269,7 +269,7 @@ const AddDirectAccess: FC<AddDirectAccessProps> = ({
             />
             <Button
                 size="xs"
-                className="ld-shrink-0"
+                flex="0 0 auto"
                 disabled={!selectedPrincipal || isMutating}
                 onClick={handleAdd}
             >

--- a/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/CustomHeadersField.tsx
@@ -52,7 +52,7 @@ export const CustomHeadersField: FC<Props> = ({
                     <TextInput
                         aria-label="Header name"
                         placeholder="anthropic-version"
-                        className="ld-grow"
+                        flex={1}
                         value={row.name}
                         disabled={disabled}
                         onChange={(e) =>
@@ -62,7 +62,7 @@ export const CustomHeadersField: FC<Props> = ({
                     <TextInput
                         aria-label="Header value"
                         placeholder="2023-06-01"
-                        className="ld-grow"
+                        flex={1}
                         value={row.value}
                         disabled={disabled}
                         onChange={(e) =>

--- a/packages/frontend/src/features/externalConnections/components/PathRulesField.module.css
+++ b/packages/frontend/src/features/externalConnections/components/PathRulesField.module.css
@@ -1,0 +1,3 @@
+.addRuleButton {
+    align-self: flex-start;
+}

--- a/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
+++ b/packages/frontend/src/features/externalConnections/components/PathRulesField.tsx
@@ -15,6 +15,7 @@ import {
     type PathMode,
     type PathPrefix,
 } from '../utils/pathRules';
+import classes from './PathRulesField.module.css';
 
 type Props = {
     label: string;
@@ -109,7 +110,7 @@ export const PathRulesField: FC<Props> = ({
                     variant="subtle"
                     size="compact-sm"
                     leftSection={<MantineIcon icon={IconPlus} />}
-                    className="ld-self-start"
+                    className={classes.addRuleButton}
                     disabled={disabled}
                     onClick={() =>
                         onPrefixesChange([...prefixes, makePathPrefix()])

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.module.css
@@ -6,3 +6,7 @@
     border-radius: var(--mantine-radius-md);
     row-gap: 4px;
 }
+
+.categoryList {
+    overflow-y: auto;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogCategoryForm.tsx
@@ -319,7 +319,7 @@ export const MetricsCatalogCategoryForm: FC<Props> = memo(
                             gap={2}
                             w="100%"
                             mah={140}
-                            className="ld-scroll-y"
+                            className={formClasses.categoryList}
                         >
                             {filteredExistingCategories.map((category) => (
                                 <MetricCatalogCategoryFormItem

--- a/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
+++ b/packages/frontend/src/features/organizationDesigns/components/DesignDetailPanel.tsx
@@ -70,14 +70,14 @@ const FileRow: FC<{
                 <Badge
                     color={KIND_COLORS[file.kind] ?? 'gray'}
                     size="sm"
-                    className="ld-shrink-0"
+                    flex="0 0 auto"
                 >
                     {file.kind}
                 </Badge>
                 <Text size="sm" truncate>
                     {file.filename}
                 </Text>
-                <Text size="xs" c="dimmed" className="ld-shrink-0">
+                <Text size="xs" c="dimmed" flex="0 0 auto">
                     {formatBytes(file.sizeBytes)}
                 </Text>
             </Group>

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.module.css
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.module.css
@@ -1,0 +1,3 @@
+.previewImage {
+    cursor: pointer;
+}

--- a/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
+++ b/packages/frontend/src/features/preview/components/PreviewAndCustomizeScreenshot.tsx
@@ -19,6 +19,7 @@ import {
 import { useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { CUSTOM_WIDTH_OPTIONS } from '../../scheduler/constants';
+import classes from './PreviewAndCustomizeScreenshot.module.css';
 
 type PreviewAndCustomizeScreenshotProps = {
     containerWidth?: number | undefined;
@@ -163,7 +164,7 @@ export const PreviewAndCustomizeScreenshot: FC<
                     onClick={() => setIsImageModalOpen(false)}
                     w="100%"
                     h="100%"
-                    className="ld-pointer"
+                    className={classes.previewImage}
                 />
             </Modal>
         </Box>

--- a/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/AddProjectGroupAccessModal.tsx
@@ -135,7 +135,7 @@ const AddProjectGroupAccessModal: FC<AddProjectGroupAccessModalProps> = ({
                                     })) ?? []
                                 }
                                 {...form.getInputProps('groupUuid')}
-                                className="ld-grow"
+                                flex={1}
                             />
                             <Select
                                 data={organizationRoles}

--- a/packages/frontend/src/features/queryHistory/QueryHistory.module.css
+++ b/packages/frontend/src/features/queryHistory/QueryHistory.module.css
@@ -134,3 +134,11 @@
     font-size: var(--mantine-font-size-xs);
     line-height: var(--mantine-line-height-md);
 }
+
+.tableMeta {
+    white-space: nowrap;
+}
+
+.errorMessage {
+    white-space: pre-wrap;
+}

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryDetailPanel.tsx
@@ -288,7 +288,11 @@ export const QueryHistoryDetailPanel: FC<Props> = ({
         if (failed) {
             return (
                 <Callout variant="danger">
-                    <Text fz="xs" ff="monospace" className="ld-pre-wrap">
+                    <Text
+                        fz="xs"
+                        ff="monospace"
+                        className={styles.errorMessage}
+                    >
                         {item.error ?? 'Query failed'}
                     </Text>
                 </Callout>
@@ -379,7 +383,7 @@ export const QueryHistoryDetailPanel: FC<Props> = ({
                         <TruncatedText maxWidth="100%" fz="md" fw={600}>
                             {item.title}
                         </TruncatedText>
-                        <Badge size="xs" className="ld-shrink-0">
+                        <Badge size="xs" flex="0 0 auto">
                             {getLanguageLabel(item.language)}
                         </Badge>
                         <QueryStatusBadge status={item.status} />

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryQueryCell.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryQueryCell.tsx
@@ -17,7 +17,7 @@ export const QueryStatusBadge: FC<{ status: QueryHistoryStatus }> = ({
         return (
             <Badge
                 size="xs"
-                className="ld-shrink-0"
+                flex="0 0 auto"
                 leftSection={<Loader size={8} color="gray" />}
             >
                 Running
@@ -27,19 +27,19 @@ export const QueryStatusBadge: FC<{ status: QueryHistoryStatus }> = ({
     switch (status) {
         case QueryHistoryStatus.ERROR:
             return (
-                <Badge size="xs" color="red" className="ld-shrink-0">
+                <Badge size="xs" color="red" flex="0 0 auto">
                     Failed
                 </Badge>
             );
         case QueryHistoryStatus.CANCELLED:
             return (
-                <Badge size="xs" className="ld-shrink-0">
+                <Badge size="xs" flex="0 0 auto">
                     Cancelled
                 </Badge>
             );
         case QueryHistoryStatus.EXPIRED:
             return (
-                <Badge size="xs" className="ld-shrink-0">
+                <Badge size="xs" flex="0 0 auto">
                     Expired
                 </Badge>
             );
@@ -70,7 +70,7 @@ export const QueryHistoryQueryCell: FC<Props> = ({ item }) => {
                         <Box
                             component="span"
                             display="inline-flex"
-                            className="ld-shrink-0"
+                            flex="0 0 auto"
                         >
                             <MantineIcon
                                 icon={IconBolt}

--- a/packages/frontend/src/features/queryHistory/components/QueryHistoryTable.tsx
+++ b/packages/frontend/src/features/queryHistory/components/QueryHistoryTable.tsx
@@ -126,7 +126,7 @@ export const QueryHistoryTable: FC<Props> = ({
                                     <Text
                                         fz="xs"
                                         c="dimmed"
-                                        className="ld-nowrap"
+                                        className={styles.tableMeta}
                                     >
                                         {`${windowCount.toLocaleString()} ${
                                             windowCount === 1 ? 'run' : 'runs'
@@ -289,7 +289,11 @@ export const QueryHistoryTable: FC<Props> = ({
                 Cell: ({ row }) => {
                     if (row.original.kind === 'window') {
                         return (
-                            <Text fz="xs" c="dimmed" className="ld-nowrap">
+                            <Text
+                                fz="xs"
+                                c="dimmed"
+                                className={styles.tableMeta}
+                            >
                                 {getWindowRangeLabel(row.original.window)}
                             </Text>
                         );
@@ -301,7 +305,7 @@ export const QueryHistoryTable: FC<Props> = ({
                     }
                     if (row.original.kind !== 'query') return null;
                     return (
-                        <Text c="dimmed" className="ld-nowrap">
+                        <Text c="dimmed" className={styles.tableMeta}>
                             {formatWhen(row.original.item.createdAt)}
                         </Text>
                     );

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -114,12 +114,7 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
 
     return (
         <>
-            <Divider
-                orientation="vertical"
-                w={1}
-                h={20}
-                className="ld-self-center"
-            />
+            <Divider orientation="vertical" w={1} h={20} />
             <SegmentedControl
                 size="xs"
                 value={selectedContentType}

--- a/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
+++ b/packages/frontend/src/features/sourceCodeEditor/components/SourceCodeEditorContent.tsx
@@ -357,7 +357,7 @@ const SourceCodeEditorContent: FC = () => {
     return (
         <>
             <Group gap={0} align="stretch" wrap="nowrap" h="100%" w="100%">
-                <Box w={300} className="ld-shrink-0">
+                <Box w={300} flex="0 0 auto">
                     <SourceCodeSidebar
                         projectUuid={projectUuid ?? ''}
                         branches={branches ?? []}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.module.css
@@ -1,0 +1,3 @@
+.menuOption {
+    cursor: pointer;
+}

--- a/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/HeaderCreate.tsx
@@ -41,6 +41,7 @@ import { isBitbucketCloudConnection } from '../../utils/isBitbucketCloudConnecti
 import { ChartErrorsAlert } from '../ChartErrorsAlert';
 import { SaveSqlChartModal } from '../SaveSqlChartModal';
 import { WriteBackToDbtModal } from '../WriteBackToDbtModal';
+import classes from './HeaderCreate.module.css';
 
 type CtaAction = 'save' | 'createVirtualView' | 'writeBackToDbt';
 
@@ -360,7 +361,9 @@ export const HeaderCreate: FC = () => {
                                             position="top"
                                             disabled={canSaveChart}
                                         >
-                                            <Group className="ld-pointer">
+                                            <Group
+                                                className={classes.menuOption}
+                                            >
                                                 <Menu.Item
                                                     disabled={!canSaveChart}
                                                     onClick={() => {
@@ -408,7 +411,9 @@ export const HeaderCreate: FC = () => {
                                             position="top"
                                             disabled={canCreateVirtualView}
                                         >
-                                            <Group className="ld-pointer">
+                                            <Group
+                                                className={classes.menuOption}
+                                            >
                                                 <Menu.Item
                                                     disabled={
                                                         !canCreateVirtualView
@@ -472,7 +477,9 @@ export const HeaderCreate: FC = () => {
                                                     );
                                             }}
                                         >
-                                            <Group className="ld-pointer">
+                                            <Group
+                                                className={classes.menuOption}
+                                            >
                                                 <Menu.Item
                                                     disabled={
                                                         writeBackDisabledMessage !==

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.module.css
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.module.css
@@ -1,0 +1,3 @@
+.previewLink {
+    cursor: pointer;
+}

--- a/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/WriteBackToDbtModal.tsx
@@ -34,6 +34,7 @@ import { useGithubDbtWriteBack } from '../hooks/useGithubDbtWriteBack';
 import { useGithubDbtWritePreview } from '../hooks/useGithubDbtWritePreview';
 import { useAppSelector } from '../store/hooks';
 import { isBitbucketCloudConnection } from '../utils/isBitbucketCloudConnection';
+import classes from './WriteBackToDbtModal.module.css';
 
 const validationSchema = z.object({
     name: z.string().min(1, 'Name is required'),
@@ -202,7 +203,7 @@ export const WriteBackToDbtModal: FC<Props> = ({ opened, onClose }) => {
                                         'noopener,noreferrer',
                                     );
                                 }}
-                                className="ld-pointer"
+                                className={classes.previewLink}
                                 title={`Open "${writePreviewData?.url}" in new tab`}
                             >
                                 {writePreviewData?.repo}

--- a/packages/frontend/src/features/sync/components/SyncModalForm.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.tsx
@@ -73,7 +73,7 @@ export const SyncModalForm: FC<Props> = ({
                         >
                             <TimeZonePicker
                                 size="sm"
-                                className="ld-grow"
+                                flex={1}
                                 placeholder={`Project Default ${
                                     projectDefaultOffsetString
                                         ? `(UTC ${projectDefaultOffsetString})`

--- a/packages/frontend/src/features/sync/components/SyncModalView.module.css
+++ b/packages/frontend/src/features/sync/components/SyncModalView.module.css
@@ -1,0 +1,7 @@
+.syncList {
+    overflow-y: auto;
+}
+
+.syncCard {
+    overflow: hidden;
+}

--- a/packages/frontend/src/features/sync/components/SyncModalView.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalView.tsx
@@ -34,6 +34,7 @@ import { useSchedulersEnabledUpdateMutation } from '../../scheduler/hooks/useSch
 import { SyncModalAction } from '../providers/types';
 import { useSyncModal } from '../providers/useSyncModal';
 import { GoogleSheetsInfoPopover } from './GoogleSheetsInfoPopover';
+import classes from './SyncModalView.module.css';
 
 const ToggleSyncEnabled: FC<{ scheduler: Scheduler }> = ({ scheduler }) => {
     const { mutate: mutateSchedulerEnabled } =
@@ -149,7 +150,7 @@ export const SyncModalView: FC<Props> = ({
             {schedulers.length > 0 ? (
                 <Box
                     mah={400}
-                    className="ld-scroll-y"
+                    className={classes.syncList}
                     onScroll={
                         onScrollBottom
                             ? (e) => {
@@ -191,7 +192,7 @@ export const SyncModalView: FC<Props> = ({
                                 <Paper
                                     key={sync.schedulerUuid}
                                     p="sm"
-                                    className="ld-overflow-hidden"
+                                    className={classes.syncCard}
                                 >
                                     <Group
                                         wrap="nowrap"

--- a/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/SqlForm.tsx
@@ -233,7 +233,7 @@ export const SqlForm: FC<Props> = ({
                 />
             </ScrollArea>
 
-            <Box className="ld-shrink-0">
+            <Box flex="0 0 auto">
                 {readOnly && !conversionState ? null : !isAmbientAiEnabled ? (
                     <Alert
                         radius={0}

--- a/packages/frontend/src/hooks/styles/tableStyles.module.css
+++ b/packages/frontend/src/hooks/styles/tableStyles.module.css
@@ -1,3 +1,7 @@
+.paper {
+    overflow: hidden;
+}
+
 .root {
     & thead tr {
         background-color: var(--mantine-color-ldGray-0);

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -509,3 +509,7 @@
     margin-top: var(--mantine-spacing-xs);
     opacity: 0.9;
 }
+
+.loadEarlierRow {
+    cursor: pointer;
+}

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1785,7 +1785,7 @@ const AppGenerate: FC = () => {
                                     justify="center"
                                     p="xs"
                                     onClick={loadEarlierMessages}
-                                    className="ld-pointer"
+                                    className={classes.loadEarlierRow}
                                 >
                                     {isFetchingNextPage ? (
                                         <Loader size="xs" />

--- a/packages/frontend/src/pages/DashboardVersionComparison.module.css
+++ b/packages/frontend/src/pages/DashboardVersionComparison.module.css
@@ -1,0 +1,3 @@
+.chartHistoryLink {
+    cursor: pointer;
+}

--- a/packages/frontend/src/pages/DashboardVersionComparison.tsx
+++ b/packages/frontend/src/pages/DashboardVersionComparison.tsx
@@ -46,6 +46,7 @@ import { getConditionalRuleLabel } from '../components/common/Filters/FilterInpu
 import MantineIcon from '../components/common/MantineIcon';
 import { useDashboardVersion } from '../hooks/dashboard/useDashboard';
 import NoTableIcon from '../svgs/emptystate-no-table.svg?react';
+import classes from './DashboardVersionComparison.module.css';
 
 interface DashboardVersionComparisonProps {
     dashboard: Dashboard | undefined;
@@ -447,7 +448,7 @@ const ChartsTable = ({
                                 size="xs"
                                 c="blue"
                                 td="none"
-                                className="ld-pointer"
+                                className={classes.chartHistoryLink}
                             >
                                 {chartName}
                             </Text>

--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.module.css
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.module.css
@@ -1,0 +1,3 @@
+.submitButton {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useState, type FC } from 'react';
 import { lightdashApi, networkHistory } from '../../api';
 import MantineIcon from '../../components/common/MantineIcon';
 import useToaster from '../../hooks/toaster/useToaster';
+import classes from './SupportDrawerContent.module.css';
 
 type SupportDrawerContentProps = {
     // Add props here
@@ -166,7 +167,11 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                 We will also share your Lightdash logs and your recent network
                 requests to help us investigate this issue.
             </Text>
-            <Button mt="xs" className="ld-self-end" onClick={handleShare}>
+            <Button
+                mt="xs"
+                className={classes.submitButton}
+                onClick={handleShare}
+            >
                 Share
             </Button>
         </Stack>

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -85,48 +85,6 @@ strong {
         opacity: 1;
     }
 }
-
-/* Layout utilities for the few rules Mantine has no style prop for. */
-.ld-shrink-0 {
-    flex-shrink: 0;
-}
-
-.ld-grow {
-    flex-grow: 1;
-}
-
-.ld-overflow-hidden {
-    overflow: hidden;
-}
-
-.ld-scroll-y {
-    overflow-y: auto;
-}
-
-.ld-self-center {
-    align-self: center;
-}
-
-.ld-self-end {
-    align-self: flex-end;
-}
-
-.ld-self-start {
-    align-self: flex-start;
-}
-
-.ld-pointer {
-    cursor: pointer;
-}
-
-.ld-nowrap {
-    white-space: nowrap;
-}
-
-.ld-pre-wrap {
-    white-space: pre-wrap;
-}
-
 /* An @mention inside a comment, in the editor and once rendered. */
 .ld-mention {
     padding: 0.1em 0.35em;


### PR DESCRIPTION
Follow-up to #28457, which introduced the `ld-*` utility classes. No ticket. Reviewers flagged the mix of a global class string with CSS modules on #29085, and the team prefers the two systems we already have: Mantine style props and CSS modules.

## What changed
- Deleted the ten `ld-*` layout utility classes from `src/styles/global.css`, and the rule that pointed agents at them in `packages/frontend/CLAUDE.md` and the `frontend-style-guide` skill. The hierarchy is now style props, then CSS modules, then theme extensions.
- `flex-shrink: 0` and `flex-grow: 1` on Mantine components use the `flex` style prop (`flex="0 0 auto"`, `flex={1}`).
- 31 vertical toolbar `Divider`s dropped the `align-self: center` class. Each one sits in a `Group` with the default `align="center"`, so the rule was a no-op.
- Every other rule (`align-self`, `overflow`, `overflow-y`, `cursor`, `white-space`, and `flex-shrink` on `MantineIcon`, which renders a raw SVG and takes no style props) moved into a role-named class in the component's CSS module. 31 new modules, 28 extended. The seven settings tables that wrap a `Table` in a `Paper` share `.paper` in `hooks/styles/tableStyles.module.css`, which they already import.

## Regression analysis
- `flex="0 0 auto"` is identical to `flex-shrink: 0` on top of the default grow and basis.
- `flex={1}` differs from `flex-grow: 1` only in basis (`0%` vs `auto`), which changes layout only when siblings also grow. The two such sites (Databricks form, external connection custom headers) are pairs of same-sized text inputs, so the split is unchanged. One `<Stack flex={1} className="ld-grow">` simply lost the redundant class.
- The parent of each of the 31 dividers was checked and is a default-aligned `Group`.
- Module classes carry the same single declaration at the same specificity (one class) as the global utility they replace.
- A repo-wide sweep finds zero `ld-*` utility strings left in tsx, ts, css, snapshots, or docs.

## Verified
- `pnpm -F frontend typecheck`, oxlint and oxfmt over all 163 touched files.
- The 14 vitest files adjacent to changed components (87 tests) pass.

#29085 should rebase onto this and use `flex="0 0 auto"` on its `Switch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUsu6cwDhqqjJxnTx7f84g
