### PR TITLE
fix: make bulk model rename discovery cache-independent

### DIFF
--- a/packages/backend/src/services/RenameService/RenameService.test.ts
+++ b/packages/backend/src/services/RenameService/RenameService.test.ts
@@ -1,14 +1,23 @@
 import { Ability } from '@casl/ability';
 import {
+    ChartType,
+    FilterOperator,
+    NotFoundError,
     OrganizationMemberRole,
     RenameType,
     RequestMethod,
+    SchedulerFormat,
+    ThresholdOperator,
+    type DashboardDAO,
     type PossibleAbilities,
+    type SavedChartDAO,
+    type SchedulerAndTargets,
     type SessionUser,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
+import { expectedDashboard } from '../../models/DashboardModel/DashboardModel.mock';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
@@ -115,4 +124,336 @@ describe('RenameService', () => {
             'sourceA__orders_amount',
         ]);
     });
+});
+
+describe('bulk model rename discovery', () => {
+    const from = 'orders';
+    const to = 'orders_restricted';
+    const payload = {
+        userUuid: user.userUuid,
+        organizationUuid: chart.organizationUuid,
+        projectUuid: chart.projectUuid,
+        schedulerUuid: undefined,
+        context: RequestMethod.CLI,
+        type: RenameType.MODEL,
+        from,
+        to,
+        dryRun: true,
+    };
+    const makeChart = (
+        uuid: string,
+        tableName: string,
+        metric: string,
+    ): SavedChartDAO => ({
+        ...chart,
+        uuid,
+        name: uuid,
+        tableName,
+        metricQuery: {
+            ...chart.metricQuery,
+            exploreName: tableName,
+            metrics: [metric],
+            filters: {},
+        },
+        chartConfig: { type: ChartType.TABLE },
+        tableConfig: { columnOrder: [metric] },
+        pivotConfig: undefined,
+    });
+    const charts = [
+        makeChart('base-with-joined-only-fields', from, 'customers_count'),
+        makeChart('joined-reference', 'payments', 'orders_amount'),
+        makeChart('stale-reference-on-destination', to, 'orders_amount'),
+        makeChart('already-renamed', to, 'orders_restricted_amount'),
+        makeChart('unrelated', 'customers', 'customers_count'),
+        {
+            ...makeChart(
+                'substring-model',
+                'archived_orders',
+                'archived_orders_amount',
+            ),
+            chartConfig: {
+                type: ChartType.CUSTOM,
+                config: {
+                    spec: {
+                        mark: 'bar',
+                        encoding: { x: { field: 'archived_orders_amount' } },
+                    },
+                },
+            },
+        } satisfies SavedChartDAO,
+    ];
+
+    const dashboard: DashboardDAO = {
+        ...expectedDashboard,
+        projectUuid: chart.projectUuid,
+        filters: {
+            dimensions: [
+                {
+                    id: 'filter',
+                    label: undefined,
+                    target: { tableName: from, fieldId: 'orders_status' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        },
+    };
+    const alert: SchedulerAndTargets = {
+        schedulerUuid: 'alert',
+        slug: 'alert',
+        name: 'Alert on an unchanged chart',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        createdBy: user.userUuid,
+        createdByName: null,
+        format: SchedulerFormat.CSV,
+        cron: '0 9 * * *',
+        savedChartUuid: 'unrelated',
+        savedChartName: 'unrelated',
+        dashboardUuid: null,
+        dashboardName: null,
+        savedSqlUuid: null,
+        savedSqlName: null,
+        appUuid: null,
+        appName: null,
+        options: {},
+        enabled: true,
+        includeLinks: true,
+        plainTextEmail: false,
+        targets: [],
+        thresholds: [
+            {
+                fieldId: 'orders_amount',
+                operator: ThresholdOperator.GREATER_THAN,
+                value: 10,
+            },
+        ],
+    };
+    const dashboardScheduler: SchedulerAndTargets = {
+        ...alert,
+        schedulerUuid: 'dashboard-scheduler',
+        name: 'Dashboard delivery',
+        savedChartUuid: null,
+        savedChartName: null,
+        dashboardUuid: dashboard.uuid,
+        dashboardName: dashboard.name,
+        thresholds: undefined,
+        filters: dashboard.filters.dimensions,
+        selectedTabs: null,
+    };
+
+    const setup = (cachedNames: string[]) => {
+        const bulkProjectModel = {
+            getSummary: vi.fn(async () => ({
+                organizationUuid: chart.organizationUuid,
+            })),
+            getExploreFromCache: vi.fn(
+                async (_projectUuid: string, name: string) => {
+                    if (!cachedNames.includes(name)) {
+                        throw new NotFoundError('Explore not cached');
+                    }
+                    return { name };
+                },
+            ),
+            getAllExploresFromCache: vi.fn(async () =>
+                Object.fromEntries(
+                    cachedNames.map((name) => [
+                        name,
+                        {
+                            name,
+                            joinedTables:
+                                name === 'payments' ? [{ table: from }] : [],
+                        },
+                    ]),
+                ),
+            ),
+        };
+        const bulkSavedChartModel = {
+            find: vi.fn(
+                async (filters: Parameters<SavedChartModel['find']>[0]) =>
+                    charts.filter(
+                        (c) =>
+                            c.projectUuid === filters.projectUuid &&
+                            (!filters.exploreNames ||
+                                filters.exploreNames.includes(c.tableName)),
+                    ),
+            ),
+            get: vi.fn(
+                async (uuid: string) => charts.find((c) => c.uuid === uuid)!,
+            ),
+            createVersion: vi.fn(),
+        };
+        const bulkDashboardModel = {
+            find: vi.fn(async () => [dashboard]),
+            getByIdOrSlug: vi.fn(async () => dashboard),
+            addVersion: vi.fn(),
+        };
+        const bulkSchedulerModel = {
+            getChartSchedulers: vi.fn(async (uuid: string) =>
+                uuid === alert.savedChartUuid ? [alert] : [],
+            ),
+            getDashboardSchedulers: vi.fn(async () => [dashboardScheduler]),
+            updateScheduler: vi.fn(),
+        };
+        return {
+            bulkProjectModel,
+            bulkSavedChartModel,
+            bulkDashboardModel,
+            bulkSchedulerModel,
+            bulkService: new RenameService({
+                lightdashConfig: lightdashConfigMock,
+                analytics: analyticsMock,
+                projectModel: bulkProjectModel as unknown as ProjectModel,
+                savedChartModel:
+                    bulkSavedChartModel as unknown as SavedChartModel,
+                dashboardModel: bulkDashboardModel as unknown as DashboardModel,
+                schedulerModel: bulkSchedulerModel as unknown as SchedulerModel,
+                schedulerClient: {} as SchedulerClient,
+                spacePermissionService:
+                    spacePermissionService as unknown as SpacePermissionService,
+            }),
+        };
+    };
+
+    test('keeps field renames scoped to their explore and cached joins', async () => {
+        const { bulkService } = setup([from, to, 'payments']);
+        const result = await bulkService.runScheduledRenameResources({
+            ...payload,
+            type: RenameType.FIELD,
+            model: from,
+            from: 'orders_amount',
+            to: 'orders_total',
+            fromReference: 'orders.amount',
+            toReference: 'orders.total',
+            fromFieldName: 'amount',
+            toFieldName: 'total',
+        });
+        expect(result).toEqual({
+            charts: [{ uuid: 'joined-reference', name: 'joined-reference' }],
+            dashboards: [],
+            alerts: [],
+            dashboardSchedulers: [],
+        });
+    });
+
+    test.each([
+        { cache: 'source only', names: [from] },
+        { cache: 'destination only', names: [to] },
+        { cache: 'both', names: [from, to] },
+        { cache: 'neither', names: [] },
+    ])(
+        'previews the same persisted changes with $cache cached as apply after recompilation',
+        async ({ names }) => {
+            const {
+                bulkService,
+                bulkProjectModel,
+                bulkSavedChartModel,
+                bulkDashboardModel,
+                bulkSchedulerModel,
+            } = setup(names);
+            const expected = {
+                charts: [
+                    {
+                        uuid: 'base-with-joined-only-fields',
+                        name: 'base-with-joined-only-fields',
+                    },
+                    { uuid: 'joined-reference', name: 'joined-reference' },
+                    {
+                        uuid: 'stale-reference-on-destination',
+                        name: 'stale-reference-on-destination',
+                    },
+                ],
+                dashboards: [{ uuid: dashboard.uuid, name: dashboard.name }],
+                alerts: [{ uuid: 'alert', name: alert.name }],
+                dashboardSchedulers: [
+                    {
+                        uuid: 'dashboard-scheduler',
+                        name: dashboardScheduler.name,
+                    },
+                ],
+            };
+            const preview = await bulkService.previewRenameResources({
+                ...payload,
+                user: {
+                    ...user,
+                    ability: new Ability<PossibleAbilities>([
+                        { subject: 'Project', action: 'update' },
+                    ]),
+                },
+            });
+            expect(preview).toEqual(expected);
+            expect(
+                await bulkService.runScheduledRenameResources(payload),
+            ).toEqual(expected);
+            expect(bulkSavedChartModel.createVersion).not.toHaveBeenCalled();
+            expect(bulkDashboardModel.addVersion).not.toHaveBeenCalled();
+            expect(bulkSchedulerModel.updateScheduler).not.toHaveBeenCalled();
+
+            bulkProjectModel.getExploreFromCache.mockRejectedValue(
+                new NotFoundError('Recompiling'),
+            );
+            bulkProjectModel.getAllExploresFromCache.mockResolvedValue({});
+            const applied = await bulkService.runScheduledRenameResources({
+                ...payload,
+                dryRun: false,
+                // UI fix-all jobs carry references and model as well as from/to.
+                model: from,
+                fromReference: from,
+                toReference: to,
+            });
+            expect(applied).toEqual(expected);
+            expect(
+                bulkSavedChartModel.createVersion.mock.calls.map(
+                    ([uuid]) => uuid,
+                ),
+            ).toEqual(expected.charts.map(({ uuid }) => uuid));
+            expect(
+                bulkDashboardModel.addVersion,
+            ).toHaveBeenCalledExactlyOnceWith(
+                dashboard.uuid,
+                expect.objectContaining({
+                    filters: expect.objectContaining({
+                        dimensions: [
+                            expect.objectContaining({
+                                target: {
+                                    tableName: to,
+                                    fieldId: 'orders_restricted_status',
+                                },
+                            }),
+                        ],
+                    }),
+                }),
+                { userUuid: user.userUuid },
+                chart.projectUuid,
+            );
+            expect(
+                bulkSchedulerModel.updateScheduler.mock.calls.map(
+                    ([scheduler]) => scheduler,
+                ),
+            ).toEqual([
+                {
+                    ...alert,
+                    thresholds: [
+                        {
+                            ...alert.thresholds![0],
+                            fieldId: 'orders_restricted_amount',
+                        },
+                    ],
+                },
+                {
+                    ...dashboardScheduler,
+                    filters: [
+                        expect.objectContaining({
+                            target: {
+                                tableName: to,
+                                fieldId: 'orders_restricted_status',
+                            },
+                        }),
+                    ],
+                },
+            ]);
+        },
+    );
 });

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -811,7 +811,12 @@ export class RenameService extends BaseService {
             let exploreName: string;
             let nameChanges: NameChanges;
 
-            if (fromReference && toReference && model) {
+            if (
+                type === RenameType.FIELD &&
+                fromReference &&
+                toReference &&
+                model
+            ) {
                 exploreName = model;
                 this.logger.debug(
                     `Rename resources: Got references for field id "${fromReference}" to "${toReference}"`,
@@ -827,30 +832,7 @@ export class RenameService extends BaseService {
             } else {
                 switch (type) {
                     case RenameType.MODEL:
-                        // This will throw error if explore does not exist
-                        // When filtering explores, we need to check if the explore exists on from, or to
-                        // since people might be running this rename method before or after dbt is updated
-
-                        let useFromExplore = true;
-                        try {
-                            await this.projectModel.getExploreFromCache(
-                                projectUuid,
-                                from,
-                            );
-                        } catch (error) {
-                            try {
-                                await this.projectModel.getExploreFromCache(
-                                    projectUuid,
-                                    to,
-                                );
-                                useFromExplore = false;
-                            } catch (err) {
-                                throw new NotFoundError(
-                                    `Neither "${from}" nor "${to}" explores exist in the project.`,
-                                );
-                            }
-                        }
-                        exploreName = useFromExplore ? from : to;
+                        exploreName = from;
 
                         nameChanges = {
                             from, // this is just the  table prefix
@@ -951,33 +933,30 @@ export class RenameService extends BaseService {
                 }
             }
 
-            this.logger.debug(
-                `Rename resources: Filtering charts by explore ${exploreName}`,
-            );
-
-            // We get all explores and their joins, because the model/field change might
-            // happen on a join, not the main chart explore name
-            // For example, if we want to rename "orders" model,
-            // and "payments" contains a join to "orders", we also want to rename all "charts"
-            // with exploreName "payments", since they can contain a join to "orders"
-            const explores =
-                await this.projectModel.getAllExploresFromCache(projectUuid);
-            // Do not filter explore errors, since the explore might be failing already, because of some renames
-            const exploreJoins: string[] = Object.values(explores)
-                .filter((e) =>
-                    e.joinedTables?.some((j) => j.table === exploreName),
-                )
-                .map((e) => e.name);
-            const exploreNames = new Set([exploreName, ...exploreJoins]);
-            this.logger.info(
-                `Rename resources: Filtering chart for explore "${exploreName}" and joins: ${exploreJoins.join(
-                    ',',
-                )}`,
-            );
-            // Note: filtering on explore name might return charts where the explore name is from a previous version
+            // Model references live in saved content even when cached explores or joins disappear.
+            // Only field renames retain explore-scoped discovery.
+            let exploreNames: string[] | undefined;
+            if (type === RenameType.FIELD) {
+                const explores =
+                    await this.projectModel.getAllExploresFromCache(
+                        projectUuid,
+                    );
+                // Include explore errors: a rename may already have broken the explore.
+                const exploreJoins = Object.values(explores)
+                    .filter((e) =>
+                        e.joinedTables?.some((j) => j.table === exploreName),
+                    )
+                    .map((e) => e.name);
+                exploreNames = Array.from(
+                    new Set([exploreName, ...exploreJoins]),
+                );
+                this.logger.info(
+                    `Rename resources: Filtering chart for explore "${exploreName}" and joins: ${exploreJoins.join(',')}`,
+                );
+            }
             const chartSummaries = await this.savedChartModel.find({
                 projectUuid,
-                exploreNames: Array.from(exploreNames),
+                ...(exploreNames && { exploreNames }),
             });
 
             this.logger.debug(

--- a/packages/backend/src/services/RenameService/rename.test.ts
+++ b/packages/backend/src/services/RenameService/rename.test.ts
@@ -952,6 +952,7 @@ describe('renameChartConfigType', () => {
                     mark: 'bar',
                     encoding: {
                         x: { field: 'payment_date' },
+                        y: { field: 'archived_payment_date' },
                     },
                 },
             },
@@ -962,6 +963,9 @@ describe('renameChartConfigType', () => {
         const config = (result as CustomVisConfig).config!;
         expect((config.spec as AnyType).data.name).toBe('invoice_data');
         expect((config.spec?.encoding as AnyType).x.field).toBe('invoice_date');
+        expect((config.spec?.encoding as AnyType).y.field).toBe(
+            'archived_payment_date',
+        );
     });
 });
 

--- a/packages/backend/src/services/RenameService/rename.ts
+++ b/packages/backend/src/services/RenameService/rename.ts
@@ -74,10 +74,10 @@ export const createRenameFactory = ({
                 newNameExtendsOld
                     ? // skip occurrences already followed by the new suffix (already renamed)
                       new RegExp(
-                          `${from}_(?!${to.slice(from.length + 1)}_)`,
+                          `\\b${from}_(?!${to.slice(from.length + 1)}_)`,
                           'g',
                       )
-                    : new RegExp(`${from}_`, 'g'),
+                    : new RegExp(`\\b${from}_`, 'g'),
                 `${to}_`,
             );
         replaceDotFieldId = (str: string) =>
@@ -830,10 +830,14 @@ export const renameSavedChart = ({
     }
 
     if (containsModelName(chart.metricQuery)) {
-        updatedChart.metricQuery = renameMetricQuery(
-            chart.metricQuery,
-            renameMethods,
-        );
+        updatedChart.metricQuery = renameMetricQuery(chart.metricQuery, {
+            ...renameMethods,
+            // Chart explore/table identities must not match substrings of other models.
+            ...(isPrefix && {
+                replaceFull: (tableName: string) =>
+                    tableName === nameChanges.from ? nameChanges.to : tableName,
+            }),
+        });
     }
 
     if (containsModelName(chart.chartConfig)) {


### PR DESCRIPTION
## What changed

- fix: make bulk model rename discovery cache-independent

Co-authored-by: Tori Whaley <tori@lightdash.com>

## Verification

CI diagnosis: job 103342430417 failed 13 tests across serviceAccountSpaceSharing, sqlRunner, and underlyingDataColumns; rename API tests passed. All three failing feature contracts were added to main after the PR's original base (commits 3837712957, 85eecb31ff, ff9dc7b89b). API CI checks out the merged revision while the preview deploys the PR branch.

Reconciliation: verified the original local and published PR trees were identical, reconciled the equivalent commits, and rebased onto origin/main at 51bfcb0080. New local revision: 27f58cfb68. `git range-diff ae5251bbdc..f674b0cde9 origin/main..HEAD` shows only publication metadata differences, with no patch changes. Worktree is clean; no assertions were weakened or tests skipped in code.

Passed on the rebased tree:
- `pnpm -F backend exec vitest related src/services/RenameService/RenameService.ts src/services/RenameService/RenameService.test.ts src/services/RenameService/rename.ts src/services/RenameService/rename.test.ts --run` — 62 tests, 2 files.
- `pnpm -F backend test src/services/SpaceService/SpaceService.test.ts` — 86 tests, 1 file.
- `pnpm -F backend typecheck`
- `NODE_OPTIONS='--max-old-space-size=8192' pnpm -F backend lint` — no errors or warnings.
- `pnpm -F backend exec oxfmt src/services/RenameService/RenameService.ts src/services/RenameService/RenameService.test.ts src/services/RenameService/rename.ts src/services/RenameService/rename.test.ts --check`
- `git diff --check origin/main...HEAD`
- `SITE_URL=http://localhost:8080 PGHOST=localhost pnpm -F api-tests test:api tests/sqlRunner.test.ts` — all 9 locally available tests passed, including Postgres/Redshift tableType assertions. Snowflake/BigQuery credentials were unavailable.

Live API coverage and limits:
- `SITE_URL=http://localhost:8080 pnpm -F api-tests test:api tests/rename.test.ts tests/underlyingDataColumns.test.ts tests/sqlRunner.test.ts tests/serviceAccountSpaceSharing.test.ts`: rename (2 tests) and underlying-data (3 tests) passed. SQL Runner initially failed because the default Docker hostname db-dev is not resolvable from the host API; rerunning with PGHOST=localhost passed. Seven service-account tests were blocked by the local unlicensed backend (422 MissingConfigError: no serviceAccountService provider), unlike CI's earlier missing-route/share-target failures.
- Runtime bootstrap timed out waiting for the frontend bundle, but the backend returned HTTP 200 on /api/v1/health and supported the API runs above.
- Refreshed dependencies with Socket Firewall and `pnpm install --frozen-lockfile --no-runtime`, retaining installed Node 24.18.0 because automatic Node 24.18.1 download encountered a runner certificate error. No manifest or lockfile edits.

Full GitHub E2E/API and other checks have not yet rerun on the updated PR revision; do not consider the PR all-green until that run completes.

## Development environment

[Open the public Lightdash development environment](https://ld-runner-prod-8100-3a34fef26970.exe.xyz) (anyone with the URL can access it)

Login: `demo@lightdash.com` / `demo_password!`

## References

Closes: [PROD-8100](https://linear.app/lightdash/issue/PROD-8100)

