### PR TITLE
Fix: Dashboard filter's single-value restriction is lost after "Explore from here"(#29099)

### DIFF
--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -118,6 +118,8 @@ export interface FilterRule<
     disabled?: boolean;
     /** Whether this filter is required */
     required?: boolean;
+    /** Whether this filter restricts selection to a single value */
+    singleValue?: boolean;
     /**
      * Overrides the field/explore case-sensitivity for this rule only.
      * Used by internal features like autocomplete search that must always
@@ -190,7 +192,6 @@ export type DashboardFilterRule<
 > = FilterRule<O, T, V, S> & {
     tileTargets?: DashboardTileTargets;
     label: undefined | string;
-    singleValue?: boolean;
     /**
      * Dashboard filters sharing a requiredGroupId form an "any-one required"
      * group: the dashboard is locked until at least one member has a value.

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -264,6 +264,36 @@ describe('addDashboardFiltersToMetricQuery', () => {
         expect(dimensionRules).toHaveLength(1);
     });
 
+    test('preserves singleValue restriction when converting dashboard filter for Explore from here', () => {
+        // Regression: issue #29099 — singleValue was dropped by
+        // convertDashboardFilterRuleToFilterRule, so the restriction was lost
+        // when a viewer clicked "Explore from here" on a tile.
+        const singleValueDashboardFilter: DashboardFilters = {
+            dimensions: [
+                {
+                    id: 'single-value-filter',
+                    label: undefined,
+                    target: { fieldId: 'a_dim1', tableName: 'test' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['foo'],
+                    singleValue: true,
+                },
+            ],
+            metrics: [],
+            tableCalculations: [],
+        };
+        const result = addDashboardFiltersToMetricQuery(
+            metricQueryWithAndFilters,
+            singleValueDashboardFilter,
+        );
+        const dimensionRules = (result.filters.dimensions as AndFilterGroup)
+            .and;
+        const applied = dimensionRules.find(
+            (r) => (r as FilterRule).target?.fieldId === 'a_dim1',
+        ) as FilterRule;
+        expect(applied?.singleValue).toBe(true);
+    });
+
     test('keeps a value-less IN_THE_CURRENT dashboard filter — it compiles from settings, not values', () => {
         const relativeDateFilter: DashboardFilters = {
             dimensions: [

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -1489,6 +1489,9 @@ const findAndOverrideChartFilter = (
                   settings: overridingDashboardFilter.settings,
               }),
               operator: overridingDashboardFilter.operator,
+              ...(overridingDashboardFilter.singleValue && {
+                  singleValue: overridingDashboardFilter.singleValue,
+              }),
           }
         : item;
 };
@@ -1589,6 +1592,9 @@ const convertDashboardFilterRuleToFilterRule = (
     }),
     ...(dashboardFilterRule.disabled && {
         disabled: dashboardFilterRule.disabled,
+    }),
+    ...(dashboardFilterRule.singleValue && {
+        singleValue: dashboardFilterRule.singleValue,
     }),
 });
 


### PR DESCRIPTION
Fix issue & Closes : #29099


### Description:

A dashboard filter with the **single-value restriction** enabled (e.g. operator "is" locked to one value) was losing that restriction when a viewer clicked **Explore from here** on a tile using it. The Explore view would reopen the filter allowing multiple values.

**Root cause:** The `singleValue` flag was declared only on `DashboardFilterRule` and was never carried over when converting to a chart-level `FilterRule`. Two code paths were both dropping it:

1. `convertDashboardFilterRuleToFilterRule` — new field path
2. `findAndOverrideChartFilter` — override path (dashboard filter targets a field already in the chart's own filters)

**Fix:**
- Moved `singleValue?: boolean` from `DashboardFilterRule` up to the base `FilterRule` type
- Carried `singleValue` through both conversion functions
- Added a regression test covering the override path

Steps to check : 

Open any dashboard 
Click Edit dashboard
Click Add filter
Pick any dimension (e.g. Status | customer)
Set operator to is
You'll see a "Multiple values" button next to the operator — click it to toggle to "Single value"
Save the filter
Save the dashboard

Reproduce the old bug (should now be fixed)
On a tile that uses that filter, click the three-dot menu → Explore from here
In the Explore view, click on the filter that was applied
Before the fix: you'd see "Multiple values" — the restriction was gone
After the fix: you should still see "Single value" — the restriction is preserved ✅

### Risk assessment:

- [ ] This is a high-risk change (No)

Purely additive change to filter conversion logic. No API changes, no data changes, fully backwards compatible.

If Checked & Correct Merge Plz . I will Try to contribute more