### PR TITLE
fix: gate chart type schema and thumbnail reads on the explore, not app view

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.dataAppVizs.test.ts
@@ -4,6 +4,7 @@ import {
     DATA_APP_VIZ_TEMPLATE,
     ForbiddenError,
     getUserAbilityBuilder,
+    MissingConfigError,
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
@@ -300,6 +301,85 @@ describe('AppGenerateService data app vizs', () => {
             await expect(listed(OrganizationMemberRole.VIEWER)).rejects.toThrow(
                 ForbiddenError,
             );
+        });
+    });
+
+    describe('who can read a chart type schema', () => {
+        // Registry installs are space-less and authored by the installer, so
+        // the schema read must follow the listing's manage:Explore gate —
+        // a view:DataApp check would deny everyone but installer and admins.
+        const someoneElsesViz = makeDataAppVizRow({
+            space_uuid: null,
+            created_by_user_uuid: 'someone-else',
+        });
+        const readSchema = async (role: OrganizationMemberRole) => {
+            const appModel = {
+                findVisualizationApp: vi
+                    .fn()
+                    .mockResolvedValue(someoneElsesViz),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                role,
+                'editor-1',
+            );
+            return service.getDataAppVisualization(
+                user,
+                'project-1',
+                'data-app-viz-1',
+            );
+        };
+
+        it.each([
+            OrganizationMemberRole.INTERACTIVE_VIEWER,
+            OrganizationMemberRole.EDITOR,
+            OrganizationMemberRole.DEVELOPER,
+            OrganizationMemberRole.ADMIN,
+        ])('lets a %s read a schema they did not author', async (role) => {
+            const result = await readSchema(role);
+            expect(result.dataAppVizUuid).toBe('data-app-viz-1');
+        });
+
+        it('refuses a viewer the schema', async () => {
+            await expect(
+                readSchema(OrganizationMemberRole.VIEWER),
+            ).rejects.toThrow(ForbiddenError);
+        });
+    });
+
+    describe('who can see a chart type thumbnail', () => {
+        const chartTypeApp = {
+            app_id: 'data-app-viz-1',
+            project_uuid: 'project-1',
+            organization_uuid: 'org-1',
+            space_uuid: null,
+            created_by_user_uuid: 'someone-else',
+            template: DATA_APP_VIZ_TEMPLATE,
+        };
+        const getThumbnail = async (role: OrganizationMemberRole) => {
+            const appModel = {
+                getApp: vi.fn().mockResolvedValue(chartTypeApp),
+            };
+            const { service, user } = buildServiceWithRealAbility(
+                appModel,
+                role,
+                'editor-1',
+            );
+            return service.getThumbnailUrl(user, 'project-1', 'data-app-viz-1');
+        };
+
+        it('gates a chart type thumbnail on the explore, not app view', async () => {
+            // Passing the ability gate surfaces the fixture's missing
+            // app-runtime storage instead of a ForbiddenError.
+            await expect(
+                getThumbnail(OrganizationMemberRole.EDITOR),
+            ).rejects.toThrow(MissingConfigError);
+        });
+
+        it('refuses a viewer the thumbnail', async () => {
+            await expect(
+                getThumbnail(OrganizationMemberRole.VIEWER),
+            ).rejects.toThrow(ForbiddenError);
         });
     });
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1225,6 +1225,23 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
+     * Chart types are offered to whoever can build a chart in an explore:
+     * picking, configuring, and previewing a renderer is part of chart
+     * building, not app access. Registry-installed chart types are space-less,
+     * so a `view:DataApp` check here would deny everyone but the installer
+     * and admins.
+     */
+    private assertCanUseChartTypes(
+        user: SessionUser,
+        context: { organizationUuid: string; projectUuid: string },
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (auditedAbility.cannot('manage', subject('Explore', context))) {
+            throw new ForbiddenError('Insufficient permissions');
+        }
+    }
+
+    /**
      * Link the given external connections to the app before its catalog stage,
      * so the generated app can call them via client.externalFetch. A connection
      * from another project is never linked (that would expose its credentialed
@@ -2031,9 +2048,17 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
-        // Viewing a thumbnail is a read: anyone who can view the app can see it
-        // (e.g. on a project homepage), not just those who can manage it.
-        await this.assertCanViewApp(user, app);
+        if (app.template === DATA_APP_VIZ_TEMPLATE) {
+            this.assertCanUseChartTypes(user, {
+                organizationUuid: app.organization_uuid,
+                projectUuid,
+            });
+        } else {
+            // Viewing a thumbnail is a read: anyone who can view the app can
+            // see it (e.g. on a project homepage), not just those who can
+            // manage it.
+            await this.assertCanViewApp(user, app);
+        }
 
         const { client: s3Client, bucket } = this.getS3Client();
         const key = AppGenerateService.appThumbnailKey(appUuid);
@@ -8644,17 +8669,7 @@ export class AppGenerateService extends BaseService {
         await this.assertDataAppsEnabled(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
-        // The library is offered to whoever can build a chart in an explore:
-        // picking a renderer is part of configuring a chart, not app access.
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError('Insufficient permissions');
-        }
+        this.assertCanUseChartTypes(user, { organizationUuid, projectUuid });
         const { data, pagination } =
             await this.appModel.listDataAppVisualizations(
                 projectUuid,
@@ -8700,15 +8715,7 @@ export class AppGenerateService extends BaseService {
         }
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError('Insufficient permissions');
-        }
+        this.assertCanUseChartTypes(user, { organizationUuid, projectUuid });
 
         if (!this.chartRegistryClient.isEnabled()) {
             return { registryEnabled: false, charts: [] };
@@ -8998,12 +9005,9 @@ export class AppGenerateService extends BaseService {
                 `Data app visualization not found: ${dataAppVizUuid}`,
             );
         }
-        await this.assertCanViewApp(user, {
-            app_id: dataAppViz.app_id,
-            project_uuid: dataAppViz.project_uuid,
-            space_uuid: dataAppViz.space_uuid,
-            organization_uuid: dataAppViz.organization_uuid,
-            created_by_user_uuid: dataAppViz.created_by_user_uuid,
+        this.assertCanUseChartTypes(user, {
+            organizationUuid: dataAppViz.organization_uuid,
+            projectUuid: dataAppViz.project_uuid,
         });
         if (version === undefined) {
             return AppGenerateService.mapDataAppViz(dataAppViz);
@@ -9037,18 +9041,10 @@ export class AppGenerateService extends BaseService {
 
         await this.assertDataAppsEnabled(user);
 
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('Explore', {
-                    organizationUuid: dataAppViz.organization_uuid,
-                    projectUuid: dataAppViz.project_uuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError('Insufficient permissions');
-        }
+        this.assertCanUseChartTypes(user, {
+            organizationUuid: dataAppViz.organization_uuid,
+            projectUuid: dataAppViz.project_uuid,
+        });
 
         return dataAppViz;
     }


### PR DESCRIPTION
## Problem

Registry-installed chart types are space-less, and the viz-schema read (`GET .../apps/visualizations/{uuid}`) and app thumbnail read authorize with `view:DataApp`. For a space-less app only the installer and project/org admins pass that check — so an editor or interactive viewer sees the chart type in the picker (the listing is deliberately gated on `manage:Explore`) but gets a 403 when the config panel fetches its schema, and its thumbnail fails to load.

## Fix

New `assertCanUseChartTypes` helper (the `manage:Explore` gate with the rationale documented once), used by:

- `getDataAppVisualization` — replaces `assertCanViewApp`, matching the listing
- `getThumbnailUrl` — for viz-template apps only; other apps keep `view:DataApp` (thumbnails on homepages etc.)
- the three pre-existing duplicated `manage:Explore` blocks (`listDataAppVisualizations`, `listRegistryChartTypes`, `getAuthorizedDataAppVizForAuthoring`), refactored onto the helper with no behavior change

## Testing

- New real-ability tests: interactive viewer/editor/developer/admin can read a schema and thumbnail they did not author; plain viewers still 403
- `pnpm -F backend typecheck` clean; dataAppVizs + registryGuards test files green

Relates: GLITCH-788