### PR TITLE
fix(spaces): honor parent-space permissions when creating nested spaces

### DIFF
--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -1969,3 +1969,182 @@ describe('SpaceService - space share target validation', () => {
         });
     });
 });
+
+describe('SpaceService.createSpace', () => {
+    const mockProjectModel = {
+        getSummary: vi.fn(),
+    };
+    const mockSpaceModel = {
+        getSpaceSummary: vi.fn(),
+        createSpace: vi.fn(),
+        addSpaceAccess: vi.fn(),
+        get: vi.fn(),
+        getSpaceBreadcrumbs: vi.fn(),
+        getSpaceQueries: vi.fn(),
+        getSpaceDashboards: vi.fn(),
+        find: vi.fn(),
+    };
+    const mockSpacePermissionService = {
+        can: vi.fn(),
+        getAccessibleSpaceUuids: vi.fn(),
+        resolveAccess: vi.fn(),
+        mergeAdminAccess: vi.fn(() => []),
+        getGroupAccess: vi.fn(),
+        getUserMetadataByUuids: vi.fn(),
+    };
+
+    const mockUser = {
+        ...createTestUser({
+            projectRole: ProjectMemberRole.VIEWER,
+        }),
+        userId: 1,
+    };
+
+    let service: SpaceService;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+
+        service = new SpaceService({
+            analytics: analyticsMock,
+            lightdashConfig: lightdashConfigMock,
+            projectModel: mockProjectModel as unknown as ProjectModel,
+            spaceModel: mockSpaceModel as unknown as SpaceModel,
+            organizationModel: {} as OrganizationModel,
+            organizationMemberProfileModel:
+                {} as OrganizationMemberProfileModel,
+            pinnedListModel: {} as PinnedListModel,
+            spacePermissionService:
+                mockSpacePermissionService as unknown as SpacePermissionService,
+            savedChartService: {} as SavedChartService,
+            dashboardService: {} as DashboardService,
+            appGenerateService: undefined,
+        });
+
+        mockProjectModel.getSummary.mockResolvedValue({
+            organizationUuid: 'test-org-uuid',
+        });
+        mockSpaceModel.getSpaceSummary.mockResolvedValue({
+            uuid: 'parent-space-uuid',
+            projectUuid: 'test-project-uuid',
+        });
+        mockSpaceModel.createSpace.mockResolvedValue({
+            uuid: 'child-space-uuid',
+        });
+        mockSpaceModel.get.mockResolvedValue({
+            uuid: 'child-space-uuid',
+            projectUuid: 'test-project-uuid',
+            organizationUuid: 'test-org-uuid',
+            name: 'Child Space',
+            inheritParentPermissions: true,
+            slug: 'child-space',
+            pinnedListUuid: null,
+            pinnedListOrder: null,
+            parentSpaceUuid: 'parent-space-uuid',
+            path: 'parent_space.child_space',
+        });
+        mockSpaceModel.getSpaceBreadcrumbs.mockResolvedValue([]);
+        mockSpaceModel.getSpaceQueries.mockResolvedValue([]);
+        mockSpaceModel.getSpaceDashboards.mockResolvedValue([]);
+        mockSpaceModel.find.mockResolvedValue([]);
+        mockSpacePermissionService.getAccessibleSpaceUuids.mockResolvedValue(
+            [],
+        );
+        mockSpacePermissionService.resolveAccess.mockResolvedValue({
+            organizationUuid: 'test-org-uuid',
+            projectUuid: 'test-project-uuid',
+            inheritsFromOrgOrProject: false,
+            access: [],
+            admins: [],
+        });
+        mockSpacePermissionService.getGroupAccess.mockResolvedValue([]);
+        mockSpacePermissionService.getUserMetadataByUuids.mockResolvedValue({});
+    });
+
+    test('allows nested space creation when the user can manage the parent space', async () => {
+        mockSpacePermissionService.can.mockResolvedValue(true);
+
+        const createdSpace = await service.createSpace(
+            'test-project-uuid',
+            mockUser as unknown as SessionUser,
+            {
+                name: 'Child Space',
+                parentSpaceUuid: 'parent-space-uuid',
+            },
+        );
+
+        expect(createdSpace.uuid).toBe('child-space-uuid');
+        expect(createdSpace.parentSpaceUuid).toBe('parent-space-uuid');
+        expect(mockSpacePermissionService.can).toHaveBeenCalledWith(
+            'manage',
+            mockUser,
+            'parent-space-uuid',
+        );
+    });
+
+    test.each([
+        { name: 'nested', parentSpaceUuid: 'parent-space-uuid' },
+        { name: 'root', parentSpaceUuid: undefined },
+    ])(
+        'blocks $name space creation without the required permission',
+        async ({ parentSpaceUuid }) => {
+            mockSpacePermissionService.can.mockResolvedValue(false);
+            await expect(
+                service.createSpace(
+                    'test-project-uuid',
+                    mockUser as SessionUser,
+                    {
+                        name: 'New Space',
+                        parentSpaceUuid,
+                    },
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(mockSpaceModel.createSpace).not.toHaveBeenCalled();
+            expect(mockSpaceModel.addSpaceAccess).not.toHaveBeenCalled();
+        },
+    );
+
+    test('rejects a parent in another project even with manage access', async () => {
+        mockSpacePermissionService.can.mockResolvedValue(true);
+        mockSpaceModel.getSpaceSummary.mockResolvedValue({
+            uuid: 'parent-space-uuid',
+            projectUuid: 'other-project-uuid',
+        });
+        await expect(
+            service.createSpace('test-project-uuid', mockUser as SessionUser, {
+                name: 'New Space',
+                parentSpaceUuid: 'parent-space-uuid',
+            }),
+        ).rejects.toThrow(NotFoundError);
+        expect(mockSpaceModel.createSpace).not.toHaveBeenCalled();
+    });
+
+    test.each([undefined, 'parent-space-uuid'])(
+        'preserves project-level create permission with parent %s',
+        async (parentSpaceUuid) => {
+            const editor = {
+                ...createTestUser({ projectRole: ProjectMemberRole.EDITOR }),
+                userId: 1,
+            };
+            mockSpacePermissionService.can.mockResolvedValue(false);
+            await expect(
+                service.createSpace(
+                    'test-project-uuid',
+                    editor as SessionUser,
+                    {
+                        name: 'New Space',
+                        parentSpaceUuid,
+                    },
+                ),
+            ).resolves.toHaveProperty('uuid', 'child-space-uuid');
+            expect(mockSpaceModel.createSpace).toHaveBeenCalledWith(
+                {
+                    name: 'New Space',
+                    parentSpaceUuid: parentSpaceUuid ?? null,
+                    inheritParentPermissions: !!parentSpaceUuid,
+                },
+                { projectUuid: 'test-project-uuid', userId: 1 },
+            );
+        },
+    );
+});

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -345,18 +345,14 @@ export class SpaceService
             await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'create',
-                subject('Space', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { spaceName: space.name },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
+        const canCreateProjectSpace = auditedAbility.can(
+            'create',
+            subject('Space', {
+                organizationUuid,
+                projectUuid,
+                metadata: { spaceName: space.name },
+            }),
+        );
 
         if (space.parentSpaceUuid) {
             // Check if parent space uuid is in project
@@ -366,6 +362,19 @@ export class SpaceService
             if (parentSpace.projectUuid !== projectUuid) {
                 throw new NotFoundError('Parent space not found');
             }
+
+            if (
+                !canCreateProjectSpace &&
+                !(await this.spacePermissionService.can(
+                    'manage',
+                    user,
+                    space.parentSpaceUuid,
+                ))
+            ) {
+                throw new ForbiddenError();
+            }
+        } else if (!canCreateProjectSpace) {
+            throw new ForbiddenError();
         }
 
         if (space.access && space.access.length > 0) {

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.test.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.test.tsx
@@ -1,0 +1,60 @@
+import {
+    ProjectMemberRole,
+    SpaceMemberRole,
+    type SpaceShare,
+} from '@lightdash/common';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../testing/testUtils';
+import { UserAccessList } from './ShareSpaceModalShared';
+
+describe('UserAccessList', () => {
+    it.each([SpaceMemberRole.ADMIN, SpaceMemberRole.EDITOR])(
+        'does not flag %s space access based on the placeholder Viewer project role',
+        async (role) => {
+            const sharedUser: SpaceShare = {
+                userUuid: 'custom-role-user',
+                firstName: 'Custom',
+                lastName: 'Role',
+                email: 'custom-role@example.com',
+                isInternal: false,
+                avatarUrl: null,
+                avatarGradient: null,
+                role,
+                projectRole: ProjectMemberRole.VIEWER,
+                hasDirectAccess: true,
+                inheritedRole: undefined,
+                inheritedFrom: undefined,
+            };
+            const onAccessChange = vi.fn();
+            renderWithProviders(
+                <UserAccessList
+                    inheritParentPermissions={false}
+                    accessList={[sharedUser]}
+                    sessionUser={undefined}
+                    onAccessChange={onAccessChange}
+                    page={1}
+                    totalPages={1}
+                    onPageChange={vi.fn()}
+                />,
+            );
+            const select = screen.getByRole('combobox');
+            expect(select).not.toHaveAttribute('aria-invalid', 'true');
+            await userEvent.hover(select);
+            expect(
+                screen.queryByText(
+                    'User needs to be promoted to interactive viewer to have this space access',
+                ),
+            ).not.toBeInTheDocument();
+            await userEvent.click(select);
+            await userEvent.click(
+                screen.getByRole('option', { name: /Can view/ }),
+            );
+            expect(onAccessChange).toHaveBeenCalledWith(
+                SpaceMemberRole.VIEWER,
+                sharedUser,
+            );
+        },
+    );
+});

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx
@@ -1,7 +1,5 @@
 import {
     OrganizationMemberRole,
-    ProjectMemberRole,
-    SpaceMemberRole,
     type LightdashUser,
     type Space,
     type SpaceGroup,
@@ -16,15 +14,9 @@ import {
     Select,
     Stack,
     Text,
-    Tooltip,
 } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import {
-    IconAlertCircle,
-    IconLock,
-    IconUsers,
-    IconUsersGroup,
-} from '@tabler/icons-react';
+import { IconLock, IconUsers, IconUsersGroup } from '@tabler/icons-react';
 import chunk from 'lodash/chunk';
 import { useCallback, useMemo, useState, type FC } from 'react';
 import { useUpdateMutation } from '../../../hooks/useSpaces';
@@ -78,9 +70,6 @@ export const UserAccessList: FC<UserAccessListProps> = ({
     return (
         <Stack gap="sm">
             {accessList.map((sharedUser) => {
-                const needsPromotion =
-                    sharedUser.projectRole === ProjectMemberRole.VIEWER &&
-                    sharedUser.role !== SpaceMemberRole.VIEWER;
                 const isSessionUser =
                     sharedUser.userUuid === sessionUser?.userUuid;
 
@@ -157,61 +146,43 @@ export const UserAccessList: FC<UserAccessListProps> = ({
                                 )?.title ?? sharedUser.role}
                             </Badge>
                         ) : (
-                            <Tooltip
-                                disabled={!needsPromotion}
-                                label="User needs to be promoted to interactive viewer to have this space access"
-                                maw={350}
-                            >
-                                <Select
-                                    classNames={{
-                                        input: disabled
-                                            ? undefined
-                                            : classes.selectInput,
-                                    }}
-                                    size="xs"
-                                    variant={disabled ? 'default' : 'unstyled'}
-                                    comboboxProps={{ withinPortal: true }}
-                                    data={userAccessTypes.map((u) => ({
-                                        label: u.title,
-                                        value: u.value,
-                                    }))}
-                                    value={sharedUser.role}
-                                    renderOption={({ option }) => {
-                                        const opt = userAccessTypes.find(
-                                            (u) => u.value === option.value,
+                            <Select
+                                classNames={{
+                                    input: disabled
+                                        ? undefined
+                                        : classes.selectInput,
+                                }}
+                                size="xs"
+                                variant={disabled ? 'default' : 'unstyled'}
+                                comboboxProps={{ withinPortal: true }}
+                                data={userAccessTypes.map((u) => ({
+                                    label: u.title,
+                                    value: u.value,
+                                }))}
+                                value={sharedUser.role}
+                                renderOption={({ option }) => {
+                                    const opt = userAccessTypes.find(
+                                        (u) => u.value === option.value,
+                                    );
+                                    return (
+                                        <Stack gap={1}>
+                                            <Text fz="sm">{opt?.title}</Text>
+                                            <Text fz="xs" opacity={0.65}>
+                                                {opt?.selectDescription}
+                                            </Text>
+                                        </Stack>
+                                    );
+                                }}
+                                onChange={(value) => {
+                                    if (value) {
+                                        onAccessChange(
+                                            value as UserAccessAction,
+                                            sharedUser,
                                         );
-                                        return (
-                                            <Stack gap={1}>
-                                                <Text fz="sm">
-                                                    {opt?.title}
-                                                </Text>
-                                                <Text fz="xs" opacity={0.65}>
-                                                    {opt?.selectDescription}
-                                                </Text>
-                                            </Stack>
-                                        );
-                                    }}
-                                    onChange={(value) => {
-                                        if (value) {
-                                            onAccessChange(
-                                                value as UserAccessAction,
-                                                sharedUser,
-                                            );
-                                        }
-                                    }}
-                                    error={needsPromotion}
-                                    rightSection={
-                                        needsPromotion ? (
-                                            <MantineIcon
-                                                icon={IconAlertCircle}
-                                                size="sm"
-                                                color="red.6"
-                                            />
-                                        ) : null
                                     }
-                                    disabled={disabled}
-                                />
-                            </Tooltip>
+                                }}
+                                disabled={disabled}
+                            />
                         )}
                     </Group>
                 );

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -123,6 +123,10 @@ const Space: FC = () => {
         return <ForbiddenPanel />;
     }
 
+    const userCanCreateNestedSpace =
+        userCanManageSpace ||
+        user.data?.ability?.can('manage', subject('Space', space));
+
     const userCanCreateDashboards = user.data?.ability?.can(
         'create',
         subject('Dashboard', { ...space }),
@@ -269,7 +273,7 @@ const Space: FC = () => {
                                 (userCanCreateDashboards ||
                                     userCanCreateCharts ||
                                     userCanCreateDataApps ||
-                                    userCanManageSpace) && (
+                                    userCanCreateNestedSpace) && (
                                     <Menu
                                         position="bottom-end"
                                         closeOnItemClick
@@ -292,7 +296,7 @@ const Space: FC = () => {
                                         </Menu.Target>
 
                                         <Menu.Dropdown>
-                                            {userCanManageSpace && (
+                                            {userCanCreateNestedSpace && (
                                                 <>
                                                     <Menu.Item
                                                         leftSection={


### PR DESCRIPTION
## What changed

- fix(spaces): honor parent-space permissions when creating nested spaces


- fix(spaces): honor parent-space permissions when creating nested spaces

Co-authored-by: Tori Whaley <tori@lightdash.com>
- Merge remote-tracking branch 'origin/prod-3071-published'


- Merge remote-tracking branch 'origin/main'


- test(spaces): query access select by its combobox role

## Verification

CI follow-up for PR #29097:
- Build & Test failed because the new test queried `textbox`, while Mantine 9.6.0 exposes the Select as `combobox`. Reproduced both test failures with current dependencies; changed the selector and both passed.
- E2E App (5/5) failed only in warehouseConnections.cy.ts: newer tests expected a combobox against the old Mantine application. Space browser tests passed in that job.
- E2E API failed on service-account sharing endpoints, SQL tableType metadata, and base-table underlying columns introduced on main after the PR's original base. Merged main at 51bfcb0080991abfb0ca0789c9c21481b8b170ec, including those implementations and the Mantine upgrade.
- Reconciled the original local and published commits after confirming their trees were identical; preserved both histories. Net PR diff remains the original five files. No tests disabled or assertions weakened.

Passed on the updated tree:
- `pnpm -F frontend test src/components/common/ShareSpaceModal/ShareSpaceModalShared.test.tsx` — 2 tests.
- `pnpm -F frontend exec vitest related src/pages/Space.tsx src/components/common/ShareSpaceModal/ShareSpaceModalShared.tsx src/components/common/ShareSpaceModal/ShareSpaceModalShared.test.tsx --run` — 2 files, 5 tests.
- `pnpm -F backend exec vitest related src/services/SpaceService/SpaceService.ts src/services/SpaceService/SpaceService.test.ts --run` — 4 files, 187 tests.
- `pnpm -F frontend typecheck` and `pnpm -F backend typecheck` — passed after rebuilding common and warehouses outputs from merged main.
- `pnpm -F backend lint` — no warnings/errors; `pnpm -F frontend lint` — zero errors, six warnings in main's roadmap code.
- `pnpm -F frontend exec oxfmt src/components/common/ShareSpaceModal/ShareSpaceModalShared.test.tsx --check`
- `SITE_URL=http://127.0.0.1:3000 pnpm exec dotenv -e .env.development.local -- pnpm -F api-tests test:api tests/sqlRunner.test.ts` — 9 tests passed (local PostgreSQL/Redshift; remote warehouse credentials unavailable).
- `tests/underlyingDataColumns.test.ts` — all 3 passed in the combined API run below.
- `git diff --check`, commit hooks, clean worktree.

Local environment limitations:
- Combined run `SITE_URL=http://127.0.0.1:3000 pnpm -F api-tests test:api tests/serviceAccountSpaceSharing.test.ts tests/underlyingDataColumns.test.ts tests/sqlRunner.test.ts`: service-account tests blocked by missing enterprise service factory; SQL tests initially used the CI hostname db-dev, then passed with local environment settings as above.
- `pnpm -F e2e cypress:run --spec cypress/e2e/app/settings/warehouseConnections.cy.ts --config baseUrl=http://127.0.0.1:3000` could not start because Xvfb is unavailable.
- Dependencies installed through Socket Firewall with frozen lockfile and --no-runtime after the pinned Node download hit a proxy certificate error; local validation used prepared Node 24.18.0.

Standards review: 0 findings. Spec review: 0 findings; fresh CI is still required. No new screenshot: follow-up only updates the test selector and integrates main; prior change-relevant evidence remains applicable. GitHub CI will rerun after publication; no claim that all checks are already green.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-3071-bd8fb0a7c49d.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-3071](https://linear.app/lightdash/issue/PROD-3071)

