### PR TITLE
fix(mcp): localize pagination guidance

### DIFF
--- a/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/McpService/__snapshots__/mcpToolContracts.snapshot.test.ts.snap
@@ -46,9 +46,6 @@ Before writing filter expressions, read the shared skill referenced by run_metri
 - Any field used for sorting MUST be included in dimensions, metrics, or table calculations
 - When similar field names exist in base and joined tables, match to the query's semantic level
 
-### Pagination
-- Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
-
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation
 - Always confirm the metric doesn't already exist via \`grep_fields\` / \`get_metadata\` first
@@ -98,9 +95,6 @@ For a complete raw SQL query, follow step 0, then skip steps 1–3 and call \`ru
 - Never mix fields from different explores in a single query
 - Any field used for sorting MUST be included in dimensions, metrics, or table calculations
 - When similar field names exist in base and joined tables, match to the query's semantic level
-
-### Pagination
-- Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
 
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation
@@ -161,9 +155,6 @@ For a complete raw SQL query, follow step 0, then skip steps 1–3 and call \`ru
 - Never mix fields from different explores in a single query
 - Any field used for sorting MUST be included in dimensions, metrics, or table calculations
 - When similar field names exist in base and joined tables, match to the query's semantic level
-
-### Pagination
-- Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
 
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation
@@ -1393,7 +1384,7 @@ Usage tips:
             "type": "string",
           },
           "page": {
-            "description": "Use this to paginate through the results. Starts at 1.",
+            "description": "Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".",
             "exclusiveMinimum": 0,
             "type": "number",
           },

--- a/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
+++ b/packages/backend/src/ee/services/McpService/mcpToolContracts.snapshot.test.ts
@@ -396,6 +396,37 @@ describe('MCP tool contracts', () => {
     );
 
     it.each(mcpTextConfigurations)(
+        'keeps pagination guidance on registered input fields: sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
+        async (options) => {
+            const service = makeMcpService();
+            mockRegisteredMcpTools.length = 0;
+            await service.createServer(makeMcpServerOptions(options));
+            const paginatedTools = mockRegisteredMcpTools.filter(
+                ({ config }) => config.inputSchema.page !== undefined,
+            );
+            expect(paginatedTools.map(({ name }) => name)).toContain(
+                McpToolName.LIST_CONTENT,
+            );
+            for (const { config } of paginatedTools) {
+                expect(schemaToJson(config.inputSchema, 'input')).toMatchObject(
+                    {
+                        properties: {
+                            page: {
+                                description:
+                                    'Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".',
+                            },
+                        },
+                    },
+                );
+            }
+            const instructions = getLatestMcpServerInstructions();
+            expect(instructions).not.toContain('### Pagination');
+            expect(instructions).not.toContain('Page parameters');
+            expect(instructions).not.toContain('NaN');
+        },
+    );
+
+    it.each(mcpTextConfigurations)(
         'ratchets MCP server instruction lengths: sql=$runSqlEnabled metric=$runMetricQueryEnabled expressions=$filterExpressionsEnabled',
         async (options) => {
             const configuration = JSON.stringify(options);
@@ -403,8 +434,8 @@ describe('MCP tool contracts', () => {
             await mcpService.createServer(makeMcpServerOptions(options));
             // Existing instruction overages cannot grow; lower these as text shrinks.
             const instructionCeilings = options.runSqlEnabled
-                ? { structured: 2944, expression: 3081 }
-                : { structured: 2147, expression: 2284 };
+                ? { structured: 2852, expression: 2989 }
+                : { structured: 2055, expression: 2192 };
             const instructionCeiling = options.runMetricQueryEnabled
                 ? instructionCeilings[
                       options.filterExpressionsEnabled

--- a/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
+++ b/packages/backend/src/ee/services/ai/prompts/mcpAnalyst.ts
@@ -28,7 +28,6 @@ Rules:
 - Never say information is unavailable before searching saved content
 - No workarounds: never suggest raw SQL, elevated permissions, tools not in this session, or UI actions the user may not have (editing or exploring charts)
 - If nothing matches, say so plainly
-- Page parameters are numbers — never \`NaN\` or \`"null"\`
 `;
 
 const SQL_ONLY_PROMPT = `# Lightdash MCP — SQL Runner Mode
@@ -48,7 +47,6 @@ Governed metric execution (\`run_metric_query\`) is not available in this sessio
 ## Rules
 
 - When an answer depends on governed metric definitions, prefer linking the user to existing saved content over re-deriving the metric in SQL
-- Page parameters are numbers — never \`NaN\` or \`"null"\`
 `;
 
 const buildMcpAnalystPrompt = (
@@ -87,9 +85,6 @@ ${runSqlEnabled ? RUN_SQL_GUIDANCE : ''}${filterExpressionsEnabled ? `${FILTER_E
 - Never mix fields from different explores in a single query
 - Any field used for sorting MUST be included in dimensions, metrics, or table calculations
 - When similar field names exist in base and joined tables, match to the query's semantic level
-
-### Pagination
-- Page parameters must be numbers (e.g., \`1\`) — never use \`NaN\` or \`"null"\`
 
 ### Custom Metrics
 - Use when the explore lacks a needed aggregation

--- a/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
+++ b/packages/backend/src/ee/services/ai/tools/__snapshots__/agentToolContracts.snapshot.test.ts.snap
@@ -2102,7 +2102,7 @@ Usage tips:
           "type": "array",
         },
         "page": {
-          "description": "Use this to paginate through the results. Starts at 1.",
+          "description": "Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".",
           "exclusiveMinimum": 0,
           "type": [
             "number",
@@ -4053,7 +4053,7 @@ Usage tips:
           "type": "string",
         },
         "page": {
-          "description": "Use this to paginate through the results. Starts at 1.",
+          "description": "Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".",
           "exclusiveMinimum": 0,
           "type": [
             "number",
@@ -4241,7 +4241,7 @@ Usage tips:
       "additionalProperties": false,
       "properties": {
         "page": {
-          "description": "Use this to paginate through the results. Starts at 1.",
+          "description": "Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".",
           "exclusiveMinimum": 0,
           "type": [
             "number",

--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.test.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.test.ts
@@ -1,0 +1,30 @@
+import { createToolSchema } from './toolSchemaBuilder';
+
+const schema = createToolSchema().withPagination().build();
+
+describe('pagination field', () => {
+    it('documents numeric pagination on the field itself', () => {
+        expect(schema.shape.page.description).toBe(
+            'Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".',
+        );
+    });
+
+    it.each([
+        { input: 1, output: 1 },
+        { input: '2', output: 2 },
+        { input: 1.5, output: 1.5 },
+        { input: null, output: null },
+    ])(
+        'preserves pagination coercion and nullability: $input',
+        ({ input, output }) => {
+            expect(schema.parse({ page: input })).toEqual({ page: output });
+        },
+    );
+
+    it.each([NaN, 'NaN', 'null', 0, -1])(
+        'preserves rejection of invalid page %s',
+        (page) => {
+            expect(schema.safeParse({ page }).success).toBe(false);
+        },
+    );
+});

--- a/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
+++ b/packages/common/src/ee/AiAgent/schemas/toolSchemaBuilder.ts
@@ -34,7 +34,7 @@ const toolSchemaBuilder = <$Schema extends z.ZodRawShape>(
                     .positive()
                     .nullable()
                     .describe(
-                        'Use this to paginate through the results. Starts at 1.',
+                        'Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string "null".',
                     ),
             }),
         ) as ToolSchemaBuilder<$Schema & { page: z.ZodNullable<z.ZodNumber> }>,

--- a/packages/common/src/schemas/json/mcp-tools-1.0.json
+++ b/packages/common/src/schemas/json/mcp-tools-1.0.json
@@ -1891,7 +1891,7 @@
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "properties": {
                     "page": {
-                        "description": "Use this to paginate through the results. Starts at 1.",
+                        "description": "Paginate results starting at 1. Pass a positive number (e.g. 1), never NaN or the string \"null\".",
                         "exclusiveMinimum": 0,
                         "type": "number"
                     },


### PR DESCRIPTION
Relates: https://github.com/anthropics/claude-code/issues/87650

Move pagination guidance from server instructions into the shared page-field description. This intentionally changes Agent page wording too; numeric-string, null and positive-fraction coercion remains unchanged.

Risk: high — model-facing guidance can influence query behavior; human peer review required before merge. No execution, authorization or validation changes.

Validation: Pagination compatibility and registered-schema tests, Agent/MCP snapshots, typechecks, lint/format and stable snapshot freshness passed.

Text and contract checks are not proof of live model compliance.
