### PR TITLE
ci: run the e2e suite against a Rainbow Machine e2e-profile environment

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -5,6 +5,8 @@ preview:
   - "packages/**/*"
   - "docker/**/*"
   - "okteto.preview.yaml"
+  - "rainbow.toml"
+  - "scripts/rainbow-e2e-env.sh"
 
 # Previews divert their database from a pre-seeded snapshot of main; PRs that
 # change the seed data itself must migrate and seed from scratch instead

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -353,137 +353,33 @@ jobs:
     needs: files-changed
     if: needs.files-changed.outputs.preview == 'true'
     outputs:
-      url: ${{ steps.deploy.outputs.url }}
+      url: ${{ steps.up.outputs.url }}
+      name: ${{ steps.up.outputs.name }}
     steps:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
-      - name: Context
-        uses: okteto/context@5212ce5ebf9d3584bafd33f4a295a8521fc5abe7 # latest
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          url: ${{ secrets.OKTETO_CONTEXT }}
-          token: ${{ secrets.OKTETO_TOKEN }}
+          sparse-checkout: scripts/rainbow-e2e-env.sh
+          sparse-checkout-cone-mode: false
 
-      - name: Create GitHub deployment
-        id: deployment
-        uses: chrnorm/deployment-action@500aa6a23c81ffa1acf71072aee3cfa2cc2e556a # v2
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          initial-status: pending
-          environment: pr-${{ github.event.number }}
-          environment-url: https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
-
-      - name: Deploy preview environment
-        id: deploy
-        uses: okteto/deploy-preview@86c45b05007dbdd42a5c8c74372f7a5912608827 # latest
+      # One environment per run, made as the recipe's e2e profile
+      # (rainbow.toml [profile.e2e]): the branch's preview parent forked,
+      # the production bundle built in the fork and served by the backend.
+      # The ordinary PR preview (the dev server) is untouched; this one is
+      # destroyed by the teardown job below.
+      - name: Create the e2e environment
+        id: up
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: pr-${{ github.event.number }}
-          # Covers a bounded diverted attempt (18m) plus the blank-volume
-          # retry with a full migrate + seed (see okteto.preview.yaml)
-          timeout: 40m
-          file: okteto.preview.yaml
-          variables: SITE_URL=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,DB_DIVERT=${{ needs.files-changed.outputs.db_divert }},TURBO_TEAM=${{ vars.TURBO_TEAM }},TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
-
-      - name: Collect failed preview diagnostics
-        if: ${{ failure() && steps.deploy.outcome == 'failure' }}
-        continue-on-error: true
-        timeout-minutes: 3
-        env:
-          OKTETO_CONTEXT: ${{ secrets.OKTETO_CONTEXT }}
-          OKTETO_TOKEN: ${{ secrets.OKTETO_TOKEN }}
-          PREVIEW_NAMESPACE: pr-${{ github.event.number }}
+          RAINBOW_MCP_TOKEN: ${{ secrets.RAINBOW_MCP_TOKEN }}
         run: |
-          curl -sSfL -o okteto https://github.com/okteto/okteto/releases/download/3.21.0/okteto-Linux-x86_64
-          echo "f1fc644e2c2d2285a557577eafc6d4494410dce17b36bac6c3c269fc04c573ef  okteto" | sha256sum --check
-          chmod +x okteto
-          sudo mv okteto /usr/local/bin/okteto
-
-          okteto context use "$OKTETO_CONTEXT" --token "$OKTETO_TOKEN" --namespace "$PREVIEW_NAMESPACE"
-          okteto kubeconfig
-
-          echo "::group::Preview pod status"
-          kubectl -n "$PREVIEW_NAMESPACE" get pods -o wide || true
-          echo "::endgroup::"
-
-          echo "::group::Recent warning events"
-          kubectl -n "$PREVIEW_NAMESPACE" get events \
-            --field-selector type=Warning \
-            --sort-by=.lastTimestamp | tail -n 100 || true
-          echo "::endgroup::"
-
-          preview_pods=$(kubectl -n "$PREVIEW_NAMESPACE" get pods \
-            -l stack.okteto.com/service=lightdash-preview \
-            -o name 2>/dev/null || true)
-
-          if [ -z "$preview_pods" ]; then
-            echo "No lightdash-preview pods found"
-            exit 0
-          fi
-
-          while IFS= read -r preview_pod; do
-            echo "::group::Current logs for $preview_pod"
-            kubectl -n "$PREVIEW_NAMESPACE" logs "$preview_pod" \
-              --all-containers=true --tail=300 --timestamps || true
-            echo "::endgroup::"
-
-            echo "::group::Previous logs for $preview_pod"
-            kubectl -n "$PREVIEW_NAMESPACE" logs "$preview_pod" \
-              --all-containers=true --previous --tail=300 --timestamps || true
-            echo "::endgroup::"
-          done <<< "$preview_pods"
-
-      - name: Set preview URL output
-        run: echo "url=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev" >> "$GITHUB_OUTPUT"
-
-      - name: Update deployment status
-        uses: chrnorm/deployment-status@6df8d036fd2fee9eb82936733953da1f8382b41e # v2
-        with:
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
-          state: success
-          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
-          environment-url: https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
-
-      - name: Comment PR with preview info
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const marker = '<!-- preview-environment-comment -->';
-            const body = `${marker}
-            ## Preview Environment
-
-            🌐 **URL:** https://lightdash-preview-pr-${context.issue.number}.lightdash.okteto.dev
-
-            📋 **Logs:** [View in GCP Console](https://console.cloud.google.com/logs/query;query=resource.labels.namespace_name%3D%22pr-${context.issue.number}%22;duration=PT30M?project=lightdash-previews)
-
-            🔧 **SSH:** \`./scripts/okteto-ssh.sh ${context.issue.number}\`
-            `;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
+          name="pr-${{ github.event.number }}-e2e-${{ github.run_id }}"
+          url=$(./scripts/rainbow-e2e-env.sh up "${{ github.head_ref }}" "$name")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "E2E environment: $url" >> "$GITHUB_STEP_SUMMARY"
 
   # ============================================================================
   # Stage 3: E2E and CLI tests (only after preview is up)
@@ -551,7 +447,7 @@ jobs:
       - name: Run API tests
         run: pnpm -F api-tests test:api
         env:
-          SITE_URL: https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
+          SITE_URL: ${{ needs.preview.outputs.url }}
           PGHOST: ${{ secrets.PGHOST }}
           PGPASSWORD: ${{ secrets.PGPASSWORD }}
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
@@ -604,7 +500,7 @@ jobs:
           install: false
           browser: firefox
           working-directory: packages/e2e
-          config: "baseUrl=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,specPattern=cypress/e2e/app/**/*.cy.{js,jsx,ts,tsx},video=false"
+          config: "baseUrl=${{ needs.preview.outputs.url }},specPattern=cypress/e2e/app/**/*.cy.{js,jsx,ts,tsx},video=false"
         env:
           SPLIT: ${{ strategy.job-total }}
           SPLIT_INDEX: ${{ strategy.job-index }}
@@ -667,7 +563,7 @@ jobs:
           browser: firefox
           working-directory: packages/e2e
           spec: cypress/e2e/app/dates.cy.ts
-          config: "baseUrl=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev,video=false"
+          config: "baseUrl=${{ needs.preview.outputs.url }},video=false"
         env:
           TZ: ${{ matrix.timezone }}
           CYPRESS_TZ: ${{ matrix.timezone }}
@@ -716,7 +612,7 @@ jobs:
           install: false
           working-directory: packages/e2e
           spec: cypress/cli/api,cypress/cli/yaml-only
-          config: "baseUrl=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev"
+          config: "baseUrl=${{ needs.preview.outputs.url }}"
 
   # CLI tests with dbt
   cli-tests:
@@ -780,7 +676,7 @@ jobs:
           install: false
           working-directory: packages/e2e
           spec: cypress/cli/integration/*
-          config: "baseUrl=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev"
+          config: "baseUrl=${{ needs.preview.outputs.url }}"
         env:
           CYPRESS_PGHOST: ${{ secrets.PGHOST }}
           CYPRESS_PGPASSWORD: ${{ secrets.PGPASSWORD }}
@@ -857,13 +753,31 @@ jobs:
           install: false
           working-directory: packages/e2e
           spec: cypress/cli/dbt/*
-          config: "baseUrl=https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev"
+          config: "baseUrl=${{ needs.preview.outputs.url }}"
         env:
           CYPRESS_PGHOST: ${{ secrets.PGHOST }}
           CYPRESS_PGPASSWORD: ${{ secrets.PGPASSWORD }}
           CYPRESS_SEED_SCHEMA: jaffle_dbt_tests_${{ github.run_id }}_${{ strategy.job-index }}
 
   # Cleanup job to drop all schemas created during CLI tests
+  preview-teardown:
+    name: Destroy the e2e environment
+    if: always() && needs.preview.result == 'success'
+    runs-on: depot-ubuntu-24.04-4
+    needs: [preview, api-tests, app-tests, timezone-tests, cli-tests-without-dbt, cli-tests, cli-dbt-tests]
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: scripts/rainbow-e2e-env.sh
+          sparse-checkout-cone-mode: false
+      - name: Destroy the e2e environment
+        env:
+          RAINBOW_MCP_TOKEN: ${{ secrets.RAINBOW_MCP_TOKEN }}
+        run: ./scripts/rainbow-e2e-env.sh down "${{ needs.preview.outputs.name }}"
+
   cleanup-schemas:
     if: always() && needs.files-changed.outputs.cli == 'true'
     runs-on: depot-ubuntu-24.04-4

--- a/rainbow.toml
+++ b/rainbow.toml
@@ -245,3 +245,14 @@ GITHUB_APP_NAME = "github-app"
 GITHUB_CLIENT_ID = "github-app"
 GITHUB_CLIENT_SECRET = "github-app"
 GITHUB_PRIVATE_KEY = "github-app"
+
+# The e2e variant (system-description/repo-config.md §4.12). CI creates one
+# environment per e2e run as this profile: the production bundle is built in
+# the fork beside the dev stack and the suite is driven at the backend, which
+# serves packages/frontend/build itself — production assets at production
+# request counts (178 per page against the dev server's 1,211), from the
+# same parent the preview forks from. The preview stays a dev server.
+[profile.e2e]
+run = "pnpm -F frontend build"
+serve_port = 8080
+memory = "12gb"                    # vite build peaked the guest near 4 GB beside the dev stack

--- a/scripts/rainbow-e2e-env.sh
+++ b/scripts/rainbow-e2e-env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Create or destroy the Rainbow Machine environment the e2e suite runs against.
+#
+#   rainbow-e2e-env.sh up   <branch> <name>   # prints the env URL on stdout
+#   rainbow-e2e-env.sh down <name>
+#
+# The environment is the branch's ordinary preview parent forked and made into
+# the recipe's `e2e` profile (rainbow.toml [profile.e2e]): the production
+# bundle built in the fork and served by the backend. It lives for one
+# workflow run; `down` at the end frees it, and an idle one is swept anyway.
+#
+# Talks JSON-RPC to the MCP endpoint with a bearer token. create_env is a
+# resumable tool: a call the server cuts off after 90 s answers "still
+# working", and calling again with the same arguments picks the work up.
+set -euo pipefail
+
+: "${RAINBOW_MCP_URL:=https://mcp.lightdash.rainbowmachine.dev/mcp}"
+: "${RAINBOW_MCP_TOKEN:?RAINBOW_MCP_TOKEN is required}"
+
+call() { # call <tool> <json arguments>
+  curl -sS --fail-with-body --max-time 120 "$RAINBOW_MCP_URL" \
+    -H "Authorization: Bearer $RAINBOW_MCP_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$1\",\"arguments\":$2}}"
+}
+
+case "${1:-}" in
+  up)
+    branch=$2; name=$3
+    args=$(jq -cn --arg b "$branch" --arg n "$name" '{branch:$b, name:$n, profile:"e2e", repo:"lightdash/lightdash"}')
+    deadline=$((SECONDS + 1500))
+    while :; do
+      out=$(call create_env "$args")
+      if [ "$(jq -r '.result.isError // false' <<<"$out")" != "true" ] && jq -e '.result.structuredContent.url' <<<"$out" >/dev/null; then
+        jq -r '.result.structuredContent | "env \(.env) \(.how) in \(.took_ms) ms (profile \(.profile))"' <<<"$out" >&2
+        jq -r '.result.structuredContent.url' <<<"$out"
+        exit 0
+      fi
+      msg=$(jq -r '.result.content[0].text // .error.message // "unknown error"' <<<"$out")
+      if [[ "$msg" == *"still working"* ]] && [ $SECONDS -lt $deadline ]; then
+        echo "create_env: $msg" >&2
+        sleep 5
+        continue
+      fi
+      echo "create_env failed: $msg" >&2
+      exit 1
+    done
+    ;;
+  down)
+    name=$2
+    out=$(call kill_env "$(jq -cn --arg n "$name" '{env:$n}')")
+    jq -r '.result.content[0].text' <<<"$out" >&2
+    ;;
+  *)
+    echo "usage: $0 up <branch> <name> | down <name>" >&2; exit 2;;
+esac


### PR DESCRIPTION
Closes: <!-- infra, no issue -->

test-all

### Description:

Runs the e2e and CLI suites against a Rainbow Machine environment instead of the Okteto preview. Supersedes the draft #28998 (same change, refreshed onto current `main` and verified against the platform's shipped profile support).

The environment is created per run as the recipe's **e2e profile**: the branch's preview parent is forked, `pnpm -F frontend build` runs in the fork, and the suite is driven at the backend on `:8080`, which serves `packages/frontend/build` itself. The ordinary PR preview (the dev server on `:3000`) is untouched. A teardown job destroys the env when the test jobs finish.

- `rainbow.toml`: `[profile.e2e]` (run, `serve_port` 8080, memory 12gb).
- `scripts/rainbow-e2e-env.sh`: `up <branch> <name>` / `down <name>` against the MCP endpoint with a bearer token; retries the resumable `create_env` until it answers.
- `pr.yml`: the `preview` job creates the env (`pr-<n>-e2e-<run id>`) and exports its URL; the six jobs that pointed at `lightdash-preview-pr-N.lightdash.okteto.dev` point at it; `preview-teardown` kills it. The Okteto deploy steps, deployment status and preview comment are gone from this job.
- `file-filters.yml`: `rainbow.toml` and the script select the preview jobs.

Okteto's `preview-closed.yaml` and `preview-db-snapshot.yml` stay until Okteto is retired.

### Why a production bundle from one env, not a dev fork per shard

Measured on rainbow-server-01 (2026-09-10): one dev env serves ~3.4 page loads/s regardless of concurrency (Vite's main thread pins one core; a `/login` load is 1,211 requests), so eleven CI jobs against it queue. The production bundle from the same env serves ~7.5 pages/s with no browser cache at 178 requests per page, the aggregate of five dev forks on a fifth of the host's cores.

### Verified

Created `e2e-profile-check` from this branch with `profile=e2e` (2026-09-11): forked in 33 s, readiness/warm-route/paint checks pass, `:8080` serves `/assets/index-*.js` from `packages/frontend/build` while `:3000` still serves `/@vite/client`. Env destroyed afterwards.

Unauthenticated reachability of a Rainbow URL from GitHub runners is already shown by #28885, where the CLI and timezone suites passed against the preview URL with no credential.

### Before this can merge

- [ ] `RAINBOW_MCP_TOKEN` repository secret — a credential GitHub Actions can call the MCP with.
- [ ] The warehouses the API and app tests create projects on (Snowflake, BigQuery, Trino, Databricks) in `[[egress.allow]]`, with their credentials stored as repo secrets on the platform.
- [ ] A full run of the suite against the profile env to retune timeouts if needed.

### Risk assessment:

- [ ] This is a high-risk change

CI-only, no product code. The failure mode is a red preview job, and reverting restores the Okteto path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PfiV5yNtRddb5QWYd97Ft

---
_Generated by [Claude Code](https://claude.ai/code/session_018PfiV5yNtRddb5QWYd97Ft)_